### PR TITLE
feat: Add YouTube caption import and export

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,6 +289,9 @@ If you are creating an open source application under a license compatible with t
               </li>
               <li><export-json></export-json></li>
               <li><import-json></import-json></li>
+              <li><export-youtube-vtt></export-youtube-vtt></li>
+              <li><export-youtube-xml></export-youtube-xml></li>
+              <li><label for="file-import-youtube-caption-dialog">Import YouTube captions</label></li>
               <li><label for="file-import-deepgram-json-dialog">Import Deepgram JSON</label></li>
               <li><label for="file-import-srt-dialog">Import SRT</label></li>
               <li><label for="file-import-vtt-dialog">Import VTT</label></li>
@@ -1095,6 +1098,7 @@ If you are creating an open source application under a license compatible with t
   <import-deepgram-json></import-deepgram-json>
   <import-srt></import-srt>
   <import-vtt></import-vtt>
+  <import-youtube-captions></import-youtube-captions>
   
   <!-- comment out if localstorage not required -->
 
@@ -1173,6 +1177,7 @@ If you are creating an open source application under a license compatible with t
 
   </script>
 
+  <script src="./js/youtube-caption-converter.js"></script>
   <script src="./js/hyperaudio-lite-editor-export.js" type="module"> </script>
   <!-- end of localstorage additions -->
 

