### PR TITLE
281 gap skipping fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1580,6 +1580,21 @@ If you are creating an open source application under a license compatible with t
     return saved;
   }
 
+  function formatGapSavings(seconds) {
+    if (seconds < 60) {
+      return `${seconds.toFixed(1)} seconds`;
+    }
+    const total = Math.round(seconds);
+    const h = Math.floor(total / 3600);
+    const m = Math.floor((total % 3600) / 60);
+    const s = total % 60;
+    const parts = [];
+    if (h > 0) parts.push(`${h}h`);
+    if (m > 0) parts.push(`${m}m`);
+    if (s > 0) parts.push(`${s}s`);
+    return parts.join(' ');
+  }
+
   function updateGapSavingsMessage() {
     const el = document.querySelector('#remove-gaps-savings');
     if (!el) return;
@@ -1588,7 +1603,7 @@ If you are creating an open source application under a license compatible with t
       return;
     }
     const saved = computeGapSavings();
-    el.textContent = `Playback shortened by ${saved.toFixed(1)} seconds`;
+    el.textContent = `Playback shortened by ${formatGapSavings(saved)}`;
     el.style.display = 'block';
   }
 

--- a/index.html
+++ b/index.html
@@ -1594,6 +1594,10 @@ If you are creating an open source application under a license compatible with t
 
   registerStrikeThrus();
   window.document.addEventListener('hyperaudioTranscriptLoaded', registerStrikeThrus, false);
+  // Also rebuild on hyperaudioInit so transcribe (Deepgram/Whisper) and
+  // JSON/SRT/VTT import inherit the current gap-skip settings against the
+  // freshly-loaded transcript.
+  window.document.addEventListener('hyperaudioInit', registerStrikeThrus, false);
 
   function registerStrikeThrus() {
     rebuildAudioDataArray();

--- a/index.html
+++ b/index.html
@@ -1629,6 +1629,29 @@ If you are creating an open source application under a license compatible with t
     rebuildAudioDataArray();
     ensureSkipListeners();
     updateGapSavingsMessage();
+    refreshHyperaudioInstance();
+  }
+
+  // Refresh the library's cached word array so the karaoke highlight stays in
+  // sync with the current DOM after structural edits. Without this, the
+  // existing sanitise()-driven refresh runs at 1000ms vs. our 150ms gap
+  // recalc, leaving the highlight pointing at detached nodes in between.
+  function refreshHyperaudioInstance() {
+    const instance = window.hyperaudioInstance;
+    if (!instance || !instance.transcript) return;
+    const words = instance.transcript.querySelectorAll('[data-m]');
+    instance.wordArr = instance.createWordArray(words);
+    instance.parentElements = instance.transcript.getElementsByTagName(instance.parentTag);
+    if (instance.currentTime !== undefined) {
+      instance.updateTranscriptVisualState(instance.currentTime);
+    }
+    // The library's polling chain may have died silently mid-edit if its
+    // cached wordArr referenced a deleted span (word.n.parentNode === null
+    // throws inside the setTimeout callback). Kicking checkPlayHead clears
+    // any pending timer and starts a fresh poll against the refreshed array.
+    if (typeof instance.checkPlayHead === 'function') {
+      instance.checkPlayHead();
+    }
   }
 
   function getTranscript() {
@@ -1820,6 +1843,14 @@ If you are creating an open source application under a license compatible with t
       const nextStart = audioDataArray[i + 1].start;
       if (t >= stop && t < nextStart) {
         myPlayer.currentTime = nextStart + 0.05;
+        // The library only listens for play/pause natively, not seeked, so
+        // it has no idea we just jumped. Kick its polling chain so the
+        // highlight re-locks onto the post-skip word instead of waiting for
+        // its stale setTimeout to fire seconds later.
+        const instance = window.hyperaudioInstance;
+        if (instance && typeof instance.checkPlayHead === 'function') {
+          instance.checkPlayHead();
+        }
         return;
       }
     }

--- a/index.html
+++ b/index.html
@@ -1614,9 +1614,21 @@ If you are creating an open source application under a license compatible with t
   // freshly-loaded transcript.
   window.document.addEventListener('hyperaudioInit', registerStrikeThrus, false);
 
