### PR TITLE
Update default example transcript and media to the new intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -509,8 +509,7 @@ If you are creating an open source application under a license compatible with t
               <span data-m="48840" data-d="339">associate </span>
               <span data-m="49180" data-d="139">with </span>
               <span data-m="49320" data-d="239">your </span>
-              <span data-m="49560" data-d="279">audio </span>
-              <span data-m="49840" data-d="339">visual </span>
+              <span data-m="49560" data-d="619">audiovisual </span>
               <span data-m="50180" data-d="519">media. </span>
             </p>
             <p>

--- a/index.html
+++ b/index.html
@@ -389,7 +389,7 @@ If you are creating an open source application under a license compatible with t
               <span data-m="11400" data-d="539">engines. </span>
               <span data-m="12300" data-d="139">There's </span>
               <span data-m="12440" data-d="159">a </span>
-              <span data-m="12600" data-d="319">whisper </span>
+              <span data-m="12600" data-d="319">Whisper </span>
               <span data-m="12920" data-d="339">model </span>
               <span data-m="13260" data-d="219">built</span><span data-m="13480" data-d="359">-in. </span>
               <span data-m="14140" data-d="139">Or </span>
@@ -440,7 +440,7 @@ If you are creating an open source application under a license compatible with t
               <span data-m="27300" data-d="119">look </span>
               <span data-m="27420" data-d="239">after </span>
               <span data-m="27660" data-d="179">the </span>
-              <span data-m="27840" data-d="1059">timings </span>
+              <span data-m="27840" data-d="1059">timings. </span>
             </p>
             <p>
               <span data-m="29000" data-d="99">You </span>

--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@ If you are creating an open source application under a license compatible with t
         <div class="top-bar-item">
           <!-- example src -->
           <div>
-            <video id="hyperplayer" class="hyperaudio-player" src="https://lab.hyperaud.io/video/HALiteIntro.mp4" type="video/mp4" controls poster="images/poster.png" style="width:400px; margin-left: -8px;">
+            <video id="hyperplayer" class="hyperaudio-player" src="https://lab.hyperaud.io/audio/HLE_Intro.mp3" type="audio/mpeg" controls poster="images/poster.png" style="width:400px; margin-left: -8px;">
               <track id="hyperplayer-vtt" label="preview" kind="subtitles" src="">
             </video>
           </div>
@@ -353,174 +353,186 @@ If you are creating an open source application under a license compatible with t
         <article>
           <section>
             <p>
-              <span data-m="560" data-d="0" class="speaker">[Angela] </span>
-              <span data-m="560" data-d="240">The </span>
-              <span data-m="800" data-d="640">Hyperaudio </span>
-              <span data-m="1440" data-d="240">Lite </span>
-              <span data-m="1680" data-d="400">Editor </span>
-              <span data-m="2080" data-d="320">makes </span>
-              <span data-m="2400" data-d="400">audio </span>
-              <span data-m="2800" data-d="240">and </span>
-              <span data-m="3040" data-d="400">video </span>
-              <span data-m="3440" data-d="240">more </span>
-              <span data-m="3680" data-d="480">accessible </span>
-              <span data-m="4160" data-d="240">through </span>
-              <span data-m="4400" data-d="160">the </span>
-              <span data-m="4560" data-d="480">creation </span>
-              <span data-m="5040" data-d="240">of </span>
-              <span data-m="5280" data-d="400">captions </span>
-              <span data-m="5680" data-d="240">and </span>
-              <span data-m="5920" data-d="500">interactive </span>
-              <span data-m="6640" data-d="500">transcripts. </span>
+              <span class="speaker" data-d="0" data-m="160">[Monika] </span>
+              <span data-m="160" data-d="299">The </span>
+              <span data-m="460" data-d="500">Hyperaudio </span>
+              <span data-m="940" data-d="279">Lite </span>
+              <span data-m="1220" data-d="619">Editor </span>
+              <span data-m="1840" data-d="359">makes </span>
+              <span data-m="2200" data-d="139">audio </span>
+              <span data-m="2340" data-d="139">and </span>
+              <span data-m="2480" data-d="259">video </span>
+              <span data-m="2740" data-d="359">more </span>
+              <span data-m="3100" data-d="399">accessible </span>
+              <span data-m="3500" data-d="319">by </span>
+              <span data-m="3820" data-d="319">creating </span>
+              <span data-m="4140" data-d="639">captions </span>
+              <span data-m="4780" data-d="439">and </span>
+              <span data-m="5220" data-d="599">interactive </span>
+              <span data-m="5820" data-d="439">transcripts. </span>
             </p>
             <p>
