### PR TITLE
244 button tooltips

### DIFF
--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -179,3 +179,55 @@ dialog::backdrop {
 
 
 }
+
+/* Minimal tooltip styling — mirrors DaisyUI .tooltip + data-tip so a future
+   tailwind rebuild can take over without HTML changes. Positioned below
+   since the toolbar is at the top of the page. Show is delayed 500ms so a
+   quick mouse pass doesn't flash a tooltip; hide is instant. */
+.tooltip {
+  position: relative;
+}
+.tooltip::before {
+  content: attr(data-tip);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 10px;
+  background: oklch(0.27 0.02 264);
+  color: #fff;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 400;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 100;
+  opacity: 0;
+  transition: opacity 0s;
+}
+.tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 4px solid transparent;
+  border-bottom-color: oklch(0.27 0.02 264);
+  pointer-events: none;
+  z-index: 100;
+  opacity: 0;
+  transition: opacity 0s;
+}
+.tooltip:hover::before,
+.tooltip:hover::after {
+  opacity: 1;
+  transition: opacity 0s 0.5s;
+}
+
+/* Sidebar toggle sits at the left edge when the sidebar is collapsed, so
+   left-anchor its tooltip bubble to avoid running off-screen. The arrow
+   stays centred under the button. */
+#sidebar-toggle.tooltip::before {
+  left: 0;
+  transform: none;
+}

--- a/index.html
+++ b/index.html
@@ -236,14 +236,14 @@ If you are creating an open source application under a license compatible with t
     <div class="main-panel" style="z-index: 2">
       <div class="navbar bg-base-100" style="background-color: #ffffff; opacity:0.95; min-height:70px;">
         <div class="navbar-start">
-          <button id="sidebar-toggle" class="btn btn-square btn-outline" style="margin-right:4px" aria-label="Toggle Sidebar">
+          <button id="sidebar-toggle" class="btn btn-square btn-outline tooltip" data-tip="Toggle sidebar" style="margin-right:4px" aria-label="Toggle Sidebar">
             <svg id="sidebar-close-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sidebar-close"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect><path d="M9 3v18"></path><path d="m16 15-3-3 3-3"></path></svg>
             <svg id="sidebar-open-icon" style="display: none" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sidebar-open"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect><path d="M9 3v18"></path><path d="m14 9 3 3-3 3"></path></svg>
           </button>
-          <button id="strikethrough" class="btn btn-square btn-outline" style="margin-right:4px" aria-label="Strike through text">
+          <button id="strikethrough" class="btn btn-square btn-outline tooltip" data-tip="Strikethrough" style="margin-right:4px" aria-label="Strike through text">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-strikethrough"><path d="M16 4H9a3 3 0 0 0-2.83 4"/><path d="M14 12a4 4 0 0 1 0 8H6"/><line x1="4" x2="20" y1="12" y2="12"/></svg>
           </button>
-          <label id="remove-gaps-btn" for="remove-gaps-modal" class="btn btn-square btn-outline relative" style="margin-right:4px" aria-label="Remove silent gaps">
+          <label id="remove-gaps-btn" for="remove-gaps-modal" class="btn btn-square btn-outline relative tooltip" data-tip="Skip silent gaps" style="margin-right:4px" aria-label="Remove silent gaps">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-rabbit"><path d="M13 16a3 3 0 0 1 2.24 5"/><path d="M18 12h.01"/><path d="M18 21h-8a4 4 0 0 1-4-4 7 7 0 0 1 7-7h.2L9.6 6.4a1 1 0 1 1 2.8-2.8L15.8 7h.2c3.3 0 6 2.7 6 6v1a2 2 0 0 1-2 2h-1a3 3 0 0 0-3 3"/><path d="M20 8.54V4a2 2 0 1 0-4 0v3"/><path d="M7.612 12.524a3 3 0 1 0-1.6 4.3"/></svg>
             <span id="remove-gaps-active-dot" style="display:none;position:absolute;top:4px;right:4px;width:9px;height:9px;border-radius:9999px;background-color:oklch(var(--p));z-index:2;pointer-events:none;"></span>
           </label>
@@ -294,7 +294,7 @@ If you are creating an open source application under a license compatible with t
               <li><label for="file-import-vtt-dialog">Import VTT</label></li>
             </ul>
           </div>
-          <label for="info-modal" class="btn btn-ghost btn-primary gap-2">
+          <label for="info-modal" class="btn btn-ghost btn-primary gap-2 tooltip" data-tip="Summary and topics" aria-label="Summary and topics">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-info"><circle cx="12" cy="12" r="10"></circle><line x1="12" x2="12" y1="16" y2="12"></line><line x1="12" x2="12.01" y1="8" y2="8"></line></svg>
           </label>
           <input type="checkbox" id="info-modal" class="modal-toggle" />
@@ -317,10 +317,10 @@ If you are creating an open source application under a license compatible with t
           <!--<label for="captions-modal" class="btn btn-outline gap-2" style="margin-right:4px">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-subtitles"><path d="M7 13h4"></path><path d="M15 13h2"></path><path d="M7 9h2"></path><path d="M13 9h4"></path><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10Z"></path></svg>
           </label>-->
-          <button id="caption-editor-btn" class="btn btn-square btn-outline" style="margin-right:4px">
+          <button id="caption-editor-btn" class="btn btn-square btn-outline tooltip" data-tip="Edit captions" style="margin-right:4px" aria-label="Edit captions">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-subtitles"><path d="M7 13h4"></path><path d="M15 13h2"></path><path d="M7 9h2"></path><path d="M13 9h4"></path><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10Z"></path></svg>
           </button>
-          <button id="transcript-editor-btn" class="btn btn-square btn-outline" style="margin-right:4px" disabled>
+          <button id="transcript-editor-btn" class="btn btn-square btn-outline tooltip" data-tip="Edit transcript" style="margin-right:4px" aria-label="Edit transcript" disabled>
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-file-text"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
           </button>
           <input type="checkbox" id="captions-modal" class="modal-toggle" />

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.2 -->
+<!--  Hyperaudio Lite Editor - Version 0.6.3 -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 


### PR DESCRIPTION
 ## Summary

  Icon-only toolbar buttons had no visible labels, leaving users to guess their function. Adds
  DaisyUI-style hover tooltips to the sidebar toggle, strikethrough, rabbit (skip silent gaps), info,
  edit-captions, and edit-transcript buttons. The FILE dropdown already has a visible label and is
  skipped.

  The compiled `tailwind-min.css` doesn't include DaisyUI's `tooltip` component, so this commit ships a
  minimal CSS implementation that matches DaisyUI's `.tooltip` + `data-tip` API. A future Tailwind rebuild
   can take over without any HTML changes.

  ### Tooltip behavior
  - Positioned below the button (the toolbar sits at the top of the page).
  - Appear after **500ms** of hover so a quick mouse pass doesn't flash a tooltip.
  - Hide instantly on unhover.
  - `#sidebar-toggle` is left-anchored so its bubble stays on-screen when the sidebar is collapsed and the
   button is at the left edge.

  Version bump to **0.6.3**.

  ## Test plan
  - [ ] Hover each icon button in the toolbar for ~500ms — tooltip appears with the labels listed above.
  - [ ] Quick mouse-pass across buttons — no tooltips flash.
  - [ ] Collapse the sidebar so `#sidebar-toggle` sits at the very left edge — tooltip stays fully visible
   (anchored to the button's left edge rather than centered).
  - [ ] Hover the rabbit while gap-skip is active — tooltip co-exists with the purple corner dot.
  - [ ] Verify the FILE dropdown still works as before with no tooltip.