### PR TITLE
281 caption switcher fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1209,13 +1209,21 @@ If you are creating an open source application under a license compatible with t
 
       holder.innerHTML = '<div class="modal-action"><label id="regenerate-btn" for="regenerate-captions-modal" class="fixed bottom-8 right-8 btn btn-outline btn-primary" >Regenerate <svg id="regenerate-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-restart"><path d="M21 6H3"></path><path d="M7 12H3"></path><path d="M7 18H3"></path><path d="M12 18a5 5 0 0 0 9-3 4.5 4.5 0 0 0-4.5-4.5c-1.33 0-2.54.54-3.41 1.41L11 14"></path><path d="M11 10v4h4"></path></svg></label></div>';
 
-      if (captionCache === null) {
+      if (captionCache === null ) {
         let newDiv = document.createElement('div');
+
+        // Set an id for the new div
         newDiv.id = 'captions-display';
+
+        // Append the new div to the existing div
+
         holder.insertAdjacentElement('beforeEnd', newDiv);
 
+        // Initialize the DOM parser
         let parser = new DOMParser();
         let html = document.querySelector('#caption-template-holder').innerHTML;
+
+        // Parse the text
         let template = parser.parseFromString(html, "text/html");
 
         let index = 0;
@@ -1239,6 +1247,7 @@ If you are creating an open source application under a license compatible with t
         });
 
         captionCache = captureCaptions(holder);
+
       } else {
         holder.innerHTML = captionCache;
       }

--- a/index.html
+++ b/index.html
@@ -704,6 +704,12 @@ If you are creating an open source application under a license compatible with t
   let transcriptCache = null;
   let captionCache = null;
 