-              <span data-m="8240" data-d="240">The </span>
-              <span data-m="8480" data-d="320">first </span>
-              <span data-m="8800" data-d="320">step </span>
-              <span data-m="9130" data-d="160">is </span>
-              <span data-m="9290" data-d="80">to </span>
-              <span data-m="9370" data-d="500">transcribe </span>
-              <span data-m="10010" data-d="240">your </span>
-              <span data-m="10240" data-d="500">content. </span>
+              <span data-m="6760" data-d="179">The </span>
+              <span data-m="6940" data-d="239">first </span>
+              <span data-m="7180" data-d="179">step </span>
+              <span data-m="7360" data-d="139">is </span>
+              <span data-m="7500" data-d="319">to </span>
+              <span data-m="7820" data-d="379">transcribe </span>
+              <span data-m="8200" data-d="339">your </span>
+              <span data-m="8540" data-d="639">content. </span>
             </p>
             <p>
-              <span data-m="11530" data-d="240">We </span>
-              <span data-m="11760" data-d="240">use </span>
-              <span data-m="12000" data-d="160">the </span>
-              <span data-m="12160" data-d="500">Deepgram </span>
-              <span data-m="12720" data-d="320">API </span>
-              <span data-m="13040" data-d="240">which </span>
-              <span data-m="13290" data-d="500">produces </span>
-              <span data-m="13920" data-d="240">high </span>
-              <span data-m="14160" data-d="400">quality </span>
-              <span data-m="14560" data-d="500">transcripts </span>
-              <span data-m="15290" data-d="240">in </span>
-              <span data-m="15530" data-d="320">double-</span>
-              <span data-m="15840" data-d="400">quick </span>
-              <span data-m="16240" data-d="460">time. </span>
-              <span data-m="17180" data-d="500">Deepgram </span>
-              <span data-m="17740" data-d="160">are </span>
-              <span data-m="17900" data-d="480">offering </span>
-              <span data-m="18380" data-d="500">45,000 </span>
-              <span data-m="19420" data-d="320">minutes </span>
-              <span data-m="19740" data-d="240">of </span>
-              <span data-m="19980" data-d="500">transcription </span>
-              <span data-m="20700" data-d="240">for </span>
-              <span data-m="20940" data-d="500">free. </span>
-              </p>
-              <p>
-              <span data-m="22060" data-d="160">You </span>
-              <span data-m="22220" data-d="240">can </span>
-              <span data-m="22460" data-d="240">use </span>
-              <span data-m="22700" data-d="160">the </span>
-              <span data-m="22860" data-d="500">Deepgram </span>
-              <span data-m="23420" data-d="320">token </span>
-              <span data-m="23740" data-d="240">with </span>
-              <span data-m="23980" data-d="240">this </span>
-              <span data-m="24220" data-d="500">application. </span>
+              <span data-m="9820" data-d="239">Choose </span>
+              <span data-m="10060" data-d="239">from </span>
+              <span data-m="10300" data-d="359">several </span>
+              <span data-m="10660" data-d="199">speech</span><span data-m="10860" data-d="99">-to</span><span data-m="10960" data-d="439">-text </span>
+              <span data-m="11400" data-d="539">engines. </span>
+              <span data-m="12300" data-d="139">There's </span>
+              <span data-m="12440" data-d="159">a </span>
+              <span data-m="12600" data-d="319">whisper </span>
+              <span data-m="12920" data-d="339">model </span>
+              <span data-m="13260" data-d="219">built</span><span data-m="13480" data-d="359">-in. </span>
+              <span data-m="14140" data-d="139">Or </span>
+              <span data-m="14280" data-d="279">for </span>
+              <span data-m="14560" data-d="479">faster </span>
+              <span data-m="15040" data-d="599">processing </span>
+              <span data-m="15640" data-d="259">and </span>
+              <span data-m="15900" data-d="459">longer </span>
+              <span data-m="16360" data-d="399">content, </span>
+              <span data-m="16960" data-d="139">you </span>
+              <span data-m="17100" data-d="279">can </span>
+              <span data-m="17380" data-d="159">connect </span>
+              <span data-m="17550" data-d="100">to </span>
+              <span data-m="17720" data-d="400">Deepgram </span>
+              <span data-m="18120" data-d="119">in </span>
+              <span data-m="18240" data-d="139">the </span>
+              <span data-m="18380" data-d="439">cloud. </span>
             </p>
             <p>