--- a/js/hyperaudio-lite-editor-export.js
+++ b/js/hyperaudio-lite-editor-export.js
@@ -71,6 +71,56 @@ class ImportJson extends HTMLElement {
 
 customElements.define('import-json', ImportJson);
 
+class ExportYoutubeVtt extends HTMLElement {
+
+  constructor() {
+    super();
+  }
+
+  exportYoutubeVtt() {
+    const jsonData = getHyperaudioJsonForExport();
+    if (!jsonData) return;
+
+    downloadText(
+      window.hyperaudioJsonToYoutubeVtt(jsonData),
+      'youtube-captions.vtt',
+      'text/vtt'
+    );
+  }
+
+  connectedCallback() {
+    this.innerHTML = `<a>Export YouTube VTT</a>`;
+    this.addEventListener('click', this.exportYoutubeVtt);
+  }
+}
+
+customElements.define('export-youtube-vtt', ExportYoutubeVtt);
+
+class ExportYoutubeXml extends HTMLElement {
+
+  constructor() {
+    super();
+  }
+
+  exportYoutubeXml() {
+    const jsonData = getHyperaudioJsonForExport();
+    if (!jsonData) return;
+
+    downloadText(
+      window.hyperaudioJsonToYoutubeTimedTextXml(jsonData),
+      'youtube-captions.xml',
+      'application/xml'
+    );
+  }
+
+  connectedCallback() {
+    this.innerHTML = `<a>Export YouTube XML</a>`;
+    this.addEventListener('click', this.exportYoutubeXml);
+  }
+}
+
+customElements.define('export-youtube-xml', ExportYoutubeXml);
+
 class ImportDeepgramJson extends HTMLElement {
 
   constructor() {
@@ -427,6 +477,120 @@ class ImportVtt extends HTMLElement {
 }
 
 customElements.define('import-vtt', ImportVtt);
+
+class ImportYoutubeCaptions extends HTMLElement {
+
+  constructor() {
+    super();
+  }
+
+  clearYoutubeCaptionMediaUrl(event) {
+    event.preventDefault();
+    document.querySelector('#youtube-caption-media').value = "";
+  }
+
+  clearYoutubeCaptionFilePicker(event) {
+    event.preventDefault();
+    document.querySelector('#youtube-caption-media-file').value = "";
+  }
+
+  confirmYoutubeCaptions() {
+    const player = document.querySelector("#hyperplayer");
+    if (document.querySelector('#youtube-caption-media-file').value == ""){
+      player.src = document.querySelector('#youtube-caption-media').value;
+    } else {
+      const mediaFile = document.querySelector('[name=youtube-caption-media-file]').files[0];
+      const mediaReader = new FileReader();
+      mediaReader.readAsArrayBuffer(mediaFile);
+      mediaReader.addEventListener('load', () => {
+        mediaFile.arrayBuffer().then((arrayBuffer) => {
+          const blob = new Blob([new Uint8Array(arrayBuffer)], {type: mediaFile.type });
+          player.src = URL.createObjectURL(blob);
+        });
+      });
+    }
+
+    const file = document.querySelector('[name=youtube-caption-file]').files[0];
+    if (!file) {
+      alert("Please select a YouTube XML or VTT caption file.");
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.addEventListener('load', (event) => {
+      const captionData = event.target.result;
+      const isXml = file.name.toLowerCase().endsWith('.xml') || captionData.trim().startsWith('<');
+      const html = isXml
+        ? window.youtubeTimedTextXmlToHtml(captionData)
+        : window.youtubeVttToHtml(captionData);
+
+      const hypertranscript = document.getElementById('hypertranscript');
+      hypertranscript.innerHTML = html;
+
+      const jsonData = htmlToJson(hypertranscript);
+      const youtubeVtt = window.hyperaudioJsonToYoutubeVtt(jsonData);
+      document.querySelector('#hyperplayer-vtt').src = "data:text/vtt," + encodeURIComponent(youtubeVtt);
+
+      updateCaptionsFromTranscript = false;
+      populateCaptionEditorFromVtt(youtubeVtt);
+      document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+    });
+
+    reader.readAsText(file);
+  }
+
+  connectedCallback() {
+    this.innerHTML = `
+    <div class="hidden-label-holder">
+      <label for="file-import-youtube-caption-dialog">Import YouTube Captions Dialog</label>
+    </div>
+    <input type="checkbox" id="file-import-youtube-caption-dialog" class="modal-toggle" />
+    <div class="modal">
+    <div class="modal-box">
+      <div class="flex flex-col gap-4 w-full">
+        <label id="close-modal" for="file-import-youtube-caption-dialog" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+        <h3 class="font-bold text-lg">Import YouTube Captions Dialog</h3>
+        <input id="youtube-caption-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
+        <span class="label-text">or use local media file</span>
+        <input id="youtube-caption-media-file" name="youtube-caption-media-file" type="file" class="file-input w-full max-w-xs" />
+        <span class="label-text">select YouTube XML or VTT file</span>
+        <input id="youtube-caption-file" name="youtube-caption-file" type="file" accept=".xml,.vtt,text/xml,text/vtt" class="file-input w-full max-w-xs" />
+      </div>
+      <div class="modal-action">
+        <label for="file-import-youtube-caption-dialog" class="btn btn-ghost">Cancel</label>
+        <label id="file-import-youtube-caption" for="file-import-youtube-caption-dialog" class="btn btn-primary">Confirm</label>
+      </div>
+    </div>
+    </div>`;
+
+    document.querySelector('#youtube-caption-media-file').addEventListener('change',this.clearYoutubeCaptionMediaUrl);
+    document.querySelector('#youtube-caption-media').addEventListener('change',this.clearYoutubeCaptionFilePicker);
+    document.querySelector('#file-import-youtube-caption').addEventListener('click',this.confirmYoutubeCaptions);
+  }
+}
+
+customElements.define('import-youtube-captions', ImportYoutubeCaptions);
+
+function getHyperaudioJsonForExport() {
+  const hypertranscript = document.getElementById('hypertranscript');
+
+  if (hypertranscript === null) {
+    alert("Currently you can only export YouTube captions from the transcript view.");
+    return null;
+  }
+
+  return htmlToJson(hypertranscript);
+}
+
+function downloadText(textData, fileName, mimeType) {
+  const dataStr = `data:${mimeType};charset=utf-8,` + encodeURIComponent(textData);
+  const downloadAnchorNode = document.createElement('a');
+  downloadAnchorNode.setAttribute('href', dataStr);
+  downloadAnchorNode.setAttribute('download', fileName);
+  document.body.appendChild(downloadAnchorNode);
+  downloadAnchorNode.click();
+  downloadAnchorNode.remove();
+}
 
 function downloadJson(jsonData) {
   // download json file

--- a/js/hyperaudio-lite-editor-export.js
+++ b/js/hyperaudio-lite-editor-export.js
@@ -496,6 +496,14 @@ class ImportYoutubeCaptions extends HTMLElement {
 
   confirmYoutubeCaptions() {
     const player = document.querySelector("#hyperplayer");
+    const hypertranscript = document.getElementById('hypertranscript');
+    const track = document.querySelector('#hyperplayer-vtt');
+
+    if (!player || !hypertranscript || !track) {
+      alert("Currently you can only import YouTube captions from the transcript view.");
+      return;
+    }
+
     if (document.querySelector('#youtube-caption-media-file').value == ""){
       player.src = document.querySelector('#youtube-caption-media').value;
     } else {
@@ -524,12 +532,11 @@ class ImportYoutubeCaptions extends HTMLElement {
         ? window.youtubeTimedTextXmlToHtml(captionData)
         : window.youtubeVttToHtml(captionData);
 
-      const hypertranscript = document.getElementById('hypertranscript');
       hypertranscript.innerHTML = html;
 
       const jsonData = htmlToJson(hypertranscript);
       const youtubeVtt = window.hyperaudioJsonToYoutubeVtt(jsonData);
-      document.querySelector('#hyperplayer-vtt').src = "data:text/vtt," + encodeURIComponent(youtubeVtt);
+      track.src = "data:text/vtt," + encodeURIComponent(youtubeVtt);
 
       updateCaptionsFromTranscript = false;
       populateCaptionEditorFromVtt(youtubeVtt);

--- a/js/youtube-caption-converter.js
+++ b/js/youtube-caption-converter.js
@@ -1,0 +1,298 @@
+(function (root) {
+  function decodeEntities(value) {
+    return String(value)
+      .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+      .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCharCode(parseInt(code, 16)))
+      .replace(/&quot;/g, '"')
+      .replace(/&apos;/g, "'")
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&');
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function normalizeLines(value) {
+    return String(value || '').replace(/\r\n|\r/g, '\n');
+  }
+
+  function parseTimestampMs(value) {
+    const clean = String(value || '').trim().replace(',', '.');
+    if (!clean) return 0;
+
+    if (!clean.includes(':')) {
+      const numeric = Number(clean);
+      return Number.isFinite(numeric) ? Math.round(numeric * 1000) : 0;
+    }
+
+    const parts = clean.split(':').map(Number);
+    if (parts.some((part) => !Number.isFinite(part))) return 0;
+
+    let seconds = 0;
+    if (parts.length === 3) {
+      seconds = parts[0] * 3600 + parts[1] * 60 + parts[2];
+    } else if (parts.length === 2) {
+      seconds = parts[0] * 60 + parts[1];
+    } else {
+      seconds = parts[0];
+    }
+    return Math.round(seconds * 1000);
+  }
+
+  function parseXmlTimeMs(value, fallbackMs, decimalIsSeconds) {
+    if (value === undefined || value === null || value === '') return fallbackMs;
+    const clean = String(value).trim();
+    if (clean.includes(':')) return parseTimestampMs(clean);
+
+    const numeric = Number(clean);
+    if (!Number.isFinite(numeric)) return fallbackMs;
+    if (clean.includes('.') || decimalIsSeconds) return Math.round(numeric * 1000);
+    return Math.round(numeric);
+  }
+
+  function formatTimestamp(ms) {
+    const safeMs = Math.max(0, Math.round(ms));
+    const hours = Math.floor(safeMs / 3600000);
+    const minutes = Math.floor((safeMs % 3600000) / 60000);
+    const seconds = Math.floor((safeMs % 60000) / 1000);
+    const millis = safeMs % 1000;
+    return [
+      String(hours).padStart(2, '0'),
+      String(minutes).padStart(2, '0'),
+      `${String(seconds).padStart(2, '0')}.${String(millis).padStart(3, '0')}`,
+    ].join(':');
+  }
+
+  function stripTags(value) {
+    return String(value || '').replace(/<[^>]+>/g, ' ');
+  }
+
+  function splitWords(value) {
+    const text = decodeEntities(stripTags(value)).replace(/\s+/g, ' ').trim();
+    return text ? text.split(' ') : [];
+  }
+
+  function wordsForSegment(text, startMs, endMs) {
+    const words = splitWords(text);
+    if (words.length === 0) return [];
+
+    const duration = Math.max(0, endMs - startMs);
+    const step = words.length > 0 ? duration / words.length : 0;
+
+    return words.map((word, index) => {
+      const wordStart = Math.round(startMs + step * index);
+      const wordEnd = index === words.length - 1
+        ? Math.round(endMs)
+        : Math.round(startMs + step * (index + 1));
+      return {
+        startMs: wordStart,
+        endMs: Math.max(wordStart, wordEnd),
+        text: word,
+      };
+    });
+  }
+
+  function wordsFromTimedCue(text, cueStartMs, cueEndMs) {
+    const timestampPattern = /<((?:\d{1,2}:)?\d{2}:\d{2}[\.,]\d{3})>/g;
+    const segments = [];
+    let activeStart = cueStartMs;
+    let lastIndex = 0;
+    let match;
+
+    while ((match = timestampPattern.exec(text)) !== null) {
+      const segmentText = text.slice(lastIndex, match.index);
+      if (segmentText.trim()) {
+        segments.push({ startMs: activeStart, text: segmentText });
+      }
+      activeStart = parseTimestampMs(match[1]);
+      lastIndex = match.index + match[0].length;
+    }
+
+    const finalText = text.slice(lastIndex);
+    if (finalText.trim()) {
+      segments.push({ startMs: activeStart, text: finalText });
+    }
+
+    if (segments.length === 0) {
+      return wordsForSegment(text, cueStartMs, cueEndMs);
+    }
+
+    return segments.flatMap((segment, index) => {
+      const segmentEnd = index < segments.length - 1 ? segments[index + 1].startMs : cueEndMs;
+      return wordsForSegment(segment.text, segment.startMs, segmentEnd);
+    });
+  }
+
+  function paragraphsToHtml(paragraphs) {
+    const body = paragraphs.map((words) => {
+      const spans = words.map((word) => {
+        const start = Math.round(word.startMs);
+        const duration = Math.max(0, Math.round(word.endMs - word.startMs));
+        return `<span data-m="${start}" data-d="${duration}">${escapeHtml(word.text)} </span>`;
+      }).join('');
+      return `<p>${spans}</p>`;
+    }).join('');
+
+    return `<article><section>${body}</section></article>`;
+  }
+
+  function youtubeVttToHtml(data) {
+    const blocks = normalizeLines(data)
+      .split(/\n\s*\n/)
+      .map((block) => block.trim())
+      .filter(Boolean);
+
+    const paragraphs = [];
+    for (const block of blocks) {
+      const lines = block.split('\n').map((line) => line.trimEnd());
+      const timingIndex = lines.findIndex((line) => line.includes('-->'));
+      if (timingIndex === -1) continue;
+
+      const timing = lines[timingIndex].split(/[\t ]*-->[\t ]*/);
+      const startMs = parseTimestampMs(timing[0]);
+      const endMs = parseTimestampMs((timing[1] || '').split(/\s+/)[0]);
+      const cueText = lines.slice(timingIndex + 1).join(' ');
+      const words = wordsFromTimedCue(cueText, startMs, endMs);
+      if (words.length > 0) paragraphs.push(words);
+    }
+
+    return paragraphsToHtml(paragraphs);
+  }
+
+  function parseAttributes(value) {
+    const attrs = {};
+    const attrPattern = /([\w:-]+)\s*=\s*("([^"]*)"|'([^']*)')/g;
+    let match;
+    while ((match = attrPattern.exec(value || '')) !== null) {
+      attrs[match[1]] = match[3] !== undefined ? match[3] : match[4];
+    }
+    return attrs;
+  }
+
+  function parseSrv3Paragraphs(xml) {
+    const paragraphs = [];
+    const pPattern = /<p\b([^>]*)>([\s\S]*?)<\/p>/gi;
+    let pMatch;
+
+    while ((pMatch = pPattern.exec(xml)) !== null) {
+      const pAttrs = parseAttributes(pMatch[1]);
+      const pStart = parseXmlTimeMs(pAttrs.t || pAttrs.start, 0, Boolean(pAttrs.start));
+      const pDuration = parseXmlTimeMs(pAttrs.d || pAttrs.dur, 0, Boolean(pAttrs.dur));
+      const pEnd = pDuration > 0 ? pStart + pDuration : pStart;
+      const sMatches = Array.from(pMatch[2].matchAll(/<s\b([^>]*)>([\s\S]*?)<\/s>/gi));
+
+      if (sMatches.length === 0) {
+        const words = wordsForSegment(pMatch[2], pStart, pEnd);
+        if (words.length > 0) paragraphs.push(words);
+        continue;
+      }
+
+      const words = [];
+      for (let i = 0; i < sMatches.length; i++) {
+        const sAttrs = parseAttributes(sMatches[i][1]);
+        const sStart = pStart + parseXmlTimeMs(sAttrs.t, 0, false);
+        const nextStart = i < sMatches.length - 1
+          ? pStart + parseXmlTimeMs(parseAttributes(sMatches[i + 1][1]).t, pEnd - pStart, false)
+          : pEnd;
+        const sDuration = parseXmlTimeMs(sAttrs.d, Math.max(0, nextStart - sStart), false);
+        words.push(...wordsForSegment(sMatches[i][2], sStart, sStart + sDuration));
+      }
+      if (words.length > 0) paragraphs.push(words);
+    }
+
+    return paragraphs;
+  }
+
+  function parseTranscriptText(xml) {
+    const paragraphs = [];
+    const textPattern = /<text\b([^>]*)>([\s\S]*?)<\/text>/gi;
+    let match;
+
+    while ((match = textPattern.exec(xml)) !== null) {
+      const attrs = parseAttributes(match[1]);
+      const startMs = parseXmlTimeMs(attrs.start, 0, true);
+      const durationMs = parseXmlTimeMs(attrs.dur, 0, true);
+      const words = wordsForSegment(match[2], startMs, startMs + durationMs);
+      if (words.length > 0) paragraphs.push(words);
+    }
+
+    return paragraphs;
+  }
+
+  function youtubeTimedTextXmlToHtml(data) {
+    const xml = normalizeLines(data);
+    const paragraphs = parseSrv3Paragraphs(xml);
+    if (paragraphs.length > 0) return paragraphsToHtml(paragraphs);
+    return paragraphsToHtml(parseTranscriptText(xml));
+  }
+
+  function normalizeJsonWords(jsonData) {
+    return ((jsonData && jsonData.words) || [])
+      .filter((word) => word && word.text !== undefined)
+      .map((word) => ({
+        startMs: Math.round(Number(word.start) * 1000),
+        endMs: Math.round(Number(word.end) * 1000),
+        text: String(word.text),
+      }))
+      .filter((word) => Number.isFinite(word.startMs) && Number.isFinite(word.endMs));
+  }
+
+  function groupWordsByParagraph(jsonData) {
+    const words = normalizeJsonWords(jsonData);
+    const paragraphs = (jsonData && jsonData.paragraphs) || [];
+    if (paragraphs.length === 0) return words.length > 0 ? [words] : [];
+
+    return paragraphs.map((paragraph) => {
+      const startMs = Math.round(Number(paragraph.start) * 1000);
+      const endMs = Math.round(Number(paragraph.end) * 1000);
+      return words.filter((word) => word.startMs >= startMs && word.startMs <= endMs);
+    }).filter((group) => group.length > 0);
+  }
+
+  function hyperaudioJsonToYoutubeVtt(jsonData) {
+    const cues = groupWordsByParagraph(jsonData).map((words) => {
+      const start = words[0].startMs;
+      const end = words[words.length - 1].endMs;
+      const text = words
+        .map((word) => `<${formatTimestamp(word.startMs)}>${escapeHtml(word.text)}`)
+        .join(' ');
+      return `${formatTimestamp(start)} --> ${formatTimestamp(end)}\n${text}`;
+    });
+
+    return `WEBVTT\n\n${cues.join('\n\n')}\n`;
+  }
+
+  function hyperaudioJsonToYoutubeTimedTextXml(jsonData) {
+    const paragraphs = groupWordsByParagraph(jsonData).map((words) => {
+      const pStart = words[0].startMs;
+      const pEnd = words[words.length - 1].endMs;
+      const spans = words.map((word) => {
+        const relativeStart = Math.max(0, word.startMs - pStart);
+        const duration = Math.max(0, word.endMs - word.startMs);
+        return `<s t="${relativeStart}" d="${duration}">${escapeHtml(word.text)}</s>`;
+      }).join('');
+      return `<p t="${pStart}" d="${Math.max(0, pEnd - pStart)}">${spans}</p>`;
+    });
+
+    return `<timedtext>\n<body>\n${paragraphs.join('\n')}\n</body>\n</timedtext>\n`;
+  }
+
+  const api = {
+    hyperaudioJsonToYoutubeTimedTextXml,
+    hyperaudioJsonToYoutubeVtt,
+    youtubeTimedTextXmlToHtml,
+    youtubeVttToHtml,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+
+  Object.assign(root, api);
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/test/youtube-caption-converter.test.js
+++ b/test/youtube-caption-converter.test.js
@@ -1,0 +1,82 @@
+const assert = require('assert');
+
+const {
+  hyperaudioJsonToYoutubeTimedTextXml,
+  hyperaudioJsonToYoutubeVtt,
+  youtubeTimedTextXmlToHtml,
+  youtubeVttToHtml,
+} = require('../js/youtube-caption-converter.js');
+
+function spanTuples(html) {
+  return Array.from(html.matchAll(/<span data-m="(\d+)" data-d="(\d+)">([^<]*)<\/span>/g))
+    .map((match) => ({
+      startMs: Number(match[1]),
+      durationMs: Number(match[2]),
+      text: match[3].trim(),
+    }));
+}
+
+{
+  const html = youtubeVttToHtml(`WEBVTT
+
+00:00:00.000 --> 00:00:03.000 align:start position:0%
+<00:00:00.500>Hello <00:00:01.250>world.
+`);
+
+  assert.deepStrictEqual(spanTuples(html), [
+    { startMs: 500, durationMs: 750, text: 'Hello' },
+    { startMs: 1250, durationMs: 1750, text: 'world.' },
+  ]);
+}
+
+{
+  const html = youtubeTimedTextXmlToHtml(`
+<timedtext>
+  <body>
+    <p t="1000" d="2500">
+      <s t="0" d="400">Hello</s>
+      <s t="600" d="500">world</s>
+    </p>
+  </body>
+</timedtext>
+`);
+
+  assert.deepStrictEqual(spanTuples(html), [
+    { startMs: 1000, durationMs: 400, text: 'Hello' },
+    { startMs: 1600, durationMs: 500, text: 'world' },
+  ]);
+}
+
+{
+  const html = youtubeTimedTextXmlToHtml(`
+<transcript>
+  <text start="0.5" dur="1.5">Hello &amp; world</text>
+</transcript>
+`);
+
+  assert.deepStrictEqual(spanTuples(html), [
+    { startMs: 500, durationMs: 500, text: 'Hello' },
+    { startMs: 1000, durationMs: 500, text: '&amp;' },
+    { startMs: 1500, durationMs: 500, text: 'world' },
+  ]);
+}
+
+{
+  const json = {
+    words: [
+      { start: 0.5, end: 1.25, text: 'Hello' },
+      { start: 1.25, end: 3, text: 'world.' },
+    ],
+    paragraphs: [{ start: 0.5, end: 3 }],
+  };
+
+  const vtt = hyperaudioJsonToYoutubeVtt(json);
+  assert.match(vtt, /WEBVTT/);
+  assert.match(vtt, /00:00:00\.500 --> 00:00:03\.000/);
+  assert.match(vtt, /<00:00:00\.500>Hello <00:00:01\.250>world\./);
+
+  const xml = hyperaudioJsonToYoutubeTimedTextXml(json);
+  assert.match(xml, /<timedtext>/);
+  assert.match(xml, /<p t="500" d="2500">/);
+  assert.match(xml, /<s t="0" d="750">Hello<\/s><s t="750" d="1750">world\.<\/s>/);
+}


### PR DESCRIPTION
Add YouTube automatic captions import/export support for issue #160.

The editor now parses word-timestamped YouTube WebVTT and SRV3/TimedText XML into the existing timed transcript spans, preserving per-word timing instead of distributing full cue timings across words.

**YouTube Caption Formats**

Adds a pure converter for inline VTT timestamps and YouTube XML `<p>/<s>` and `<text>` shapes, plus export helpers that write word-timestamped VTT and XML from the current transcript.

**Editor Menu**

Adds File menu entries for YouTube VTT/XML export and YouTube caption import alongside the existing Hyperaudio, SRT, VTT, and Deepgram actions.

Validated locally with the converter unit test, JavaScript syntax checks, diff whitespace check, and a browser smoke check.

Refs #160