### PR TITLE
Fix karaoke highlight crash when editing the transcript

### DIFF
--- a/index.html
+++ b/index.html
@@ -743,6 +743,22 @@ If you are creating an open source application under a license compatible with t
 
     const hyperaudioInstance = new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick);
 
+    // Patch for #294: if the library's polling chain runs while wordArr
+    // still references a span deleted by an in-progress edit, the original
+    // throws on word.n.parentNode.classList and the chain dies silently.
+    // Strip detached entries before delegating — the next debounced
+    // refreshHyperaudioInstance will rebuild wordArr from the live DOM.
+    const originalUpdateVisualState = hyperaudioInstance.updateTranscriptVisualState.bind(hyperaudioInstance);
+    hyperaudioInstance.updateTranscriptVisualState = function (currentTime) {
+      if (hyperaudioInstance.wordArr) {
+        const live = hyperaudioInstance.wordArr.filter(w => w.n && w.n.parentNode);
+        if (live.length !== hyperaudioInstance.wordArr.length) {
+          hyperaudioInstance.wordArr = live;
+        }
+      }
+      return originalUpdateVisualState(currentTime);
+    };
+
     window.hyperaudioInstance = hyperaudioInstance;
 
     const sanitisationCheck = function () {


### PR DESCRIPTION
## Summary

When the user deletes spans in the transcript while playback is running, `hyperaudio-lite`'s cached `wordArr` still references the now-detached nodes. If its `setTimeout` poll fires before the editor's debounced `refreshHyperaudioInstance` rebuilds the array, `updateTranscriptVisualState` dereferences `word.n.parentNode.classList` on a node whose `parentNode` is `null` — the rejection happens inside the `setTimeout` callback so the polling chain dies silently, freezing the karaoke highlight for the rest of the session.

Monkeypatches `updateTranscriptVisualState` on the `HyperaudioLite` instance to filter `wordArr` to live entries before delegating to the original. The library only uses `wordArr` via a fresh binary search per call, so a temporarily shrunken array is consistent. The next debounced `refreshHyperaudioInstance` rebuilds `wordArr` fully from the live DOM.

Kept the fix in the editor rather than upstream because the race only exists for editor-style consumers that mutate the transcript DOM at runtime; `hyperaudio-lite` is otherwise read-only.

Fixes #294.

## Test plan

- [ ] Play the demo media. Rapidly delete words/paragraphs from the transcript. Confirm no console errors and the highlight keeps tracking the audio.
- [ ] Strikethrough toggle + gap-skip continue to work as before.
- [ ] Switch to caption mode and back via `restoreTranscript` — confirm the patch is applied to the fresh `HyperaudioLite` instance (re-applied on every `hyperaudio()` call).
- [ ] Page load with no edits → highlight behavior unchanged from main.