-              <span data-d="0" data-m="25770" class="speaker">[Angela] </span>
-              <span data-m="25770" data-d="240"> Once </span>
-              <span data-m="26020" data-d="500">transcribed, </span>
-              <span data-m="26890" data-d="240">you </span>
-              <span data-m="27140" data-d="160">can </span>
-              <span data-m="27300" data-d="400">correct </span>
-              <span data-m="27700" data-d="160">the </span>
-              <span data-m="27860" data-d="500">transcript </span>
-              <span data-m="28410" data-d="160">and </span>
-              <span data-m="28570" data-d="240">add </span>
-              <span data-m="28820" data-d="240">speaker </span>
-              <span data-m="29050" data-d="320">names </span>
-              <span data-m="29380" data-d="400">between </span>
-              <span data-m="29770" data-d="480">square </span>
-              <span data-m="30260" data-d="500">brackets. </span>
+              <span data-m="19300" data-d="259">Once </span>
+              <span data-m="19560" data-d="479">transcribed, </span>
+              <span data-m="20100" data-d="139">you </span>
+              <span data-m="20240" data-d="279">can </span>
+              <span data-m="20520" data-d="219">correct </span>
+              <span data-m="20740" data-d="299">the </span>
+              <span data-m="21040" data-d="339">transcript </span>
+              <span data-m="21380" data-d="179">and </span>
+              <span data-m="21560" data-d="279">add </span>
+              <span data-m="21840" data-d="299">speaker </span>
+              <span data-m="22140" data-d="399">names </span>
+              <span data-m="22540" data-d="379">between </span>
+              <span data-m="22920" data-d="199">square </span>
+              <span data-m="23120" data-d="699">brackets. </span>
             </p>
             <p>
-              <span data-m="31610" data-d="240">Just </span>
-              <span data-m="31860" data-d="320">edit </span>
-              <span data-m="32170" data-d="240">the </span>
-              <span data-m="32410" data-d="480">transcript </span>
-              <span data-m="32900" data-d="160">like </span>
-              <span data-m="33050" data-d="160">you </span>
-              <span data-m="33220" data-d="160">would </span>
-              <span data-m="33380" data-d="160">any </span>
-              <span data-m="33530" data-d="320">other </span>
-              <span data-m="33850" data-d="240">text </span>
-              <span data-m="34250" data-d="240">and </span>
-              <span data-m="34490" data-d="240">we'll </span>
-              <span data-m="34730" data-d="240">look </span>
-              <span data-m="34970" data-d="320">after </span>
-              <span data-m="35290" data-d="240">the </span>
-              <span data-m="35530" data-d="500">timings. </span>
+              <span data-m="24640" data-d="299">Just </span>
+              <span data-m="24940" data-d="239">edit </span>
+              <span data-m="25180" data-d="279">the </span>
+              <span data-m="25460" data-d="339">transcript </span>
+              <span data-m="25800" data-d="159">like </span>
+              <span data-m="25960" data-d="119">you </span>
+              <span data-m="26080" data-d="159">would </span>
+              <span data-m="26240" data-d="199">any </span>
+              <span data-m="26440" data-d="279">other </span>
+              <span data-m="26720" data-d="239">text </span>
+              <span data-m="27020" data-d="99">and </span>
+              <span data-m="27120" data-d="179">we'll </span>
+              <span data-m="27300" data-d="119">look </span>
+              <span data-m="27420" data-d="239">after </span>
+              <span data-m="27660" data-d="179">the </span>
+              <span data-m="27840" data-d="1059">timings </span>
             </p>
             <p>