+  // A new transcript was just created with no captions of its own
+  // (transcribe / JSON import / SRT-VTT import) — discard any cached caption
+  // editor so the next entry rebuilds from the fresh transcript. Caption
+  // edits otherwise persist; localStorage load manages its own cache.
+  window.document.addEventListener('hyperaudioInit', () => { captionCache = null; }, false);
+
   document.querySelector('#caption-editor-btn').addEventListener('click', (e) => {
     let holder = document.querySelector('.transcript-holder');
     transcriptCache = holder.cloneNode(true);
@@ -1203,21 +1209,13 @@ If you are creating an open source application under a license compatible with t
 
       holder.innerHTML = '<div class="modal-action"><label id="regenerate-btn" for="regenerate-captions-modal" class="fixed bottom-8 right-8 btn btn-outline btn-primary" >Regenerate <svg id="regenerate-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-restart"><path d="M21 6H3"></path><path d="M7 12H3"></path><path d="M7 18H3"></path><path d="M12 18a5 5 0 0 0 9-3 4.5 4.5 0 0 0-4.5-4.5c-1.33 0-2.54.54-3.41 1.41L11 14"></path><path d="M11 10v4h4"></path></svg></label></div>';
 
-      if (captionCache === null ) {
+      if (captionCache === null) {
         let newDiv = document.createElement('div');
-
-        // Set an id for the new div
         newDiv.id = 'captions-display';
-
-        // Append the new div to the existing div
-
         holder.insertAdjacentElement('beforeEnd', newDiv);
-      
-        // Initialize the DOM parser
+
         let parser = new DOMParser();
         let html = document.querySelector('#caption-template-holder').innerHTML;
-
-        // Parse the text
         let template = parser.parseFromString(html, "text/html");
 
         let index = 0;
@@ -1238,11 +1236,9 @@ If you are creating an open source application under a license compatible with t
           captionTempl.querySelector('.line2').value = line2;
 
           holder.querySelector('#captions-display').insertAdjacentElement('beforeEnd', captionTempl);
-          //document.querySelector('#captions-display').insertAdjacentElement('beforeEnd', captionTempl);
         });
 
         captionCache = captureCaptions(holder);
-      
       } else {
         holder.innerHTML = captionCache;
       }

--- a/js/caption-modified.js
+++ b/js/caption-modified.js
@@ -148,17 +148,24 @@ var caption = function () {
       // If the entire segment fits on a line, add it to the captions.
       if (segment.chars < maxLineLength) {
 
-        if (segment.duration === 0){
-          if (i < arr.length) {
-            segment.duration = arr[i+1].start - segment.start; 
-          } else {
-            segment.duration = 5 * 1000;
-          }
-        } 
+        // Prefer the last word's actual end time over the accumulated
+        // duration, which only sums word durations and undercounts the
+        // segment whenever there are silent gaps between words.
+        var lastWord = segment.words[segment.words.length - 1];
+        var segmentStop;
+        if (lastWord !== undefined && !isNaN(lastWord.start + lastWord.duration)) {
+          segmentStop = lastWord.start + lastWord.duration;
+        } else if (segment.duration > 0) {
+          segmentStop = segment.start + segment.duration;
+        } else if (i + 1 < arr.length) {
+          segmentStop = arr[i+1].start;
+        } else {
+          segmentStop = segment.start + 5;
+        }
 
         thisCaption = new captionMeta(
           formatSeconds(segment.start),
-          formatSeconds(segment.start + segment.duration),
+          formatSeconds(segmentStop),
           '',
         );
 

--- a/js/hyperaudio-lite-editor-deepgram.js
+++ b/js/hyperaudio-lite-editor-deepgram.js
@@ -119,6 +119,10 @@ class DeepgramService extends HTMLElement {
   }
 
   getData(event) {
+    // If the user is in caption mode, switch back to transcript view so the
+    // transcribing loader is visible and the result lands in the right place.
+    // #transcript-editor-btn is disabled in transcript mode, so this no-ops.
+    document.querySelector('#transcript-editor-btn')?.click();
     document.querySelector('#hypertranscript').innerHTML = '<div class="vertically-centre"><center>Transcribing....</center><br/><img src="'+transcribingSvg+'" width="50" alt="transcribing" style="margin: auto; display: block;"></div>';
     const language = document.querySelector('#language').value;
     const model = document.querySelector('#language-model').value;

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -125,6 +125,11 @@ function loadWhisperClient(modal, workerBaseUrl) {
 
   async function handleFormSubmission() {
 
+    // If the user is in caption mode, switch back to transcript view so the
+    // transcribing loader is visible and the result lands in the right place.
+    // #transcript-editor-btn is disabled in transcript mode, so this no-ops.
+    document.querySelector('#transcript-editor-btn')?.click();
+
     const model_name = modelNameSelectionInput.value;
     const file = fileUploadBtn.files[0];
     const audio = await readAudioFrom(file);


### PR DESCRIPTION
## Summary

  Three related caption-editor bugs surfaced while testing the Deepgram flow end-to-end.

  ### 1. Stale captions after a new transcript (`9e1f849`)
  `populateCaptionEditor` short-circuits on a non-null `captionCache`, which is the right behavior for preserving user caption edits across transcript edits — but
  the cache was never invalidated when a *fresh* transcript was produced. After running Deepgram or Whisper, or importing JSON/SRT/VTT, switching to the caption
  page showed captions from the **previous** transcript.

  Fix: invalidate `captionCache` on the `hyperaudioInit` event, which all three "new transcript" code paths already dispatch. The localStorage load path manages
  its own cache (it loads captions alongside the transcript), so `hyperaudioTranscriptLoaded` is intentionally not used as a trigger. The Regenerate button is
  unchanged.

  ### 2. Transcribing from caption mode produced no visible loader and no result (`1a4a7c7`)
  Both `getData()` (Deepgram) and `handleFormSubmission()` (Whisper) write the "Transcribing…" loader and the final transcript to `#hypertranscript`. While the
  user is in caption mode, `#hypertranscript` is detached from the DOM — so the loader never showed and the result never landed.

  Fix: programmatically click `#transcript-editor-btn` at the start of each transcribe flow. The button is `disabled` whenever the user is already in transcript
  view (initial HTML state + set explicitly on switch-back), so the click is a no-op in transcript mode and a clean mode-switch in caption mode.

  ### 3. Short-caption stop times were too early (`aab08a2`)
  In `caption-modified.js`, the short-caption path (`segment.chars < maxLineLength`) used `segment.start + segment.duration` for the caption's stop time, where
  `segment.duration` is the *sum of word durations*. When a segment contained silent gaps between words, the sum was shorter than the wall-clock span, and the
  caption text visibly outran its time range — e.g., "So group one is the first one." with a real end at 5.04s was emitted with an Out of 3.28s.

  Fix: use the last word's actual end (`lastWord.start + lastWord.duration`) for the stop time, with fallbacks for missing word durations. The long-segment path
  already used per-word end times via `lastOutTime` and was unaffected.

  Likely latent before #277 (which bumped the paragraph-break gap from 0.5s to 4.0s); short paragraphs rarely had large internal silent gaps so sum-of-durations ≈
  span.

  ## Test plan
  - [ ] Transcribe a file → switch to caption view → confirm captions reflect the new transcript.
  - [ ] Edit a caption in caption view → switch to transcript view → switch back → confirm caption edits persist (cache not over-invalidated).
  - [ ] Click Regenerate → confirm captions rebuild from current transcript and discard caption edits.
  - [ ] In caption view, start a new transcription (Deepgram and Whisper) → confirm the view switches to transcript and the "Transcribing…" loader is visible →
  confirm the resulting transcript renders.
  - [ ] Already in transcript view, start a transcription → confirm behavior unchanged (loader visible, result lands).
  - [ ] Load a session from localStorage that contains captions → confirm captions are not wiped on next tab switch.
  - [ ] Transcribe content with notable silent gaps within a paragraph → switch to caption view → confirm each caption's Out time matches the actual last-word end
  (not the truncated sum-of-durations).