### PR TITLE
Migrate Deepgram integration to current API

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,14 +112,7 @@ If you are creating an open source application under a license compatible with t
         <span class="label-text">Language</span>
         <select id="language" name="language" placeholder="language" class="select select-bordered w-full max-w-xs">
         </select>
-  
-        <span class="label-text">Quality</span>
-        <select id="tier" name="tier" placeholder="tier" class="select select-bordered w-full max-w-xs">
-          <option value="base">Base</option>
-          <option value="enhanced">Enhanced (Better)</option>
-          <option value="nova">Nova-2 (Best)</option>
-        </select>
-  
+
       </div>
       <div class="modal-action">
         <label id="transcribe-btn" for="transcribe-modal" class="btn btn-primary">TRANSCRIBE</label>

--- a/js/hyperaudio-lite-editor-deepgram.js
+++ b/js/hyperaudio-lite-editor-deepgram.js
@@ -1,5 +1,68 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 1.0.2 */
+/*! Version 1.1.0 */
+
+const DEEPGRAM_LANGUAGE_LABELS = {
+  "en": "English",
+  "en-US": "English (United States)",
+  "en-GB": "English (Great Britain)",
+  "en-AU": "English (Australia)",
+  "en-IN": "English (India)",
+  "en-NZ": "English (New Zealand)",
+  "es": "Spanish",
+  "es-419": "Spanish (Latin America)",
+  "fr": "French",
+  "fr-CA": "French (Canada)",
+  "de": "German",
+  "hi": "Hindi",
+  "hi-Latn": "Hindi (Latin Script)",
+  "it": "Italian",
+  "ja": "Japanese",
+  "ko": "Korean",
+  "nl": "Dutch",
+  "no": "Norwegian",
+  "pl": "Polish",
+  "pt": "Portuguese",
+  "pt-BR": "Portuguese (Brazil)",
+  "pt-PT": "Portuguese (Portugal)",
+  "ru": "Russian",
+  "sv": "Swedish",
+  "ta": "Tamil",
+  "tr": "Turkish",
+  "uk": "Ukrainian",
+  "id": "Indonesian",
+  "da": "Danish",
+  "zh": "Chinese",
+  "zh-CN": "Chinese, Simplified Mandarin (China)",
+  "zh-TW": "Chinese, Traditional Mandarin (Taiwan)",
+  "multi": "Multilingual (code-switching)"
+};
+
+const DEEPGRAM_MODELS = [
+  {
+    value: "nova-3",
+    label: "Nova-3 (recommended)",
+    languages: ["en", "en-US", "es", "fr", "de", "hi", "it", "ja", "ko", "nl", "pl", "pt", "ru", "sv", "tr", "uk", "multi"]
+  },
+  {
+    value: "nova-2",
+    label: "Nova-2",
+    languages: ["en", "en-US", "en-GB", "en-AU", "en-IN", "en-NZ", "zh", "zh-CN", "zh-TW", "da", "nl", "fr", "fr-CA", "de", "hi", "hi-Latn", "id", "it", "ja", "ko", "no", "pl", "pt", "pt-BR", "pt-PT", "ru", "es", "es-419", "sv", "ta", "tr", "uk"]
+  },
+  { value: "nova-2-meeting", label: "Nova-2 — Meeting", languages: ["en", "en-US"] },
+  { value: "nova-2-phonecall", label: "Nova-2 — Phone Call", languages: ["en", "en-US"] },
+  { value: "nova-2-finance", label: "Nova-2 — Finance", languages: ["en", "en-US"] },
+  { value: "nova-2-medical", label: "Nova-2 — Medical", languages: ["en", "en-US"] },
+  {
+    value: "enhanced",
+    label: "Enhanced",
+    languages: ["en", "en-US", "da", "nl", "fr", "de", "hi", "it", "ja", "ko", "no", "pl", "pt", "pt-BR", "ru", "es", "sv", "ta", "tr", "uk"]
+  },
+  {
+    value: "base",
+    label: "Base",
+    languages: ["en", "en-US", "en-GB", "en-AU", "en-IN", "en-NZ", "zh", "zh-CN", "zh-TW", "nl", "fr", "fr-CA", "de", "hi", "hi-Latn", "id", "it", "ja", "ko", "no", "pl", "pt", "pt-BR", "pt-PT", "ru", "es", "es-419", "sv", "ta", "tr", "uk"]
+  }
+];
 
 class DeepgramService extends HTMLElement {
 
@@ -8,37 +71,17 @@ class DeepgramService extends HTMLElement {
   }
 
   configureLanguage() {
-
-    populateLanguageDeepgram();
-
     const selectModel = document.querySelector('#deepgram-form #language-model');
-    const optionLanguageModel = {
-      "General": "general",
-      "Whisper (Tiny)": "whisper-tiny",
-      "Whisper (Base)": "whisper-base",
-      "Whisper (Small)": "whisper-small",
-      "Whisper (Medium)": "whisper-medium",
-      "Whisper (Large)": "whisper-large",
-      "Meeting": "meeting",
-      "Phone call": "phonecall",
-      "Voicemail": "voicemail",
-      "Finance": "finance",
-      "Conversational AI": "conversationalai", 
-      "Video": "video",
-      "Medical": "medical"   
-    }
-
-    let counter = 0
-    Object.keys(optionLanguageModel).forEach( model => {
-      let option = document.createElement("option")
-      option.value = optionLanguageModel[model]
-      option.innerHTML = `${model}`
-      if (counter === 0) {
-        option.selected = "selected"
+    DEEPGRAM_MODELS.forEach((model, index) => {
+      const option = document.createElement("option");
+      option.value = model.value;
+      option.innerHTML = model.label;
+      if (index === 0) {
+        option.selected = "selected";
       }
       selectModel.appendChild(option);
-      counter += 1;
-    } );
+    });
+    populateLanguagesForModel(DEEPGRAM_MODELS[0].value);
   }
 
   clearMediaUrl(event) {
@@ -71,98 +114,8 @@ class DeepgramService extends HTMLElement {
   }
 
   updateDropdowns(event) {
-    let model = document.querySelector('#deepgram-form #language-model').value;
-
-    // update languages depending on model
-    if (model.startsWith("whisper")){
-      populateLanguageWhisper();
-    } else {
-      if (model === "general") {
-        populateLanguageDeepgram();
-      } else {
-        populateLanguageDeepgramRestricted();
-      }
-    }
-  }
-
-  updateLanguageDropdown(event) {
-    let tier = document.querySelector('#deepgram-form #tier').value;
-
-    console.log(tier);
-
-    if (tier === "base" || tier === "enhanced" ){
-      populateLanguageDeepgram();
-    }
-
-    if (tier === "nova"){
-      populateLanguageDeepgramRestricted();
-    }
-  }
-
-  updateTierDropdown(event) {
-
-    const deepgramModelCompatibility = {
-      "zh_general": ["base"],
-      "zh-CN_general": ["base"],
-      "zh-TW_general": ["base"],
-      "da_general": ["enhanced", "base"],
-      "nl_general":	["enhanced", "base"],
-      "en_general": ["nova", "enhanced", "base"],
-      "en_meeting": ["nova", "enhanced", "base"],
-      "en_phonecall": ["nova", "enhanced", "base"],
-      "en_voicemail": ["nova", "base"],
-      "en_finance": ["nova", "enhanced", "base"],
-      "en_conversationalai": ["nova", "base"],
-      "en_video": ["nova","base"],
-      "en_medical": ["nova"],
-      "en-AU_general": ["nova", "base"],
-      "en-GB_general": ["nova", "base"],
-      "en-IN_general": ["nova", "base"],
-      "en-NZ_general": ["nova", "base"],
-      "en-US_general": ["nova", "enhanced", "base"],
-      "en-US_meeting": ["nova","enhanced", "base"],
-      "en-US_phonecall": ["nova", "enhanced", "base"],
-      "en-US_voicemail": ["nova","base"],
-      "en-US_finance": ["nova","enhanced", "base"],
-      "en-US_conversationalai": ["nova","base"],
-      "en-US_video": ["nova", "base"],
-      "en-US_medical": ["nova"],
-      "nl_general": ["enhanced", "base"],
-      "fr_general": ["enhanced" , "base"],
-      "fr-CA_general": ["base"],
-      "de_general": ["enhanced", "base"],
-      "hi_general":	["enhanced", "base"],
-      "hi-Latn_general": ["base"],
-      "id_general":	["base"],
-      "it_general": ["enhanced", "base"],
-      "ja_general": ["enhanced", "base"],
-      "ko_general": ["enhanced", "base"],
-      "no_general":["enhanced", "base"],
-      "pl_general":["enhanced", "base"],
-      "pt_general":	["enhanced", "base"],
-      "pt-BR_general": ["enhanced", "base"],
-      "pt-PT_general": ["enhanced", "base"],
-      "ru_general": ["base"],
-      "es_general": ["enhanced", "base"],
-      "es-419_general": ["enhanced", "base"],
-      "sv_general": ["enhanced", "base"],
-      "ta_general":	["enhanced"],
-      "tr_general": ["base"],
-      "uk_general": ["base"]
-    }
-
-    let model = document.querySelector('#deepgram-form #language-model').value;
-    let lang = document.querySelector('#deepgram-form #language').value;
-    let tiers = deepgramModelCompatibility[lang+"_"+model];
-
-    let options = document.querySelector('#tier').options;
-
-    for (let option of options) {
-      option.disabled = true;
-      if (typeof tiers !== "undefined" && tiers.length > 0 && tiers.includes(option.value)) {
-        option.disabled = false;
-      }
-    };
+    const model = document.querySelector('#deepgram-form #language-model').value;
+    populateLanguagesForModel(model);
   }
 
   getData(event) {
@@ -172,20 +125,19 @@ class DeepgramService extends HTMLElement {
     let media =  document.querySelector('#deepgram-media').value;
     const token =  document.querySelector('#token').value;
     const file = document.querySelector('#deepgram-file').files[0];
-    let tier = document.querySelector('#tier').value;
 
     if (media.toLowerCase().startsWith("https://") === false && media.toLowerCase().startsWith("http://") === false) {
       media = "https://"+media;
     }
 
     if (file !== undefined) {
-      fetchDataLocal(token, file, tier, language, model);
+      fetchDataLocal(token, file, language, model);
       document.querySelector('#deepgram-media').value = "";
     } else {
       if (media !== "" || token !== "") {
         let player = document.querySelector("#hyperplayer");
         player.src = media;
-        fetchData(token, media, tier, language, model);
+        fetchData(token, media, language, model);
       } else {
         document.querySelector('#hypertranscript').innerHTML = '<div class="vertically-centre"><img src="'+errorSvg+'" width="50" alt="error" style="margin: auto; display: block;"><br/><center>Please include both a link to the media and token in the form. </center></div>';
       }
@@ -237,16 +189,13 @@ function addModalEventListeners(modal) {
   document.querySelector('#transcribe-btn').addEventListener('click', modal.getData);
   document.querySelector('#deepgram-file').addEventListener('change', modal.updatePlayerWithLocalFile);
   document.querySelector('#language-model').addEventListener('change', modal.updateDropdowns);
-  document.querySelector('#language-model').addEventListener('change', modal.updateTierDropdown);
-  document.querySelector('#language').addEventListener('change', modal.updateTierDropdown);
-  document.querySelector('#tier').addEventListener('change', modal.updateLanguageDropdown);
 }
 
-function fetchData(token, media, tier, language, model) {
+function fetchData(token, media, language, model) {
 
-  let url = getApiUrl(tier, language, model);
-  
-  fetch(url, {  
+  let url = getApiUrl(language, model);
+
+  fetch(url, {
     method: 'POST',
     headers: {
       'Authorization': 'Token '+token+'',
@@ -262,7 +211,7 @@ function fetchData(token, media, tier, language, model) {
     } else {
       console.log("response ok");
     }
-    
+
     return response.json();
   })
   .then(json => {
@@ -275,17 +224,16 @@ function fetchData(token, media, tier, language, model) {
     }
   })
   .catch(function (error) {
-    displayAppropriateErrorMessage(error, token, media, tier, language, model, false);
+    displayAppropriateErrorMessage(error);
   })
 }
 
-function fetchDataLocal(token, file, tier, language, model) {
+function fetchDataLocal(token, file, language, model) {
 
   const apiKey = token;
 
-  // Create a new FileReader instance
   const reader = new FileReader();
-  
+
   reader.readAsArrayBuffer(file);
   let blob = null;
 
@@ -297,9 +245,8 @@ function fetchDataLocal(token, file, tier, language, model) {
       let player = document.querySelector("#hyperplayer");
       player.src = URL.createObjectURL(blob);
 
-      let url = getApiUrl(tier, language, model);
+      let url = getApiUrl(language, model);
 
-      // if the token is not present we just add the media to the player
       if (token !== "") {
         fetch(url, {
           method: 'POST',
@@ -318,7 +265,6 @@ function fetchDataLocal(token, file, tier, language, model) {
           return response.json();
         })
         .then(json => {
-          // check to see if any transcript data has come back before proceeding, give error message if not
           if (json.results.channels[0] === undefined || json.results.channels[0].alternatives[0].words.length === 0) {
             displayNoWordsError();
           } else {
@@ -326,92 +272,37 @@ function fetchDataLocal(token, file, tier, language, model) {
           }
         })
         .catch(function (error) {
-          displayAppropriateErrorMessage(error, token, file, tier, language, model, true);
+          displayAppropriateErrorMessage(error);
         })
       } else {
-        document.querySelector('#hypertranscript').innerHTML = ''; 
+        document.querySelector('#hypertranscript').innerHTML = '';
       }
     });
   });
 }
 
-function getApiUrl(tier, language, model) {
-  let url = null;
-  let languageParam = `&language=${language}`;
-  if (language === "xx") {
-    //signifies autodetect
-    languageParam  = "&detect_language=true";
-  }
-
-  let novaPrefix = "";
-  if (tier === "nova") {
-    novaPrefix = "2-";
-  }
-
-  if (model.startsWith("whisper")) { // no tier
-    url = `https://api.deepgram.com/v1/listen?model=${model}${languageParam}&diarize=true&summarize=true&topics=true&smart_format=true`
-  } else {
-    url = `https://api.deepgram.com/v1/listen?model=${novaPrefix}${model}&tier=${tier}&diarize=true&summarize=true&topics=true&language=${language}&smart_format=true`
-  }
-  return (url);
+function getApiUrl(language, model) {
+  const languageParam = (language === "xx") ? "&detect_language=true" : `&language=${language}`;
+  return `https://api.deepgram.com/v1/listen?model=${model}${languageParam}&diarize=true&summarize=v2&topics=true&smart_format=true`;
 }
 
-function displayAppropriateErrorMessage(error, token, file, tier, language, model, isLocal) {
-  console.dir("error is : "+error);
-  
+function displayAppropriateErrorMessage(error) {
+  console.dir("error is : " + error);
   error = error + "";
 
-  let errorDisplayed = displayError(error, tier);
-  
-  if (error.indexOf("400") > 0 && tier === "enhanced") {
-    tier = "base";
-    if (isLocal === true) {
-      fetchDataLocal(token, file, tier, language, model);
-    } else {
-      fetchData(token, file, tier, language, model);
-    }
-    
-    displayRetryError();
-    errorDisplayed = true;
-  }
-
-  if (error.indexOf("400") > 0 && tier === "nova") {
-    tier = "enhanced";
-    if (isLocal === true) {
-      fetchDataLocal(token, file, tier, language, model);
-    } else {
-      fetchData(token, file, tier, language, model);
-    }
-
-    displayRetryError();
-    errorDisplayed = true;
-  }
-
-  this.dataError = true;
-
-  if (errorDisplayed === false) {
-    displayGenericError();
-  }
-}
-
-function displayError(error, tier) {
-  if (error.indexOf("401") > 0 || (error.indexOf("400") > 0 && tier === "base")) {
+  if (error.indexOf("401") > 0 || error.indexOf("400") > 0) {
     document.querySelector('#hypertranscript').innerHTML = '<div class="vertically-centre"><img src="'+errorSvg+'" width="50" alt="error" style="margin: auto; display: block;"><br/><center>Sorry.<br/>It appears that the media URL does not exist<br/> or the token is invalid.</center></div>';
-    return true;
+    return;
   }
   if (error.indexOf("402") > 0) {
     document.querySelector('#hypertranscript').innerHTML = '<div class="vertically-centre"><img src="'+errorSvg+'" width="50" alt="error" style="margin: auto; display: block;"><br/><center>Sorry.<br/>It appears that the token is invalid.</center></div>';
-    return true;
+    return;
   }
-  return false;
+  displayGenericError();
 }
 
 function displayGenericError() {
   document.querySelector('#hypertranscript').innerHTML = '<div class="vertically-centre"><img src="'+errorSvg+'" width="50" alt="error" style="margin: auto; display: block;"><br/><center>Sorry.<br/>An unexpected error has occurred.</center></div>';
-}
-
-function displayRetryError() {
-  document.querySelector('#hypertranscript').innerHTML = '<div class="vertically-centre"><img src="'+transcribingSvg+'" width="50" alt="error" style="margin: auto; display: block;"><br/><center>There appears to be a language / model incompatibility. Retrying with a different model.</center></div>';
 }
 
 function displayNoWordsError() {
@@ -567,144 +458,16 @@ function extractLanguage(json) {
   return (language);
 }
 
-function populateLanguageDeepgram() {
-
+function populateLanguagesForModel(modelValue) {
   const select = document.querySelector('#language');
+  if (!select) return;
   select.innerHTML = "";
 
-  const optionLanguage = {
-    "English": "en",
-    "English (United States)": "en-US",
-    "English (Great Britain)": "en-GB",
-    "English (Australia)": "en-AU",
-    "English (India)" : "en-IN",
-    "English (New Zealand)" : "en-NZ",
-    "Chinese": "zh",
-    "Chinese, Simplified Mandarin (China)": "zh-CN",
-    "Chinese, Traditional Mandarin (Taiwan)": "zh-TW",
-    "Dutch": "nl",
-    "French" : "fr",
-    "French (Canada)" : "fr-CA",
-    "German" : "de",
-    "Hindi" : "hi",
-    "Hindi (Latin Script)" : "hi-Latn",
-    "Indonesian" : "id",
-    "Italian": "it",
-    "Japanese" : "ja",
-    "Korean" : "ko",
-    "Polish" : "pl",
-    "Portuguese": "pt",
-    "Portuguese (Brazil)" : "pt-BR",
-    "Portuguese (Portugal)" : "pt-PT",
-    "Russian" : "ru",
-    "Spanish" : "es",
-    "Swedish" : "sv",
-    "Turkish" : "tr",
-    "Ukrainian": "uk"
-  }
-
-  Object.keys(optionLanguage).forEach( language => {
-    let option = document.createElement("option")
-    option.value = optionLanguage[language]
-    option.innerHTML = `${language}`
+  const model = DEEPGRAM_MODELS.find(m => m.value === modelValue) || DEEPGRAM_MODELS[0];
+  model.languages.forEach(code => {
+    const option = document.createElement("option");
+    option.value = code;
+    option.innerHTML = DEEPGRAM_LANGUAGE_LABELS[code] || code;
     select.appendChild(option);
-  } );
-
-  document.querySelector("#tier").disabled=false;
-}
-
-function populateLanguageWhisper() {
-
-  const select = document.querySelector('#language');
-  select.innerHTML = "";
-
-  const optionLanguage = {
-    "Auto Detect": "xx",
-    "English": "en",
-    "Afrikaans": "af",
-    "Arabic": "ar",
-    "Armenian": "hy",
-    "Azerbaijani": "az",
-    "Belarusian": "be",
-    "Bosnian": "bs",
-    "Bulgarian": "bg",
-    "Catalan": "ca",
-    "Chinese": "zh",
-    "Croatian": "hr",
-    "Czech": "cs",
-    "Danish": "da",
-    "Dutch": "nl",
-    "Estonian": "et",
-    "Finnish": "fi",
-    "French": "fr",
-    "Galician": "gl",
-    "German": "de",
-    "Greek": "el",
-    "Hebrew": "he",
-    "Hindi": "hi",
-    "Hungarian": "hu",
-    "Icelandic": "is",
-    "Indonesian": "id",
-    "Italian": "it",
-    "Japanese": "ja",
-    "Kannada": "kn",
-    "Kazakh": "kk",
-    "Korean": "ko",
-    "Latvian": "lv",
-    "Lithuanian": "lt",
-    "Macedonian": "mk",
-    "Malay": "ms",
-    "Marathi": "mr",
-    "Maori": "mi",
-    "Nepali": "ne",
-    "Norwegian": "no",
-    "Persian": "fa",
-    "Polish": "pl",
-    "Portuguese": "pt",
-    "Romanian": "ro",
-    "Russian": "ru",
-    "Serbian": "sr",
-    "Slovak": "sk",
-    "Slovenian": "sl",
-    "Spanish": "es",
-    "Swahili": "sw",
-    "Swedish": "sv",
-    "Tagalog": "tl",
-    "Tamil": "ta",
-    "Thai": "th",
-    "Turkish": "tr",
-    "Ukrainian": "uk",
-    "Urdu": "ur",
-    "Vietnamese": "vi",
-    "Welsh": "cy"
-  };
-
-  Object.keys(optionLanguage).forEach( language => {
-    let option = document.createElement("option");
-    option.value = optionLanguage[language];
-    option.innerHTML = `${language}`
-    select.appendChild(option);
-  } );
-
-  document.querySelector("#tier").disabled=true;
-}
-
-function populateLanguageDeepgramRestricted() {
-
-  const select = document.querySelector('#language');
-  select.innerHTML = "";
-
-  const optionLanguage = {
-    "English": "en",
-    "English (United States)": "en-US"
-  }
-
-  Object.keys(optionLanguage).forEach( language => {
-    let option = document.createElement("option")
-    option.value = optionLanguage[language]
-    option.innerHTML = `${language}`
-    select.appendChild(option);
-  } );
-
-  document.querySelector("#tier").disabled=false;
+  });
 }


### PR DESCRIPTION
Deepgram has deprecated the tier=base|enhanced|nova parameter and the 2-general/2-meeting model-name prefix; models are now selected directly (nova-3, nova-2, nova-2-meeting, enhanced, base). This collapses the previous Model + Quality dropdowns into a single Model dropdown, drops the per-language/tier compatibility matrix and the nova->enhanced->base retry fallback, and updates the URL builder to use summarize=v2.

Whisper-via-Deepgram options are removed from this modal so the Deepgram modal contains only Deepgram models. The browser-side Whisper tab (client-whisper-service) is unaffected.

- Hardcoded DEEPGRAM_MODELS list with per-model supported language sets at the top of the file; populateLanguagesForModel replaces the three legacy populators.
- Drop tier parameter from getData/fetchData/fetchDataLocal/ getApiUrl/displayAppropriateErrorMessage and remove the fallback retry chain.
- Remove the Quality (#tier) select from the Deepgram modal template in index.html.
- Bump version to 1.1.0.

Addresses #278 