-              <span data-m="36890" data-d="240">When </span>
-              <span data-m="37130" data-d="320">happy </span>
-              <span data-m="37450" data-d="240">with </span>
-              <span data-m="37690" data-d="240">your </span>
-              <span data-m="37930" data-d="480">transcript, </span>
-              <span data-m="38410" data-d="160">you </span>
-              <span data-m="38570" data-d="160">can </span>
-              <span data-m="38730" data-d="400">convert </span>
-              <span data-m="39130" data-d="160">it </span>
-              <span data-m="39290" data-d="160">to </span>
-              <span data-m="39450" data-d="480">captions </span>
-              <span data-m="39930" data-d="160">and </span>
-              <span data-m="40090" data-d="400">tweak </span>
-              <span data-m="40490" data-d="240">those </span>
-              <span data-m="40730" data-d="400">captions </span>
-              <span data-m="41130" data-d="320">within </span>
-              <span data-m="41450" data-d="160">the </span>
-              <span data-m="41610" data-d="500">editor. </span>
+              <span data-m="29000" data-d="99">You </span>
+              <span data-m="29100" data-d="179">can </span>
+              <span data-m="29280" data-d="239">also </span>
+              <span data-m="29520" data-d="199">tidy </span>
+              <span data-m="29720" data-d="139">up </span>
+              <span data-m="29860" data-d="379">your </span>
+              <span data-m="30240" data-d="499">content, </span>
+              <span data-m="31100" data-d="239">strike </span>
+              <span data-m="31340" data-d="219">out </span>
+              <span data-m="31560" data-d="399">filler </span>
+              <span data-m="31960" data-d="239">words </span>
+              <span data-m="32200" data-d="238">or </span>
+              <span data-m="32439" data-d="300">any </span>
+              <span data-m="32740" data-d="439">unwanted </span>
+              <span data-m="33180" data-d="219">text </span>
+              <span data-m="33480" data-d="199">and </span>
+              <span data-m="33680" data-d="379">remove </span>
+              <span data-m="34060" data-d="339">gaps </span>
+              <span data-m="34400" data-d="179">and </span>
+              <span data-m="34580" data-d="779">silences, </span>
+              <span data-m="35800" data-d="159">all </span>
+              <span data-m="35960" data-d="179">while </span>
+              <span data-m="36140" data-d="199">the </span>
+              <span data-m="36340" data-d="459">timings </span>
+              <span data-m="36800" data-d="499">stay </span>
+              <span data-m="37300" data-d="339">perfectly </span>
+              <span data-m="37640" data-d="279">in </span>
+              <span data-m="37920" data-d="359">sync </span>
+              <span data-m="38280" data-d="179">with </span>
+              <span data-m="38460" data-d="239">your </span>
+              <span data-m="38700" data-d="379">media. </span>
             </p>
             <p>
-              <span data-m="43090" data-d="500">Finally, </span>
-              <span data-m="43730" data-d="240">you </span>
-              <span data-m="43960" data-d="240">should </span>
-              <span data-m="44200" data-d="160">be </span>
-              <span data-m="44360" data-d="240">ready </span>
-              <span data-m="44600" data-d="160">to </span>
-              <span data-m="44770" data-d="400">export </span>
-              <span data-m="45160" data-d="240">your </span>
-              <span data-m="45410" data-d="480">transcript </span>
-              <span data-m="45880" data-d="160">in </span>
-              <span data-m="46050" data-d="160">a </span>
-              <span data-m="46200" data-d="320">number </span>
-              <span data-m="46520" data-d="80">of </span>
-              <span data-m="46600" data-d="480">formats </span>
-              <span data-m="47090" data-d="160">that </span>
-              <span data-m="47240" data-d="80">you </span>
-              <span data-m="47320" data-d="240">can </span>
-              <span data-m="47560" data-d="500">associate </span>
-              <span data-m="48120" data-d="160">with </span>
-              <span data-m="48280" data-d="240">your </span>
-              <span data-m="48520" data-d="320">audio</span>
-              <span data-m="48840" data-d="400">visual </span>
-              <span data-m="49240" data-d="500">media. </span>
+              <span data-m="40060" data-d="139">When </span>
+              <span data-m="40200" data-d="239">you're </span>
+              <span data-m="40440" data-d="199">happy </span>
+              <span data-m="40640" data-d="99">with </span>
+              <span data-m="40740" data-d="319">your </span>
+              <span data-m="41060" data-d="239">transcript, </span>
+              <span data-m="41740" data-d="79">convert </span>
+              <span data-m="41820" data-d="139">it </span>
+              <span data-m="41960" data-d="179">to </span>
+              <span data-m="42140" data-d="479">captions </span>
+              <span data-m="42620" data-d="239">and </span>
+              <span data-m="42860" data-d="239">tweak </span>
+              <span data-m="43100" data-d="199">them </span>
+              <span data-m="43300" data-d="259">right </span>
+              <span data-m="43560" data-d="139">there </span>
+              <span data-m="43700" data-d="119">in </span>
+              <span data-m="43820" data-d="219">the </span>
+              <span data-m="44040" data-d="839">editor. </span>
             </p>
             <p>
