### PR TITLE
Modernise local Whisper: transformers.js v4, WebGPU, windowed inference

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,19 +132,19 @@ If you are creating an open source application under a license compatible with t
         <label for="model-name-input" class="form-label label-text">Which model should be used?</label>
         <div>
           <select class="form-select select select-bordered w-full max-w-xs" aria-label="Default select example" id="model-name-input">
-            <option selected="" value="Xenova/whisper-tiny.en">Whisper (Tiny) English</option>
-            <option value="Xenova/whisper-tiny">Whisper (Tiny)</option>
-            <option value="Xenova/whisper-base.en">Whisper (Base) English</option>
-            <option value="Xenova/whisper-base">Whisper (Base)</option>
-            <option value="Xenova/whisper-small.en">Whisper (Small) English</option>
-            <option value="Xenova/whisper-small">Whisper (Small)</option>
-            <option value="distil-whisper/distil-small.en">Whisper Distil (Small) English</option>
+            <option selected="" value="onnx-community/whisper-tiny.en_timestamped">Whisper (Tiny) English – ~40–80 MB</option>
+            <option value="onnx-community/whisper-tiny_timestamped">Whisper (Tiny) – ~40–80 MB</option>
+            <option value="onnx-community/whisper-base.en_timestamped">Whisper (Base) English – ~80–150 MB</option>
+            <option value="onnx-community/whisper-base_timestamped">Whisper (Base) – ~80–150 MB</option>
+            <option value="onnx-community/whisper-small.en_timestamped">Whisper (Small) English – ~250–490 MB</option>
+            <option value="onnx-community/whisper-small_timestamped">Whisper (Small) – ~250–490 MB</option>
+            <option value="onnx-community/whisper-large-v3-turbo_timestamped">Whisper (Large v3 Turbo) – ~560 MB, GPU recommended</option>
           </select>
         </div>
         <div class="form-text" style="font-size: 90%;">
-          <p style="padding-top:16px">The models are listed in order of size. The larger the model, the more accurate it is – and slower to process.</p> 
+          <p style="padding-top:16px">The models are listed in order of size. The larger the model, the more accurate it is – and slower to process.</p>
           <p>The English models are slightly more accurate (for the English language only).</p>
-          <p>* Whisper running in the browser is currently in beta.</p>
+          <p>Each model is downloaded once and cached by the browser. Transcription runs on your GPU (WebGPU) when available, otherwise on the CPU.</p>
         </div>
       </div>
       
@@ -542,7 +542,7 @@ If you are creating an open source application under a license compatible with t
       <h3 class="font-bold text-lg"  style="margin-bottom:16px">Transcribe</h3>
       <div role="tablist" class="tabs tabs-lifted">
 
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:160px" aria-label="Whisper (Local) *" checked />
+        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:160px" aria-label="Whisper (Local)" checked />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
           <client-whisper-service templateSelector="#whisper-client-template"></client-whisper-service>
         </div>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.3 -->
+<!--  Hyperaudio Lite Editor - Version 0.6.6 (last changed in release 0.6.6) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,6 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="version" content="0.6.6">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -25,7 +26,7 @@ If you are creating an open source application under a license compatible with t
   <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
  
   <script src="js/hyperaudio-lite-editor-deepgram.js"></script>
-  <script src="js/hyperaudio-lite-editor-whisper.js"></script>
+  <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.6"></script>
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -132,9 +132,9 @@ If you are creating an open source application under a license compatible with t
         <label for="model-name-input" class="form-label label-text">Which model should be used?</label>
         <div>
           <select class="form-select select select-bordered w-full max-w-xs" aria-label="Default select example" id="model-name-input">
-            <option selected="" value="onnx-community/whisper-tiny.en_timestamped">Whisper (Tiny) English – ~40–80 MB</option>
-            <option value="onnx-community/whisper-tiny_timestamped">Whisper (Tiny) – ~40–80 MB</option>
-            <option value="onnx-community/whisper-base.en_timestamped">Whisper (Base) English – ~80–150 MB</option>
+            <option value="onnx-community/whisper-tiny.en_timestamped">Whisper (Tiny) English – ~40–80 MB, fastest, least accurate</option>
+            <option value="onnx-community/whisper-tiny_timestamped">Whisper (Tiny) – ~40–80 MB, fastest, least accurate</option>
+            <option selected="" value="onnx-community/whisper-base.en_timestamped">Whisper (Base) English – ~80–150 MB</option>
             <option value="onnx-community/whisper-base_timestamped">Whisper (Base) – ~80–150 MB</option>
             <option value="onnx-community/whisper-small.en_timestamped">Whisper (Small) English – ~250–490 MB</option>
             <option value="onnx-community/whisper-small_timestamped">Whisper (Small) – ~250–490 MB</option>