+  // Recalculate gap-skips and the savings message when the user edits the
+  // transcript (e.g., deletes a word — the time it occupied becomes a gap).
+  // Debounced so we coalesce rapid keystrokes. Delegated on document so the
+  // listener survives transcript element replacement via restoreTranscript().
+  let gapRecalcTimer = null;
+  document.addEventListener('input', (e) => {
+    if (!e.target || e.target.id !== 'hypertranscript') return;
+    clearTimeout(gapRecalcTimer);
+    gapRecalcTimer = setTimeout(registerStrikeThrus, 150);
+  });
+
   function registerStrikeThrus() {
     rebuildAudioDataArray();
     ensureSkipListeners();
+    updateGapSavingsMessage();
   }
 
   function getTranscript() {


### PR DESCRIPTION
## Summary

  Four small fixes around gap-skip so the feature feels live instead of stale. Addresses #281 and #284

  ### 1. Carry settings across to new transcripts (`483ef62`)
  `registerStrikeThrus` (which rebuilds `audioDataArray` and re-attaches skip listeners against the
  current transcript and gap settings) was only bound to `hyperaudioTranscriptLoaded`, which only the
  localStorage load path dispatches. Deepgram, Whisper, and JSON/SRT/VTT import dispatch `hyperaudioInit`
  instead, so the skip pipeline kept pointing at the previous transcript's word data.

  Fix: bind `registerStrikeThrus` to `hyperaudioInit` as well. The two events are disjoint, so no
  double-fire.

  ### 2. Labeled-units format for the savings line (`28e3507`)
  "Playback shortened by 3725.4 seconds" doesn't scale well past a minute. Sub-minute savings still render
   as `12.3 seconds` (decimal preserved), but from 60s upward it switches to labeled units that drop zero
  components: `1m 30s`, `1h 2m 5s`, `1h`.

  ### 3. Recalculate on transcript edits and new transcripts (`a2c43b6`)
  - Call `updateGapSavingsMessage()` from `registerStrikeThrus` so the "Playback shortened by X" line
  reflects the new transcript on every rebuild (transcribe / import / localStorage load / strikethrough
  toggle).
  - Add a debounced `input` listener delegated on `document` that calls `registerStrikeThrus` after 150ms
  of edit inactivity on `#hypertranscript`. Deleting a word turns its time slot into a gap, which should
  be reflected in both the skip pipeline and the savings message. Delegated on `document` so the listener
  survives transcript element replacement via `restoreTranscript`.

  ### 4. Keep the karaoke highlight in sync (`4983b0e`)
  The hyperaudio-lite library tracks the active word via a cached `wordArr` and a chained `setTimeout`
  that polls `currentTime`, but it only natively listens for `play`/`pause` — not `seeked` or DOM
  mutations. That leaves two windows where the highlight freezes:

  - **After edits**: the polling chain crashes silently if it touches a now-detached span
  (`word.n.parentNode` is `null`, `.classList` throws inside the `setTimeout` callback), and nothing
  restarts it.
  - **After a gap skip**: our code calls `myPlayer.currentTime = nextStart + 0.05` directly; the library
  has no idea we jumped and waits for its stale timer to fire seconds later before relocating the active
  word.

  Fix: a `refreshHyperaudioInstance()` helper rebuilds `wordArr` and `parentElements`, updates the visual
  state, and kicks `checkPlayHead` to restart the polling chain. Called from `registerStrikeThrus` so
  edits and new transcripts both refresh the library's caches. Also kick `checkPlayHead` from
  `checkStrikeThrus` right after a gap skip so the highlight resyncs to the post-skip word immediately
  rather than waiting for the stale timer.

  ## Test plan
  - [ ] Enable gap-skip with custom threshold/buffer. Transcribe a new file via Deepgram → confirm skips
  fire and the savings line updates.
  - [ ] Same flow via Whisper.
  - [ ] Same flow via JSON/SRT/VTT import.
  - [ ] Load a saved session from localStorage → confirm skips still work and the savings line is correct.
  - [ ] Delete a word in the transcript while gap-skip is on → confirm within ~150ms the savings line
  updates and the new gap (the deleted word's slot) is skipped on playback.
  - [ ] Confirm karaoke highlight follows playback continuously across deletions (no freeze on the last
  edited word).
  - [ ] Confirm karaoke highlight follows playback continuously across gap skips (no freeze at the start
  of the gap).
  - [ ] Confirm savings line shows `X.X seconds` under 60s, `Xm Ys` between 1–59 min, `Xh Ym Zs` for ≥ 1h.