-              <span data-m="50540" data-d="400">Use </span>
-              <span data-m="50940" data-d="400">formats </span>
-              <span data-m="51340" data-d="160">like </span>
-              <span data-m="51500" data-d="500">interactive </span>
-              <span data-m="52140" data-d="500">transcripts </span>
-              <span data-m="52780" data-d="160">with </span>
-              <span data-m="52940" data-d="240">the </span>
-              <span data-m="53180" data-d="560">Hyperaudio </span>
-              <span data-m="53740" data-d="320">Lite </span>
-              <span data-m="54060" data-d="400">Library </span>
-              <span data-m="54460" data-d="240">or </span>
-              <span data-m="54700" data-d="480">WordPress </span>
-              <span data-m="55180" data-d="480">module </span>
-              <span data-m="55660" data-d="160">to </span>
-              <span data-m="55820" data-d="480">integrate </span>
-              <span data-m="56300" data-d="320">into </span>
-              <span data-m="56620" data-d="240">your </span>
-              <span data-m="56860" data-d="500">website. </span>
-            </p> 
+              <span data-m="45240" data-d="99">Finally, </span>
+              <span data-m="45700" data-d="319">export </span>
+              <span data-m="46020" data-d="359">your </span>
+              <span data-m="46380" data-d="359">transcript </span>
+              <span data-m="46740" data-d="59">in </span>
+              <span data-m="46800" data-d="239">a </span>
+              <span data-m="47040" data-d="159">number </span>
+              <span data-m="47200" data-d="419">of </span>
+              <span data-m="47620" data-d="799">formats </span>
+              <span data-m="48420" data-d="419">to </span>
+              <span data-m="48840" data-d="339">associate </span>
+              <span data-m="49180" data-d="139">with </span>
+              <span data-m="49320" data-d="239">your </span>
+              <span data-m="49560" data-d="279">audio </span>
+              <span data-m="49840" data-d="339">visual </span>
+              <span data-m="50180" data-d="519">media. </span>
+            </p>
+            <p>
+              <span data-m="51160" data-d="159">Use </span>
+              <span data-m="51320" data-d="239">the </span>
+              <span data-m="51560" data-d="600">Hyperaudio </span>
+              <span data-m="52160" data-d="439">Lite </span>
+              <span data-m="52600" data-d="339">Library </span>
+              <span data-m="52940" data-d="259">or </span>
+              <span data-m="53200" data-d="479">WordPress </span>
+              <span data-m="53680" data-d="839">plugin </span>
+              <span data-m="54520" data-d="299">to </span>
+              <span data-m="54820" data-d="779">embed </span>
+              <span data-m="55600" data-d="419">interactive </span>
+              <span data-m="56020" data-d="539">transcripts </span>
+              <span data-m="56560" data-d="359">directly </span>
+              <span data-m="56920" data-d="159">into </span>
+              <span data-m="57080" data-d="239">your </span>
+              <span data-m="57320" data-d="579">website. </span>
+            </p>
           </section>
-        </article>        
+        </article>
       </div>
     </div>
     <div id="captionsource-alert" class="alert alert-info shadow-lg" style="visibility:hidden; z-index:2; position:absolute; top:50%; left:50%; width:480px; height:140px; margin: -240px 0 0 -240px;">


### PR DESCRIPTION
Closes #315

- Default player now points at the new intro recording, `https://lab.hyperaud.io/audio/HLE_Intro.mp3` (`type` updated to `audio/mpeg`; the `<video>` element plays audio fine and keeps showing the poster).
- Embedded example transcript replaced with the new narration (multi-engine story), generated by the modernised local Whisper from #313 — speaker label `[Monika]`, word-level timings throughout.
- Hyphenated-word fragment spans (`speech`/`-to`/`-text`, `built`/`-in.`) are placed adjacent on one line with no whitespace between, so they render as single words — a newline between inline elements renders as a space.

Worth a quick click-around on the live page before merging: words early/middle/late should jump to the right audio moments, and caption generation should line up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)