@@ -144,6 +144,7 @@ If you are creating an open source application under a license compatible with t
         <div class="form-text" style="font-size: 90%;">
           <p style="padding-top:16px">The models are listed in order of size. The larger the model, the more accurate it is – and slower to process.</p>
           <p>The English models are slightly more accurate (for the English language only).</p>
+          <p>Tiny is best suited to short, clear recordings – on long or noisy audio small models can garble difficult passages, so prefer Base or larger.</p>
           <p>Each model is downloaded once and cached by the browser. Transcription runs on your GPU (WebGPU) when available, otherwise on the CPU.</p>
         </div>
       </div>

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -107,8 +107,9 @@ function loadWhisperClient(modal, workerBaseUrl) {
 
   function handleError(message) {
     console.error("Whisper error: " + message);
+    const detail = message ? '<br/><span style="font-size:80%; opacity:0.7">'+String(message).slice(0, 200)+'</span>' : '';
     document.getElementById("hypertranscript").innerHTML =
-      '<div class="vertically-centre"><img src="'+errorSvg+'" width="50" alt="error" style="margin: auto; display: block;"><br/><center>Sorry.<br/>Transcription failed.<br/>Try a smaller model or reload the page.</center></div>';
+      '<div class="vertically-centre"><img src="'+errorSvg+'" width="50" alt="error" style="margin: auto; display: block;"><br/><center>Sorry.<br/>Transcription failed.<br/>Try a smaller model or reload the page.'+detail+'</center></div>';
   }
 
   function handleInferenceDone(results) {
@@ -125,7 +126,7 @@ function loadWhisperClient(modal, workerBaseUrl) {
       if (word.text.indexOf("[") < 0  && word.text.indexOf("]") < 0) {
         let start = Math.floor(word.timestamp[0]*1000);
         let end = word.timestamp[1] ?? (word.timestamp[0] + 0.5);
-        let duration = Math.floor((end*1000)-1) - start;
+        let duration = Math.max(0, Math.floor((end*1000)-1) - start);
         let wordCapitalised = false;
 
         if (Array.from(word.text)[0].toUpperCase() === Array.from(word.text)[0]){

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -130,7 +130,7 @@ function loadWhisperClient(modal, workerBaseUrl) {
   function renderLoadingMessage() {
     const msg = document.querySelector("#hypertranscript .transcribing-msg");
     if (msg !== null) {
-      msg.textContent = `${progressMessage} · ${formatElapsed(Date.now() - progressStart)}`;
+      msg.textContent = `${progressMessage} (${formatElapsed(Date.now() - progressStart)})`;
     }
   }
 

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -86,6 +86,7 @@ function loadWhisperClient(modal, workerBaseUrl) {
           console.log(`Whisper running on ${data.device} (${data.dtype})`);
           break;
         case "result":
+          stopProgressClock();
           handleInferenceDone(data);
           break;
         case "error":
@@ -102,14 +103,44 @@ function loadWhisperClient(modal, workerBaseUrl) {
     return worker;
   }
 
-  function updateLoadingMessage(message) {
+  let progressTicker = null;
+  let progressStart = 0;
+  let progressMessage = "";
+
+  // progress messages only arrive when a whole window completes, so a ticking
+  // clock is the liveness signal in between
+  function startProgressClock() {
+    progressStart = Date.now();
+    clearInterval(progressTicker);
+    progressTicker = setInterval(renderLoadingMessage, 1000);
+  }
+
+  function stopProgressClock() {
+    clearInterval(progressTicker);
+    progressTicker = null;
+  }
+
+  function formatElapsed(ms) {
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+  }
+
+  function renderLoadingMessage() {
     const msg = document.querySelector("#hypertranscript .transcribing-msg");
     if (msg !== null) {
-      msg.textContent = message;
+      msg.textContent = `${progressMessage} · ${formatElapsed(Date.now() - progressStart)}`;
     }
   }
 
+  function updateLoadingMessage(message) {
+    progressMessage = message;
+    renderLoadingMessage();
+  }
+
   function handleError(message) {
+    stopProgressClock();
     console.error("Whisper error: " + message);
     const detail = message ? '<br/><span style="font-size:80%; opacity:0.7">'+String(message).slice(0, 200)+'</span>' : '';
     document.getElementById("hypertranscript").innerHTML =
@@ -180,6 +211,8 @@ function loadWhisperClient(modal, workerBaseUrl) {
 
     const loadingMessageContainer = document.getElementById("hypertranscript");
     loadingMessageContainer.innerHTML = '<div class="vertically-centre"><center class="transcribing-msg">Preparing model…</center><br/><img src="'+transcribingSvg+'" width="50" alt="transcribing" style="margin: auto; display: block;"></div>';
+    progressMessage = "Preparing model…";
+    startProgressClock();
 
     let audio;
     try {

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 0.0.6 (caption editor patch) */
+/*! Version 0.1.0 (transformers.js v4 / WebGPU) */
 
 class WhisperService extends HTMLElement {
 
@@ -32,8 +32,8 @@ class WhisperService extends HTMLElement {
           modal.innerHTML = whisperTempl.innerHTML;
           loadWhisperClient(modal, workerBaseUrl);
         })
-        .catch(function(err) {  
-          console.log('Template error: ', err);  
+        .catch(function(err) {
+          console.log('Template error: ', err);
         });
     } else {
       modal.innerHTML = document.querySelector(templateSelector).innerHTML;
@@ -53,12 +53,12 @@ function loadWhisperClient(modal, workerBaseUrl) {
   const formSubmitBtn = document.getElementById("form-submit-btn");
   const modelNameSelectionInput = document.getElementById("model-name-input");
   const videoPlayer = document.getElementById("hyperplayer");
-  
+
 
   if (workerBaseUrl === undefined || workerBaseUrl === null) {
     workerBaseUrl = "./";
   }
-  
+
   const whisperWorkerPath = workerBaseUrl + "js/whisper.worker.js";
 
   let webWorker = createWorker();
@@ -70,12 +70,45 @@ function loadWhisperClient(modal, workerBaseUrl) {
   function createWorker() {
     const worker = new Worker(whisperWorkerPath, { type: "module" });
 
-    let results = [];
     worker.onmessage = (event) => {
-      handleInferenceDone(event.data);
+      const data = event.data;
+      switch (data.type) {
+        case "progress":
+          updateLoadingMessage(data.phase === "download"
+            ? `Downloading model… ${data.progress}%`
+            : `Transcribing… ${data.progress}%`);
+          break;
+        case "device":
+          console.log(`Whisper running on ${data.device} (${data.dtype})`);
+          break;
+        case "result":
+          handleInferenceDone(data);
+          break;
+        case "error":
+          handleError(data.message);
+          break;
+      }
+    };
+
+    worker.onerror = (event) => {
+      console.error(event);
+      handleError(event.message || "The transcription worker crashed.");
     };
 
     return worker;
+  }
+
+  function updateLoadingMessage(message) {
+    const msg = document.querySelector("#hypertranscript .transcribing-msg");
+    if (msg !== null) {
+      msg.textContent = message;
+    }
+  }
+
+  function handleError(message) {
+    console.error("Whisper error: " + message);
+    document.getElementById("hypertranscript").innerHTML =
+      '<div class="vertically-centre"><img src="'+errorSvg+'" width="50" alt="error" style="margin: auto; display: block;"><br/><center>Sorry.<br/>Transcription failed.<br/>Try a smaller model or reload the page.</center></div>';
   }
 
   function handleInferenceDone(results) {
@@ -91,29 +124,30 @@ function loadWhisperClient(modal, workerBaseUrl) {
       // ignore text with square brackets - usually contains things like [BLANK _AUDIO]
       if (word.text.indexOf("[") < 0  && word.text.indexOf("]") < 0) {
         let start = Math.floor(word.timestamp[0]*1000);
-        let duration = Math.floor((word.timestamp[1]*1000)-1) - start;
+        let end = word.timestamp[1] ?? (word.timestamp[0] + 0.5);
+        let duration = Math.floor((end*1000)-1) - start;
         let wordCapitalised = false;
-  
+
         if (Array.from(word.text)[0].toUpperCase() === Array.from(word.text)[0]){
           wordCapitalised = true;
         }
-  
+
         if (wordCapitalised === true && lastWord.endsWith(".") ){
           sentences += 1;
         }
-  
+
         lastWord = word.text;
-        
+
         // new para every 5 sentences
         if (sentences % 5 === 0 && sentences !== 0) {
           hypertranscript += "\n  </p>\n  <p>\n";
           sentences = 0;
         }
-  
+
         hypertranscript += `<span data-m='${start}' data-d='${duration}'>${word.text} </span>\n`;
       }
     });
-    
+
     const resultsContainer = document.getElementById("hypertranscript");
     resultsContainer.innerHTML = "<article>\n <section>\n  <p>\n" + hypertranscript + "  </p>\n </section>\n</article>\n";
 
@@ -132,13 +166,6 @@ function loadWhisperClient(modal, workerBaseUrl) {
 
     const model_name = modelNameSelectionInput.value;
     const file = fileUploadBtn.files[0];
-    const audio = await readAudioFrom(file);
-
-    webWorker.postMessage({
-      type: "INFERENCE_REQUEST",
-      audio,
-      model_name
-    });
 
     videoPlayer.src = URL.createObjectURL(file);
 
@@ -147,19 +174,35 @@ function loadWhisperClient(modal, workerBaseUrl) {
     }
 
     const loadingMessageContainer = document.getElementById("hypertranscript");
+    loadingMessageContainer.innerHTML = '<div class="vertically-centre"><center class="transcribing-msg">Preparing model…</center><br/><img src="'+transcribingSvg+'" width="50" alt="transcribing" style="margin: auto; display: block;"></div>';
 
-    console.log("show spinner");
-    console.log(loadingMessageContainer);
+    let audio;
+    try {
+      audio = await readAudioFrom(file);
+    } catch (e) {
+      console.error(e);
+      handleError("Could not decode the media file.");
+      return;
+    }
 
-    loadingMessageContainer.innerHTML = '<div class="vertically-centre"><center class="transcribing-msg">Transcribing.... </center><br/><img src="'+transcribingSvg+'" width="50" alt="transcribing" style="margin: auto; display: block;"></div>';
+    // transfer the buffer rather than copying it - large files would otherwise
+    // be structured-cloned in full
+    webWorker.postMessage({
+      type: "INFERENCE_REQUEST",
+      audio,
+      model_name
+    }, [audio.buffer]);
   }
 
   async function readAudioFrom(file) {
     const sampling_rate = 16e3;
     const audioCTX = new AudioContext({ sampleRate: sampling_rate });
-    const response = await file.arrayBuffer();
-    const decoded = await audioCTX.decodeAudioData(response);
-    const audio = decoded.getChannelData(0);
-    return audio;
+    try {
+      const response = await file.arrayBuffer();
+      const decoded = await audioCTX.decodeAudioData(response);
+      return decoded.getChannelData(0);
+    } finally {
+      audioCTX.close();
+    }
   }
 }

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -1,5 +1,9 @@
-/*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 0.1.0 (transformers.js v4 / WebGPU) */
+/**
+ * hyperaudio-lite-editor-whisper.js
+ * (C) The Hyperaudio Project
+ * @version 0.6.6 — last changed in release 0.6.6
+ * @license MIT
+ */
 
 class WhisperService extends HTMLElement {
 
@@ -59,7 +63,7 @@ function loadWhisperClient(modal, workerBaseUrl) {
     workerBaseUrl = "./";
   }
 
-  const whisperWorkerPath = workerBaseUrl + "js/whisper.worker.js";
+  const whisperWorkerPath = workerBaseUrl + "js/whisper.worker.js?v=0.6.6";
 
   let webWorker = createWorker();
 

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -157,14 +157,17 @@ function loadWhisperClient(modal, workerBaseUrl) {
 
     results.output.chunks.forEach((word) => {
 
-      // ignore text with square brackets - usually contains things like [BLANK _AUDIO]
-      if (word.text.indexOf("[") < 0  && word.text.indexOf("]") < 0) {
+      // whisper marks word boundaries with a leading space on the text
+      const text = word.text.trim();
+
+      // ignore empty text and text with square brackets - usually contains things like [BLANK _AUDIO]
+      if (text.length > 0 && text.indexOf("[") < 0  && text.indexOf("]") < 0) {
         let start = Math.floor(word.timestamp[0]*1000);
         let end = word.timestamp[1] ?? (word.timestamp[0] + 0.5);
         let duration = Math.max(0, Math.floor((end*1000)-1) - start);
         let wordCapitalised = false;
 
-        if (Array.from(word.text)[0].toUpperCase() === Array.from(word.text)[0]){
+        if (Array.from(text)[0].toUpperCase() === Array.from(text)[0]){
           wordCapitalised = true;
         }
 
@@ -172,7 +175,7 @@ function loadWhisperClient(modal, workerBaseUrl) {
           sentences += 1;
         }
 
-        lastWord = word.text;
+        lastWord = text;
 
         // new para every 5 sentences
         if (sentences % 5 === 0 && sentences !== 0) {
@@ -180,7 +183,7 @@ function loadWhisperClient(modal, workerBaseUrl) {
           sentences = 0;
         }
 
-        hypertranscript += `<span data-m='${start}' data-d='${duration}'>${word.text} </span>\n`;
+        hypertranscript += `<span data-m='${start}' data-d='${duration}'>${text} </span>\n`;
       }
     });
 

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -45,16 +45,20 @@ self.addEventListener("message", async (event) => {
   }
 });
 
-function pickDtype(model_name, device) {
+// Preferred dtype first, then a fallback: the quantized exports of some of the
+// *_timestamped models predate the v4 ONNX runtime and fail session creation
+// ("Missing required scale ... MatMulNBits"), so always keep a variant in the
+// list that loads everywhere – fp32, except for turbo where fp32 is 2.5 GB.
+function pickDtypes(model_name, device) {
   if (model_name.includes("large-v3-turbo")) {
-    return "q4f16";
+    return ["q4f16", "q4"];
   }
   if (device === "webgpu") {
     // fp16 whisper decoders are numerically fragile and prone to repetition
     // loops – use the same per-component dtypes as the official demos.
-    return { encoder_model: "fp32", decoder_model_merged: "q4" };
+    return [{ encoder_model: "fp32", decoder_model_merged: "q4" }, "fp32"];
   }
-  return "q8";
+  return ["q8", "fp32"];
 }
 
 async function getPipeline(model_name, devices) {
@@ -64,32 +68,40 @@ async function getPipeline(model_name, devices) {
 
   let lastError = null;
   for (const device of devices) {
-    const dtype = pickDtype(model_name, device);
-    const dtypeLabel = typeof dtype === "string" ? dtype : JSON.stringify(dtype);
-    const key = `${model_name}|${device}|${dtypeLabel}`;
+    for (const dtype of pickDtypes(model_name, device)) {
+      const dtypeLabel = typeof dtype === "string" ? dtype : JSON.stringify(dtype);
+      const key = `${model_name}|${device}|${dtypeLabel}`;
 
-    if (cache.key === key && cache.pipe !== null) {
-      return cache.pipe;
-    }
-
-    try {
-      const pipe = await pipeline("automatic-speech-recognition", model_name, {
-        device,
-        dtype,
-        progress_callback: makeDownloadProgress(),
-      });
-
-      if (cache.pipe !== null) {
-        await cache.pipe.dispose().catch(() => {});
+      if (cache.key === key && cache.pipe !== null) {
+        return cache.pipe;
       }
-      cache = { key, pipe, device };
 
-      console.log(`Whisper pipeline ready: ${model_name} on ${device} (${dtypeLabel})`);
-      self.postMessage({ type: "device", device, dtype: dtypeLabel });
-      return pipe;
-    } catch (e) {
-      console.warn(`Failed to initialise ${model_name} on ${device}:`, e);
-      lastError = e;
+      // free the previous model's (GPU) memory before loading the next one
+      if (cache.pipe !== null) {
+        try {
+          await cache.pipe.dispose();
+        } catch (e) {
+          console.warn("Failed to dispose previous pipeline:", e);
+        }
+        cache = { key: null, pipe: null, device: null };
+      }
+
+      try {
+        const pipe = await pipeline("automatic-speech-recognition", model_name, {
+          device,
+          dtype,
+          progress_callback: makeDownloadProgress(),
+        });
+
+        cache = { key, pipe, device };
+
+        console.log(`Whisper pipeline ready: ${model_name} on ${device} (${dtypeLabel})`);
+        self.postMessage({ type: "device", device, dtype: dtypeLabel });
+        return pipe;
+      } catch (e) {
+        console.warn(`Failed to initialise ${model_name} on ${device} (${dtypeLabel}):`, e);
+        lastError = e;
+      }
     }
   }
   throw lastError || new Error("No usable inference device");
@@ -144,6 +156,7 @@ async function transcribe(pipe, audio) {
     });
 
     chunks = i === 0 ? windowChunks : stitch(chunks, windowChunks, offsetSeconds);
+    chunks = collapseRepeats(chunks);
 
     self.postMessage({
       type: "progress",
@@ -153,6 +166,29 @@ async function transcribe(pipe, audio) {
   }
 
   return { text: chunks.map((c) => c.text).join(""), chunks };
+}
+
+// When the whisper decoder gets stuck in a repetition loop its word-timestamp
+// prediction collapses too: dozens of words come back with the identical start
+// time. Real speech never starts two words at the same instant, so within each
+// run of same-start chunks keep only the first occurrence of each word.
+function collapseRepeats(chunks) {
+  const out = [];
+  let runStart = null;
+  let seen = null;
+  for (const chunk of chunks) {
+    if (chunk.timestamp[0] !== runStart) {
+      runStart = chunk.timestamp[0];
+      seen = new Set();
+    }
+    const key = chunk.text.trim().toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(chunk);
+  }
+  return out;
 }
 
 // Join two overlapping windows at a word boundary: find the inter-word gap in

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -1,23 +1,184 @@
-import { pipeline } from "https://cdn.jsdelivr.net/npm/@xenova/transformers@2.11.0";
+import { pipeline } from "https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0";
+
+const SAMPLE_RATE = 16000;
+const WINDOW_S = 300;   // transcribe in 5-minute windows to bound memory
+const OVERLAP_S = 10;   // each seam is transcribed by both windows
+
+let cache = { key: null, pipe: null, device: null };
 
 self.addEventListener("message", async (event) => {
   const { type, audio, model_name } = event.data;
 
-  if (type === "INFERENCE_REQUEST") {
-  
-    const automaticSpeechRecognition = await pipeline(
-      "automatic-speech-recognition",
-      model_name,
-      { revision: "output_attentions" }
-    );
-  
-    let output = await automaticSpeechRecognition(audio, {
+  if (type !== "INFERENCE_REQUEST") {
+    return;
+  }
+
+  let pipe;
+  try {
+    pipe = await getPipeline(model_name);
+  } catch (e) {
+    console.error(e);
+    self.postMessage({ type: "error", stage: "load", message: e?.message || String(e) });
+    return;
+  }
+
+  try {
+    const output = await transcribe(pipe, audio);
+    self.postMessage({ type: "result", output });
+  } catch (e) {
+    console.error(e);
+    // WebGPU can pass pipeline init yet fail at inference time on some GPUs –
+    // rebuild on WASM and retry once before giving up.
+    if (cache.device === "webgpu") {
+      try {
+        pipe = await getPipeline(model_name, ["wasm"]);
+        const output = await transcribe(pipe, audio);
+        self.postMessage({ type: "result", output });
+        return;
+      } catch (retryError) {
+        console.error(retryError);
+        self.postMessage({ type: "error", stage: "transcribe", message: retryError?.message || String(retryError) });
+        return;
+      }
+    }
+    self.postMessage({ type: "error", stage: "transcribe", message: e?.message || String(e) });
+  }
+});
+
+function pickDtype(model_name, device) {
+  if (model_name.includes("large-v3-turbo")) {
+    return "q4f16";
+  }
+  if (device === "webgpu") {
+    // fp16 whisper decoders are numerically fragile and prone to repetition
+    // loops – use the same per-component dtypes as the official demos.
+    return { encoder_model: "fp32", decoder_model_merged: "q4" };
+  }
+  return "q8";
+}
+
+async function getPipeline(model_name, devices) {
+  if (devices === undefined) {
+    devices = self.navigator?.gpu ? ["webgpu", "wasm"] : ["wasm"];
+  }
+
+  let lastError = null;
+  for (const device of devices) {
+    const dtype = pickDtype(model_name, device);
+    const dtypeLabel = typeof dtype === "string" ? dtype : JSON.stringify(dtype);
+    const key = `${model_name}|${device}|${dtypeLabel}`;
+
+    if (cache.key === key && cache.pipe !== null) {
+      return cache.pipe;
+    }
+
+    try {
+      const pipe = await pipeline("automatic-speech-recognition", model_name, {
+        device,
+        dtype,
+        progress_callback: makeDownloadProgress(),
+      });
+
+      if (cache.pipe !== null) {
+        await cache.pipe.dispose().catch(() => {});
+      }
+      cache = { key, pipe, device };
+
+      console.log(`Whisper pipeline ready: ${model_name} on ${device} (${dtypeLabel})`);
+      self.postMessage({ type: "device", device, dtype: dtypeLabel });
+      return pipe;
+    } catch (e) {
+      console.warn(`Failed to initialise ${model_name} on ${device}:`, e);
+      lastError = e;
+    }
+  }
+  throw lastError || new Error("No usable inference device");
+}
+
+function makeDownloadProgress() {
+  const files = new Map();
+  let lastPercent = -1;
+
+  return (info) => {
+    if (info.status !== "progress" || !info.total) {
+      return;
+    }
+    files.set(info.file, { loaded: info.loaded, total: info.total });
+
+    let loaded = 0, total = 0;
+    files.forEach((f) => { loaded += f.loaded; total += f.total; });
+
+    const percent = Math.floor((loaded / total) * 100);
+    if (percent !== lastPercent) {
+      lastPercent = percent;
+      self.postMessage({ type: "progress", phase: "download", progress: percent });
+    }
+  };
+}
+
+async function transcribe(pipe, audio) {
+  const windowSamples = WINDOW_S * SAMPLE_RATE;
+  const stepSamples = (WINDOW_S - OVERLAP_S) * SAMPLE_RATE;
+  const windowCount = audio.length <= windowSamples
+    ? 1
+    : Math.ceil((audio.length - windowSamples) / stepSamples) + 1;
+
+  let chunks = [];
+
+  for (let i = 0; i < windowCount; i++) {
+    const offsetSamples = i * stepSamples;
+    const offsetSeconds = offsetSamples / SAMPLE_RATE;
+    const window = audio.subarray(offsetSamples, offsetSamples + windowSamples);
+
+    const output = await pipe(window, {
       return_timestamps: "word",
       chunk_length_s: 30,
       stride_length_s: 5,
     });
-  
-    console.log(output);
-    self.postMessage({ output: output });
+
+    const windowChunks = (output.chunks || []).map((chunk) => {
+      const start = chunk.timestamp[0] + offsetSeconds;
+      // the final word of a window can come back with a null end timestamp
+      const end = (chunk.timestamp[1] ?? chunk.timestamp[0] + 0.5) + offsetSeconds;
+      return { text: chunk.text, timestamp: [start, end] };
+    });
+
+    chunks = i === 0 ? windowChunks : stitch(chunks, windowChunks, offsetSeconds);
+
+    self.postMessage({
+      type: "progress",
+      phase: "transcribe",
+      progress: Math.round(((i + 1) / windowCount) * 100),
+    });
   }
-});
+
+  return { text: chunks.map((c) => c.text).join(""), chunks };
+}
+
+// Join two overlapping windows at a word boundary: find the inter-word gap in
+// the previous window's output closest to the overlap midpoint and cut there,
+// so the seam always falls in silence between words, never mid-word.
+function stitch(prevChunks, nextChunks, overlapStart) {
+  const overlapEnd = overlapStart + OVERLAP_S;
+  const midpoint = overlapStart + OVERLAP_S / 2;
+
+  let cut = midpoint;
+  let bestDistance = Infinity;
+  for (let i = 1; i < prevChunks.length; i++) {
+    const gapStart = prevChunks[i - 1].timestamp[1];
+    const gapEnd = prevChunks[i].timestamp[0];
+    if (gapEnd < overlapStart || gapStart > overlapEnd) {
+      continue;
+    }
+    const gapMiddle = (gapStart + gapEnd) / 2;
+    const distance = Math.abs(gapMiddle - midpoint);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      cut = gapMiddle;
+    }
+  }
+
+  return prevChunks
+    .filter((c) => c.timestamp[1] <= cut)
+    .concat(nextChunks.filter((c) => c.timestamp[0] > cut));
+}

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -1,3 +1,10 @@
+/**
+ * whisper.worker.js
+ * (C) The Hyperaudio Project
+ * @version 0.6.6 — last changed in release 0.6.6
+ * @license MIT
+ */
+
 import { pipeline } from "https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0";
 
 const SAMPLE_RATE = 16000;

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -172,7 +172,27 @@ async function transcribe(pipe, audio) {
     });
   }
 
+  chunks = mergeWordFragments(chunks);
+
   return { text: chunks.map((c) => c.text).join(""), chunks };
+}
+
+// Whisper marks the start of a word with a leading space on the chunk text; a
+// chunk without one ("-to", "-text" in "speech-to-text") is a fragment of the
+// word before it. Merge fragments into their parent so hyphenated words render
+// as one timed span instead of "speech -to -text".
+function mergeWordFragments(chunks) {
+  const out = [];
+  for (const chunk of chunks) {
+    const prev = out[out.length - 1];
+    if (prev !== undefined && !chunk.text.startsWith(" ")) {
+      prev.text += chunk.text;
+      prev.timestamp = [prev.timestamp[0], chunk.timestamp[1]];
+    } else {
+      out.push({ text: chunk.text, timestamp: [...chunk.timestamp] });
+    }
+  }
+  return out;
 }
 
 // transformers.js merges its internal 30s chunks by matching tokens across the

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -155,12 +155,12 @@ async function transcribe(pipe, audio) {
       stride_length_s: 5,
     });
 
-    const windowChunks = (output.chunks || []).map((chunk) => {
+    const windowChunks = dropRewindDuplicates((output.chunks || []).map((chunk) => {
       const start = chunk.timestamp[0] + offsetSeconds;
       // the final word of a window can come back with a null end timestamp
       const end = (chunk.timestamp[1] ?? chunk.timestamp[0] + 0.5) + offsetSeconds;
       return { text: chunk.text, timestamp: [start, end] };
-    });
+    }));
 
     chunks = i === 0 ? windowChunks : stitch(chunks, windowChunks, offsetSeconds);
     chunks = collapseRepeats(chunks);
@@ -173,6 +173,26 @@ async function transcribe(pipe, audio) {
   }
 
   return { text: chunks.map((c) => c.text).join(""), chunks };
+}
+
+// transformers.js merges its internal 30s chunks by matching tokens across the
+// seam; when the two decodes of the overlap disagree the merge can fail and a
+// stretch of words is emitted twice. The re-emit starts with word timestamps
+// rewinding – something real speech never does – so on a rewind of more than a
+// second, drop back to where the re-decode begins and let the later decode
+// (which carries on into the following audio) win.
+function dropRewindDuplicates(chunks) {
+  const out = [];
+  for (const chunk of chunks) {
+    const start = chunk.timestamp[0];
+    if (out.length > 0 && start < out[out.length - 1].timestamp[0] - 1.0) {
+      while (out.length > 0 && out[out.length - 1].timestamp[0] >= start - 0.2) {
+        out.pop();
+      }
+    }
+    out.push(chunk);
+  }
+  return out;
 }
 
 // When the whisper decoder gets stuck in a repetition loop its word-timestamp


### PR DESCRIPTION
Closes #308

## What this does

Replaces the local Whisper stack (`@xenova/transformers` 2.11.0, WASM/CPU only) with **transformers.js 4.2.0**, adding WebGPU inference, the `onnx-community/*_timestamped` model exports, model-download/transcription progress, windowed inference for long files, proper error handling, and a set of output-quality fixes found during testing.

### Worker (`js/whisper.worker.js`, rewritten)

- **WebGPU first, WASM fallback** — including a rebuild-and-retry on WASM if a GPU passes init but fails during inference. The chosen device/dtype is logged to the console.
- **Per-device dtypes matching the official demos**: fp32 encoder + q4 decoder on WebGPU (fp16 decoders are numerically fragile — caused repetition-loop hallucinations in testing), q8 on WASM, q4f16 for Large v3 Turbo.
- **Dtype fallback**: some `*_timestamped` quantized exports predate the v4 ONNX runtime and fail session creation (e.g. base.en's q8 decoder: "Missing required scale … MatMulNBits"); each device tries its preferred dtype then a variant that loads everywhere (fp32, or q4 for turbo).
- **Windowed inference**: 5-minute windows with 10 s overlap, stitched at the inter-word gap nearest the overlap midpoint so seams land in silence, never mid-word. Bounds memory on hour-plus files.
- **Pipeline cached per model** and disposed *before* the next model loads (switching previously left both resident).

### Output-quality fixes (worker)

All three exploit the same invariant — real speech only moves forward in time:

- **Repetition-loop containment**: when Whisper's decoder loops, its word timestamps collapse to a single value; within each run of same-start words only the first occurrence of each word is kept, so hallucination loops can't flood the transcript.
- **Rewind dedupe**: transformers.js merges its internal 30 s chunks by token matching; when the two decodes of an overlap disagree (e.g. "audiovisual." vs "audio visual media.") the merge fails and re-emits a stretch of words. The re-emit starts with timestamps rewinding — truncate back to the rewind point and let the later decode (the one not truncated by a chunk edge) win.
- **Word-fragment merge**: whisper marks word starts with a leading space; fragments without one are parts of the previous word, so "speech-to-text" now renders as one timed span instead of "speech -to -text".

### Client (`js/hyperaudio-lite-editor-whisper.js`)

- Loader live-updates with phase, percentage and elapsed time: "Preparing model… (4s)" → "Downloading model… 63% (12s)" → "Transcribing… 40% (1m 23s)". Progress only arrives per completed window, so the ticking clock is the liveness signal in between.
- The decoded audio buffer is **transferred** to the worker instead of structured-cloned, and the decode `AudioContext` is closed after use (it leaked one per run) — together with windowing this addresses the browser lock-up on large files.
- Worker errors and crashes render an error screen with the underlying message instead of an eternal spinner.
- Whisper's leading word-boundary space is trimmed when rendering, so spans carry a single trailing space — this also makes the sentence/paragraph capitalisation check examine the first letter rather than the space (which always passed), giving better-placed paragraph breaks.
- Null final-word timestamps no longer produce `NaN`/negative `data-d`.

### Model menu (`index.html`)

- Switched to the `_timestamped` exports with download sizes in the labels; added Large v3 Turbo (~560 MB, GPU recommended); dropped distil-small (no timestamped export).
- **Default is now Base English** — with WebGPU it's faster than Tiny was on CPU, and Tiny's failure mode on long/noisy audio is fabrication rather than graceful degradation. Tiny remains, labelled "fastest, least accurate", with help copy steering long-form audio to Base+.

### Versioning (0.6.6)

Per the project convention: `@version 0.6.6 — last changed in release 0.6.6` JSDoc headers on both JS files, index.html version comment + `<meta name="version">` bumped, and `?v=0.6.6` cache-busting on the whisper script tag and worker path.

## Tested

- WebGPU path verified on Tiny and Base, including the dtype fallback (exercised by base.en's broken q8 export) and mid-session model switching.
- Hour-long file transcribed; a Tiny repetition loop was contained by the collapse logic and resolved by Base.
- Rewind dedupe and fragment merge verified against the real-world failures that motivated them (~57 s clip, base model, wav and mp3).
- Not formally exercised: a forced-WASM run (`--disable-features=WebGPU`) and seam spot-checks at the 5-minute boundaries.

## Follow-ups filed

- #310 — pre-existing `sanitise()` crash surfaced by error screens
- #311 — WASM/CPU speed-ups (cross-origin isolation, parallel windows)
- #312 — transcript editable during transcription
- #314 — license header alignment (the two whisper files ship MIT-headed per current convention; the sweep converts them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
