### PR TITLE
Local Whisper 0.6.7: honest progress, device/dtype fixes, language selection, repetition guards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.6 (last changed in release 0.6.6) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.7 (last changed in release 0.6.7) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.6">
+  <meta name="version" content="0.6.7">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -26,7 +26,7 @@ If you are creating an open source application under a license compatible with t
   <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
  
   <script src="js/hyperaudio-lite-editor-deepgram.js"></script>
-  <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.6"></script>
+  <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.7"></script>
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -132,21 +132,50 @@ If you are creating an open source application under a license compatible with t
       <div class="mb-3">
         <label for="model-name-input" class="form-label label-text">Which model should be used?</label>
         <div>
-          <select class="form-select select select-bordered w-full max-w-xs" aria-label="Default select example" id="model-name-input">
-            <option value="onnx-community/whisper-tiny.en_timestamped">Whisper (Tiny) English – ~40–80 MB, fastest, least accurate</option>
-            <option value="onnx-community/whisper-tiny_timestamped">Whisper (Tiny) – ~40–80 MB, fastest, least accurate</option>
-            <option selected="" value="onnx-community/whisper-base.en_timestamped">Whisper (Base) English – ~80–150 MB</option>
-            <option value="onnx-community/whisper-base_timestamped">Whisper (Base) – ~80–150 MB</option>
-            <option value="onnx-community/whisper-small.en_timestamped">Whisper (Small) English – ~250–490 MB</option>
-            <option value="onnx-community/whisper-small_timestamped">Whisper (Small) – ~250–490 MB</option>
-            <option value="onnx-community/whisper-large-v3-turbo_timestamped">Whisper (Large v3 Turbo) – ~560 MB, GPU recommended</option>
+          <select class="form-select select select-bordered w-full max-w-xs" aria-label="Whisper model" id="model-name-input">
+            <option value="tiny">Whisper (Tiny) – ~40–80 MB, fastest, least accurate</option>
+            <option selected="" value="base">Whisper (Base) – ~80–150 MB</option>
+            <option value="small">Whisper (Small) – ~250–490 MB</option>
+            <option value="turbo">Whisper (Large v3 Turbo) – ~560 MB, GPU recommended</option>
+          </select>
+        </div>
+        <label for="whisper-language" class="form-label label-text" style="display:block; padding-top:12px">Language</label>
+        <div>
+          <select class="form-select select select-bordered w-full max-w-xs" id="whisper-language">
+            <option selected="" value="en">English</option>
+            <option value="">Auto-detect</option>
+            <option value="es">Spanish</option>
+            <option value="fr">French</option>
+            <option value="de">German</option>
+            <option value="it">Italian</option>
+            <option value="pt">Portuguese</option>
+            <option value="nl">Dutch</option>
+            <option value="sv">Swedish</option>
+            <option value="no">Norwegian</option>
+            <option value="da">Danish</option>
+            <option value="fi">Finnish</option>
+            <option value="pl">Polish</option>
+            <option value="cs">Czech</option>
+            <option value="el">Greek</option>
+            <option value="ro">Romanian</option>
+            <option value="hu">Hungarian</option>
+            <option value="ru">Russian</option>
+            <option value="uk">Ukrainian</option>
+            <option value="tr">Turkish</option>
+            <option value="ar">Arabic</option>
+            <option value="he">Hebrew</option>
+            <option value="hi">Hindi</option>
+            <option value="id">Indonesian</option>
+            <option value="vi">Vietnamese</option>
+            <option value="th">Thai</option>
+            <option value="ja">Japanese</option>
+            <option value="ko">Korean</option>
+            <option value="zh">Chinese</option>
           </select>
         </div>
         <div class="form-text" style="font-size: 90%;">
-          <p style="padding-top:16px">The models are listed in order of size. The larger the model, the more accurate it is – and slower to process.</p>
-          <p>The English models are slightly more accurate (for the English language only).</p>
-          <p>Tiny is best suited to short, clear recordings – on long or noisy audio small models can garble difficult passages, so prefer Base or larger.</p>
-          <p>Each model is downloaded once and cached by the browser. Transcription runs on your GPU (WebGPU) when available, otherwise on the CPU.</p>
+          <p style="padding-top:12px">Models download once, then run locally – on your GPU when available. Larger models are more accurate but slower.</p>
+          <p>For non-English media select the language – auto-detect can mistranslate on the smaller models.</p>
         </div>
       </div>
       

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -94,6 +94,19 @@ function loadWhisperClient(modal, workerBaseUrl) {
           handleInferenceDone(data);
           break;
         case "error":
+          // a failed session creation poisons the WASM runtime for every
+          // later attempt in that worker, so in-worker fallbacks can't be
+          // trusted – throw the worker away and retry once in a fresh one
+          // with the most compatible config (wasm + fp32)
+          if (data.stage === "load" && lastSubmission !== null && lastSubmission.compatRetried === false) {
+            lastSubmission.compatRetried = true;
+            console.warn("Model failed to load – retrying in a fresh worker in compatibility mode (wasm/fp32)");
+            webWorker.terminate();
+            webWorker = createWorker();
+            updateLoadingMessage("Retrying in compatibility mode…");
+            submitToWorker(lastSubmission.file, lastSubmission.model_name, true);
+            break;
+          }
           handleError(data.message);
           break;
       }
@@ -110,6 +123,7 @@ function loadWhisperClient(modal, workerBaseUrl) {
   let progressTicker = null;
   let progressStart = 0;
   let progressMessage = "";
+  let lastSubmission = null;
 
   // progress messages only arrive when a whole window completes, so a ticking
   // clock is the liveness signal in between
@@ -221,8 +235,15 @@ function loadWhisperClient(modal, workerBaseUrl) {
     progressMessage = "Preparing model…";
     startProgressClock();
 
+    lastSubmission = { file, model_name, compatRetried: false };
+    await submitToWorker(file, model_name, false);
+  }
+
+  async function submitToWorker(file, model_name, compat) {
     let audio;
     try {
+      // the buffer is transferred away on each submission, so a retry has to
+      // decode the file again
       audio = await readAudioFrom(file);
     } catch (e) {
       console.error(e);
@@ -235,7 +256,8 @@ function loadWhisperClient(modal, workerBaseUrl) {
     webWorker.postMessage({
       type: "INFERENCE_REQUEST",
       audio,
-      model_name
+      model_name,
+      compat
     }, [audio.buffer]);
   }
 

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -80,7 +80,9 @@ function loadWhisperClient(modal, workerBaseUrl) {
         case "progress":
           updateLoadingMessage(data.phase === "download"
             ? `Downloading model… ${data.progress}%`
-            : `Transcribing… ${data.progress}%`);
+            : data.phase === "prepare"
+              ? "Preparing model…"
+              : `Transcribing… ${data.progress}%`);
           break;
         case "device":
           console.log(`Whisper running on ${data.device} (${data.dtype})`);

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -88,6 +88,14 @@ function loadWhisperClient(modal, workerBaseUrl) {
           break;
         case "device":
           console.log(`Whisper running on ${data.device} (${data.dtype})`);
+          // a pathologically slow warm-up means this browser's WebGPU is not
+          // worth using (e.g. extensive internal CPU fallback) – remember
+          // that and use the plain CPU path next time. The flag expires so
+          // the GPU gets re-probed as browser implementations improve.
+          if (data.device === "webgpu" && data.warmupSeconds > SLOW_WEBGPU_WARMUP_S) {
+            localStorage.setItem(AVOID_WEBGPU_KEY, JSON.stringify({ at: Date.now(), warmupSeconds: data.warmupSeconds }));
+            console.warn(`WebGPU warm-up took ${data.warmupSeconds.toFixed(1)}s – future transcriptions in this browser will use the CPU instead (re-probed after ${AVOID_WEBGPU_DAYS} days)`);
+          }
           break;
         case "result":
           stopProgressClock();
@@ -124,6 +132,20 @@ function loadWhisperClient(modal, workerBaseUrl) {
   let progressStart = 0;
   let progressMessage = "";
   let lastSubmission = null;
+
+  const AVOID_WEBGPU_KEY = "hyperaudio-whisper-avoid-webgpu";
+  const SLOW_WEBGPU_WARMUP_S = 30;
+  const AVOID_WEBGPU_DAYS = 30;
+
+  function shouldAvoidWebGpu() {
+    try {
+      const stored = JSON.parse(localStorage.getItem(AVOID_WEBGPU_KEY));
+      if (stored !== null && (Date.now() - stored.at) < AVOID_WEBGPU_DAYS * 24 * 60 * 60 * 1000) {
+        return true;
+      }
+    } catch (e) { /* absent or malformed – treat as no preference */ }
+    return false;
+  }
 
   // progress messages only arrive when a whole window completes, so a ticking
   // clock is the liveness signal in between
@@ -257,7 +279,8 @@ function loadWhisperClient(modal, workerBaseUrl) {
       type: "INFERENCE_REQUEST",
       audio,
       model_name,
-      compat
+      compat,
+      avoid_webgpu: shouldAvoidWebGpu()
     }, [audio.buffer]);
   }
 

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -56,6 +56,7 @@ function loadWhisperClient(modal, workerBaseUrl) {
   const fileUploadBtn = document.getElementById("file-input");
   const formSubmitBtn = document.getElementById("form-submit-btn");
   const modelNameSelectionInput = document.getElementById("model-name-input");
+  const languageSelectionInput = document.getElementById("whisper-language");
   const videoPlayer = document.getElementById("hyperplayer");
 
 
@@ -64,6 +65,20 @@ function loadWhisperClient(modal, workerBaseUrl) {
   }
 
   const whisperWorkerPath = workerBaseUrl + "js/whisper.worker.js?v=0.6.7";
+
+  // Firefox runs Whisper on the CPU (its WebGPU is still much slower than
+  // its CPU path) – workable for the smaller models, but the larger ones may
+  // be slow or fail. Say so up front rather than letting users find out.
+  if (/firefox/i.test(navigator.userAgent)) {
+    const form = modal.querySelector("form");
+    if (form !== null) {
+      const note = document.createElement("div");
+      note.setAttribute("role", "alert");
+      note.style.cssText = "background:#fff7e0; border-left:4px solid #f0a800; border-radius:4px; padding:8px 12px; margin-bottom:12px; font-size:85%;";
+      note.textContent = "Firefox: we recommend the Tiny or Base models – larger models may be slow or may not work.";
+      form.prepend(note);
+    }
+  }
 
   let webWorker = createWorker();
 
@@ -88,33 +103,12 @@ function loadWhisperClient(modal, workerBaseUrl) {
           break;
         case "device":
           console.log(`Whisper running on ${data.device} (${data.dtype})`);
-          // a pathologically slow warm-up means this browser's WebGPU is not
-          // worth using (e.g. extensive internal CPU fallback) – remember
-          // that and use the plain CPU path next time. The flag expires so
-          // the GPU gets re-probed as browser implementations improve.
-          if (data.device === "webgpu" && data.warmupSeconds > SLOW_WEBGPU_WARMUP_S) {
-            localStorage.setItem(AVOID_WEBGPU_KEY, JSON.stringify({ at: Date.now(), warmupSeconds: data.warmupSeconds }));
-            console.warn(`WebGPU warm-up took ${data.warmupSeconds.toFixed(1)}s – future transcriptions in this browser will use the CPU instead (re-probed after ${AVOID_WEBGPU_DAYS} days)`);
-          }
           break;
         case "result":
           stopProgressClock();
           handleInferenceDone(data);
           break;
         case "error":
-          // a failed session creation poisons the WASM runtime for every
-          // later attempt in that worker, so in-worker fallbacks can't be
-          // trusted – throw the worker away and retry once in a fresh one
-          // with the most compatible config (wasm + fp32)
-          if (data.stage === "load" && lastSubmission !== null && lastSubmission.compatRetried === false) {
-            lastSubmission.compatRetried = true;
-            console.warn("Model failed to load – retrying in a fresh worker in compatibility mode (wasm/fp32)");
-            webWorker.terminate();
-            webWorker = createWorker();
-            updateLoadingMessage("Retrying in compatibility mode…");
-            submitToWorker(lastSubmission.file, lastSubmission.model_name, true);
-            break;
-          }
           handleError(data.message);
           break;
       }
@@ -131,21 +125,6 @@ function loadWhisperClient(modal, workerBaseUrl) {
   let progressTicker = null;
   let progressStart = 0;
   let progressMessage = "";
-  let lastSubmission = null;
-
-  const AVOID_WEBGPU_KEY = "hyperaudio-whisper-avoid-webgpu";
-  const SLOW_WEBGPU_WARMUP_S = 30;
-  const AVOID_WEBGPU_DAYS = 30;
-
-  function shouldAvoidWebGpu() {
-    try {
-      const stored = JSON.parse(localStorage.getItem(AVOID_WEBGPU_KEY));
-      if (stored !== null && (Date.now() - stored.at) < AVOID_WEBGPU_DAYS * 24 * 60 * 60 * 1000) {
-        return true;
-      }
-    } catch (e) { /* absent or malformed – treat as no preference */ }
-    return false;
-  }
 
   // progress messages only arrive when a whole window completes, so a ticking
   // clock is the liveness signal in between
@@ -243,7 +222,18 @@ function loadWhisperClient(modal, workerBaseUrl) {
     // #transcript-editor-btn is disabled in transcript mode, so this no-ops.
     document.querySelector('#transcript-editor-btn')?.click();
 
-    const model_name = modelNameSelectionInput.value;
+    const size = modelNameSelectionInput.value;
+    const language = languageSelectionInput !== null ? languageSelectionInput.value : "";
+    // English gets the slightly more accurate English-only variants; any
+    // other language (or auto-detect) needs the multilingual ones. Turbo
+    // only exists as a multilingual model.
+    const WHISPER_MODELS = {
+      tiny:  { en: "onnx-community/whisper-tiny.en_timestamped",  multi: "onnx-community/whisper-tiny_timestamped" },
+      base:  { en: "onnx-community/whisper-base.en_timestamped",  multi: "onnx-community/whisper-base_timestamped" },
+      small: { en: "onnx-community/whisper-small.en_timestamped", multi: "onnx-community/whisper-small_timestamped" },
+      turbo: { en: "onnx-community/whisper-large-v3-turbo_timestamped", multi: "onnx-community/whisper-large-v3-turbo_timestamped" },
+    };
+    const model_name = (WHISPER_MODELS[size] || WHISPER_MODELS.base)[language === "en" ? "en" : "multi"];
     const file = fileUploadBtn.files[0];
 
     videoPlayer.src = URL.createObjectURL(file);
@@ -257,15 +247,8 @@ function loadWhisperClient(modal, workerBaseUrl) {
     progressMessage = "Preparing model…";
     startProgressClock();
 
-    lastSubmission = { file, model_name, compatRetried: false };
-    await submitToWorker(file, model_name, false);
-  }
-
-  async function submitToWorker(file, model_name, compat) {
     let audio;
     try {
-      // the buffer is transferred away on each submission, so a retry has to
-      // decode the file again
       audio = await readAudioFrom(file);
     } catch (e) {
       console.error(e);
@@ -279,8 +262,7 @@ function loadWhisperClient(modal, workerBaseUrl) {
       type: "INFERENCE_REQUEST",
       audio,
       model_name,
-      compat,
-      avoid_webgpu: shouldAvoidWebGpu()
+      language
     }, [audio.buffer]);
   }
 

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -1,7 +1,7 @@
 /**
  * hyperaudio-lite-editor-whisper.js
  * (C) The Hyperaudio Project
- * @version 0.6.6 — last changed in release 0.6.6
+ * @version 0.6.7 — last changed in release 0.6.7
  * @license MIT
  */
 
@@ -63,7 +63,7 @@ function loadWhisperClient(modal, workerBaseUrl) {
     workerBaseUrl = "./";
   }
 
-  const whisperWorkerPath = workerBaseUrl + "js/whisper.worker.js?v=0.6.6";
+  const whisperWorkerPath = workerBaseUrl + "js/whisper.worker.js?v=0.6.7";
 
   let webWorker = createWorker();
 

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -82,7 +82,9 @@ function loadWhisperClient(modal, workerBaseUrl) {
             ? `Downloading model… ${data.progress}%`
             : data.phase === "prepare"
               ? "Preparing model…"
-              : `Transcribing… ${data.progress}%`);
+              : data.progress === null
+                ? "Transcribing…"
+                : `Transcribing… ${data.progress}%`);
           break;
         case "device":
           console.log(`Whisper running on ${data.device} (${data.dtype})`);

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -1,7 +1,7 @@
 /**
  * whisper.worker.js
  * (C) The Hyperaudio Project
- * @version 0.6.6 — last changed in release 0.6.6
+ * @version 0.6.7 — last changed in release 0.6.7
  * @license MIT
  */
 

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -14,7 +14,7 @@ const OVERLAP_S = 10;   // each seam is transcribed by both windows
 let cache = { key: null, pipe: null, device: null };
 
 self.addEventListener("message", async (event) => {
-  const { type, audio, model_name, compat } = event.data;
+  const { type, audio, model_name, compat, avoid_webgpu } = event.data;
 
   if (type !== "INFERENCE_REQUEST") {
     return;
@@ -22,10 +22,12 @@ self.addEventListener("message", async (event) => {
 
   let pipe;
   try {
-    // compatibility mode: a previous worker died on a failed session
-    // creation (which poisons the WASM runtime for all later attempts),
-    // so this fresh worker goes straight to the most compatible config
-    pipe = await getPipeline(model_name, compat ? ["wasm"] : undefined, compat);
+    // compat: a previous worker died on a failed session creation (which
+    // poisons the WASM runtime for all later attempts), so this fresh worker
+    // goes straight to the most compatible config. avoid_webgpu: this
+    // browser's WebGPU measured pathologically slow on an earlier run.
+    const devices = (compat || avoid_webgpu) ? ["wasm"] : undefined;
+    pipe = await getPipeline(model_name, devices, compat);
   } catch (e) {
     console.error(e);
     self.postMessage({ type: "error", stage: "load", message: e?.message || String(e) });
@@ -80,11 +82,7 @@ function pickDtypes(model_name, device) {
 
 async function getPipeline(model_name, devices, compat) {
   if (devices === undefined) {
-    // Firefox's WebGPU initialises and completes but is far slower than its
-    // WASM path (measured 2026-06: minutes vs 13s for the same clip) – prefer
-    // WASM there until its WebGPU matures
-    const slowWebGpu = /firefox/i.test(self.navigator?.userAgent || "");
-    devices = self.navigator?.gpu && !slowWebGpu ? ["webgpu", "wasm"] : ["wasm"];
+    devices = self.navigator?.gpu ? ["webgpu", "wasm"] : ["wasm"];
   }
 
   let lastError = null;
@@ -114,20 +112,25 @@ async function getPipeline(model_name, devices, compat) {
           progress_callback: makeDownloadProgress(),
         });
 
+        let warmupSeconds = null;
         if (device === "webgpu") {
           // run one second of silence through the pipeline so that shader
           // compilation happens here, under "Preparing model…", rather than
           // inside the first transcription window – and so a GPU that fails
           // at inference time is caught now, while falling through to WASM
-          // is still cheap
+          // is still cheap. The duration doubles as a quality probe of this
+          // browser's WebGPU implementation.
           self.postMessage({ type: "progress", phase: "prepare" });
+          const warmupStart = Date.now();
           await pipe(new Float32Array(SAMPLE_RATE));
+          warmupSeconds = (Date.now() - warmupStart) / 1000;
         }
 
         cache = { key, pipe, device };
 
-        console.log(`Whisper pipeline ready: ${model_name} on ${device} (${dtypeLabel})`);
-        self.postMessage({ type: "device", device, dtype: dtypeLabel });
+        console.log(`Whisper pipeline ready: ${model_name} on ${device} (${dtypeLabel})`
+          + (warmupSeconds !== null ? `, warm-up ${warmupSeconds.toFixed(1)}s` : ""));
+        self.postMessage({ type: "device", device, dtype: dtypeLabel, warmupSeconds });
         return pipe;
       } catch (e) {
         console.warn(`Failed to initialise ${model_name} on ${device} (${dtypeLabel}):`, e);

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -5,7 +5,7 @@
  * @license MIT
  */
 
-import { pipeline } from "https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0";
+import { pipeline, env } from "https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0";
 
 const SAMPLE_RATE = 16000;
 const WINDOW_S = 300;   // transcribe in 5-minute windows to bound memory
@@ -24,8 +24,13 @@ self.addEventListener("message", async (event) => {
   try {
     // compat: a previous worker died on a failed session creation (which
     // poisons the WASM runtime for all later attempts), so this fresh worker
-    // goes straight to the most compatible config. avoid_webgpu: this
+    // goes straight to the most compatible config — including bypassing the
+    // browser model cache, whose writes can fail mid-stream on very large
+    // files ("Error in input stream" on Firefox). avoid_webgpu: this
     // browser's WebGPU measured pathologically slow on an earlier run.
+    if (compat) {
+      env.useBrowserCache = false;
+    }
     const devices = (compat || avoid_webgpu) ? ["wasm"] : undefined;
     pipe = await getPipeline(model_name, devices, compat);
   } catch (e) {

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -145,6 +145,15 @@ async function transcribe(pipe, audio) {
   let chunks = [];
 
   for (let i = 0; i < windowCount; i++) {
+    // announce the window before running it – otherwise nothing updates the
+    // loader between the model download and the first completed window, and
+    // it shows a stale "Downloading model" for the whole first inference
+    self.postMessage({
+      type: "progress",
+      phase: "transcribe",
+      progress: Math.round((i / windowCount) * 100),
+    });
+
     const offsetSamples = i * stepSamples;
     const offsetSeconds = offsetSamples / SAMPLE_RATE;
     const window = audio.subarray(offsetSamples, offsetSamples + windowSamples);

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -65,6 +65,13 @@ function pickDtypes(model_name, device) {
     // loops – use the same per-component dtypes as the official demos.
     return [{ encoder_model: "fp32", decoder_model_merged: "q4" }, "fp32"];
   }
+  // the q8 exports of the base models fail session creation on the WASM
+  // runtime ("Missing required scale ... MatMulNBits", huggingface/
+  // transformers.js#1707) – go straight to fp32 rather than landing every
+  // CPU user on a doomed download
+  if (model_name.includes("whisper-base")) {
+    return ["fp32"];
+  }
   return ["q8", "fp32"];
 }
 

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -14,7 +14,7 @@ const OVERLAP_S = 10;   // each seam is transcribed by both windows
 let cache = { key: null, pipe: null, device: null };
 
 self.addEventListener("message", async (event) => {
-  const { type, audio, model_name } = event.data;
+  const { type, audio, model_name, compat } = event.data;
 
   if (type !== "INFERENCE_REQUEST") {
     return;
@@ -22,7 +22,10 @@ self.addEventListener("message", async (event) => {
 
   let pipe;
   try {
-    pipe = await getPipeline(model_name);
+    // compatibility mode: a previous worker died on a failed session
+    // creation (which poisons the WASM runtime for all later attempts),
+    // so this fresh worker goes straight to the most compatible config
+    pipe = await getPipeline(model_name, compat ? ["wasm"] : undefined, compat);
   } catch (e) {
     console.error(e);
     self.postMessage({ type: "error", stage: "load", message: e?.message || String(e) });
@@ -65,17 +68,17 @@ function pickDtypes(model_name, device) {
     // loops – use the same per-component dtypes as the official demos.
     return [{ encoder_model: "fp32", decoder_model_merged: "q4" }, "fp32"];
   }
-  // the q8 exports of the base models fail session creation on the WASM
-  // runtime ("Missing required scale ... MatMulNBits", huggingface/
-  // transformers.js#1707) – go straight to fp32 rather than landing every
-  // CPU user on a doomed download
-  if (model_name.includes("whisper-base")) {
+  // the q8 exports of the base and tiny *_timestamped models fail session
+  // creation on the WASM runtime ("Missing required scale ... MatMulNBits",
+  // huggingface/transformers.js#1707) – go straight to fp32 rather than
+  // landing every CPU user on a doomed download
+  if (model_name.includes("whisper-base") || model_name.includes("whisper-tiny")) {
     return ["fp32"];
   }
   return ["q8", "fp32"];
 }
 
-async function getPipeline(model_name, devices) {
+async function getPipeline(model_name, devices, compat) {
   if (devices === undefined) {
     // Firefox's WebGPU initialises and completes but is far slower than its
     // WASM path (measured 2026-06: minutes vs 13s for the same clip) – prefer
@@ -86,7 +89,7 @@ async function getPipeline(model_name, devices) {
 
   let lastError = null;
   for (const device of devices) {
-    for (const dtype of pickDtypes(model_name, device)) {
+    for (const dtype of (compat ? ["fp32"] : pickDtypes(model_name, device))) {
       const dtypeLabel = typeof dtype === "string" ? dtype : JSON.stringify(dtype);
       const key = `${model_name}|${device}|${dtypeLabel}`;
 

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -5,7 +5,7 @@
  * @license MIT
  */
 
-import { pipeline, env } from "https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0";
+import { pipeline } from "https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0";
 
 const SAMPLE_RATE = 16000;
 const WINDOW_S = 300;   // transcribe in 5-minute windows to bound memory
@@ -14,25 +14,20 @@ const OVERLAP_S = 10;   // each seam is transcribed by both windows
 let cache = { key: null, pipe: null, device: null };
 
 self.addEventListener("message", async (event) => {
-  const { type, audio, model_name, compat, avoid_webgpu } = event.data;
+  const { type, audio, model_name } = event.data;
 
   if (type !== "INFERENCE_REQUEST") {
     return;
   }
 
+  // a language hint stops multilingual models re-detecting the language per
+  // 30s chunk (which can drift into translating instead of transcribing).
+  // English-only models reject the option, so it only applies to multilingual.
+  const language = (event.data.language && !model_name.includes(".en")) ? event.data.language : null;
+
   let pipe;
   try {
-    // compat: a previous worker died on a failed session creation (which
-    // poisons the WASM runtime for all later attempts), so this fresh worker
-    // goes straight to the most compatible config — including bypassing the
-    // browser model cache, whose writes can fail mid-stream on very large
-    // files ("Error in input stream" on Firefox). avoid_webgpu: this
-    // browser's WebGPU measured pathologically slow on an earlier run.
-    if (compat) {
-      env.useBrowserCache = false;
-    }
-    const devices = (compat || avoid_webgpu) ? ["wasm"] : undefined;
-    pipe = await getPipeline(model_name, devices, compat);
+    pipe = await getPipeline(model_name);
   } catch (e) {
     console.error(e);
     self.postMessage({ type: "error", stage: "load", message: e?.message || String(e) });
@@ -40,7 +35,7 @@ self.addEventListener("message", async (event) => {
   }
 
   try {
-    const output = await transcribe(pipe, audio);
+    const output = await transcribe(pipe, audio, language);
     self.postMessage({ type: "result", output });
   } catch (e) {
     console.error(e);
@@ -49,7 +44,7 @@ self.addEventListener("message", async (event) => {
     if (cache.device === "webgpu") {
       try {
         pipe = await getPipeline(model_name, ["wasm"]);
-        const output = await transcribe(pipe, audio);
+        const output = await transcribe(pipe, audio, language);
         self.postMessage({ type: "result", output });
         return;
       } catch (retryError) {
@@ -66,6 +61,22 @@ self.addEventListener("message", async (event) => {
 // *_timestamped models predate the v4 ONNX runtime and fail session creation
 // ("Missing required scale ... MatMulNBits"), so always keep a variant in the
 // list that loads everywhere – fp32, except for turbo where fp32 is 2.5 GB.
+// navigator.gpu existing does not mean a usable GPU exists (headless and
+// GPU-less machines expose the API but yield no adapter) – and a failed
+// webgpu attempt poisons every later device attempt in the same worker, so
+// it must be ruled out before trying, not after failing.
+async function hasGpuAdapter() {
+  try {
+    if (!self.navigator?.gpu) {
+      return false;
+    }
+    const adapter = await self.navigator.gpu.requestAdapter();
+    return adapter !== null;
+  } catch (e) {
+    return false;
+  }
+}
+
 function pickDtypes(model_name, device) {
   if (model_name.includes("large-v3-turbo")) {
     return ["q4f16", "q4"];
@@ -75,24 +86,27 @@ function pickDtypes(model_name, device) {
     // loops – use the same per-component dtypes as the official demos.
     return [{ encoder_model: "fp32", decoder_model_merged: "q4" }, "fp32"];
   }
-  // the q8 exports of the base and tiny *_timestamped models fail session
-  // creation on the WASM runtime ("Missing required scale ... MatMulNBits",
-  // huggingface/transformers.js#1707) – go straight to fp32 rather than
-  // landing every CPU user on a doomed download
-  if (model_name.includes("whisper-base") || model_name.includes("whisper-tiny")) {
-    return ["fp32"];
-  }
-  return ["q8", "fp32"];
+  // On the WASM runtime, q4 is the only quantized variant of the
+  // *_timestamped exports that loads – q8/int8/uint8 fail session creation
+  // ("Missing required scale ... MatMulNBits", huggingface/transformers.js
+  // #1707) and fp16 fails with a graph error. q4 verified on tiny, base and
+  // small; it is also a quarter of fp32's size, which matters because very
+  // large downloads have proven fragile on flaky connections.
+  return ["q4", "fp32"];
 }
 
-async function getPipeline(model_name, devices, compat) {
+async function getPipeline(model_name, devices) {
   if (devices === undefined) {
-    devices = self.navigator?.gpu ? ["webgpu", "wasm"] : ["wasm"];
+    // Firefox's WebGPU initialises and completes but is far slower than its
+    // own WASM path (measured 2026-06: minutes vs 13s for the same clip) –
+    // prefer WASM there until its implementation matures
+    const slowWebGpu = /firefox/i.test(self.navigator?.userAgent || "");
+    devices = !slowWebGpu && (await hasGpuAdapter()) ? ["webgpu", "wasm"] : ["wasm"];
   }
 
   let lastError = null;
   for (const device of devices) {
-    for (const dtype of (compat ? ["fp32"] : pickDtypes(model_name, device))) {
+    for (const dtype of pickDtypes(model_name, device)) {
       const dtypeLabel = typeof dtype === "string" ? dtype : JSON.stringify(dtype);
       const key = `${model_name}|${device}|${dtypeLabel}`;
 
@@ -135,7 +149,7 @@ async function getPipeline(model_name, devices, compat) {
 
         console.log(`Whisper pipeline ready: ${model_name} on ${device} (${dtypeLabel})`
           + (warmupSeconds !== null ? `, warm-up ${warmupSeconds.toFixed(1)}s` : ""));
-        self.postMessage({ type: "device", device, dtype: dtypeLabel, warmupSeconds });
+        self.postMessage({ type: "device", device, dtype: dtypeLabel });
         return pipe;
       } catch (e) {
         console.warn(`Failed to initialise ${model_name} on ${device} (${dtypeLabel}):`, e);
@@ -167,7 +181,7 @@ function makeDownloadProgress() {
   };
 }
 
-async function transcribe(pipe, audio) {
+async function transcribe(pipe, audio, language) {
   const startedAt = Date.now();
   const windowSamples = WINDOW_S * SAMPLE_RATE;
   const stepSamples = (WINDOW_S - OVERLAP_S) * SAMPLE_RATE;
@@ -197,6 +211,7 @@ async function transcribe(pipe, audio) {
       return_timestamps: "word",
       chunk_length_s: 30,
       stride_length_s: 5,
+      ...(language !== null ? { language } : {}),
     });
 
     const windowChunks = dropRewindDuplicates((output.chunks || []).map((chunk) => {
@@ -216,7 +231,7 @@ async function transcribe(pipe, audio) {
     });
   }
 
-  chunks = mergeWordFragments(chunks);
+  chunks = collapseCycles(mergeWordFragments(chunks));
 
   const seconds = (Date.now() - startedAt) / 1000;
   console.log(`Whisper transcription took ${seconds.toFixed(1)}s for ${(audio.length / SAMPLE_RATE).toFixed(1)}s of audio (${cache.device})`);
@@ -258,6 +273,55 @@ function dropRewindDuplicates(chunks) {
       }
     }
     out.push(chunk);
+  }
+  return out;
+}
+
+// A looping decoder can also creep its timestamps forward, emitting the same
+// word cycle over and over at slightly advancing times – invisible to the
+// same-instant collapse below. Real speech essentially never repeats the
+// identical word sequence many times back to back with identical punctuation,
+// so collapse such runs to their first occurrence. Single-word cycles need a
+// higher bar ("no, no, no" is legitimate speech).
+function collapseCycles(chunks) {
+  const texts = chunks.map((c) => c.text.trim().toLowerCase());
+
+  const cycleMatches = (start, candidate, n) => {
+    if (candidate + n > texts.length) {
+      return false;
+    }
+    for (let k = 0; k < n; k++) {
+      if (texts[start + k] !== texts[candidate + k]) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const out = [];
+  let i = 0;
+  while (i < chunks.length) {
+    let collapsed = false;
+    // smallest period first, so "a b a b a b" collapses as the 2-cycle
+    for (let n = 1; n <= 8 && !collapsed; n++) {
+      let reps = 1;
+      while (cycleMatches(i, i + reps * n, n)) {
+        reps++;
+      }
+      const minReps = n === 1 ? 6 : 4;
+      if (reps >= minReps) {
+        for (let k = 0; k < n; k++) {
+          out.push(chunks[i + k]);
+        }
+        console.log(`Collapsed repetition loop: "${chunks.slice(i, i + n).map((c) => c.text.trim()).join(" ")}" × ${reps}`);
+        i += reps * n;
+        collapsed = true;
+      }
+    }
+    if (!collapsed) {
+      out.push(chunks[i]);
+      i++;
+    }
   }
   return out;
 }

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -100,6 +100,16 @@ async function getPipeline(model_name, devices) {
           progress_callback: makeDownloadProgress(),
         });
 
+        if (device === "webgpu") {
+          // run one second of silence through the pipeline so that shader
+          // compilation happens here, under "Preparing model…", rather than
+          // inside the first transcription window – and so a GPU that fails
+          // at inference time is caught now, while falling through to WASM
+          // is still cheap
+          self.postMessage({ type: "progress", phase: "prepare" });
+          await pipe(new Float32Array(SAMPLE_RATE));
+        }
+
         cache = { key, pipe, device };
 
         console.log(`Whisper pipeline ready: ${model_name} on ${device} (${dtypeLabel})`);

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -146,6 +146,7 @@ function makeDownloadProgress() {
 }
 
 async function transcribe(pipe, audio) {
+  const startedAt = Date.now();
   const windowSamples = WINDOW_S * SAMPLE_RATE;
   const stepSamples = (WINDOW_S - OVERLAP_S) * SAMPLE_RATE;
   const windowCount = audio.length <= windowSamples
@@ -194,6 +195,9 @@ async function transcribe(pipe, audio) {
   }
 
   chunks = mergeWordFragments(chunks);
+
+  const seconds = (Date.now() - startedAt) / 1000;
+  console.log(`Whisper transcription took ${seconds.toFixed(1)}s for ${(audio.length / SAMPLE_RATE).toFixed(1)}s of audio (${cache.device})`);
 
   return { text: chunks.map((c) => c.text).join(""), chunks };
 }

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -77,7 +77,11 @@ function pickDtypes(model_name, device) {
 
 async function getPipeline(model_name, devices) {
   if (devices === undefined) {
-    devices = self.navigator?.gpu ? ["webgpu", "wasm"] : ["wasm"];
+    // Firefox's WebGPU initialises and completes but is far slower than its
+    // WASM path (measured 2026-06: minutes vs 13s for the same clip) – prefer
+    // WASM there until its WebGPU matures
+    const slowWebGpu = /firefox/i.test(self.navigator?.userAgent || "");
+    devices = self.navigator?.gpu && !slowWebGpu ? ["webgpu", "wasm"] : ["wasm"];
   }
 
   let lastError = null;

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -157,11 +157,13 @@ async function transcribe(pipe, audio) {
   for (let i = 0; i < windowCount; i++) {
     // announce the window before running it – otherwise nothing updates the
     // loader between the model download and the first completed window, and
-    // it shows a stale "Downloading model" for the whole first inference
+    // it shows a stale "Downloading model" for the whole first inference.
+    // progress is only countable across windows, so a single-window file
+    // (under 5 minutes) gets no percentage – the elapsed clock carries it
     self.postMessage({
       type: "progress",
       phase: "transcribe",
-      progress: Math.round((i / windowCount) * 100),
+      progress: windowCount > 1 ? Math.round((i / windowCount) * 100) : null,
     });
 
     const offsetSamples = i * stepSamples;
@@ -187,7 +189,7 @@ async function transcribe(pipe, audio) {
     self.postMessage({
       type: "progress",
       phase: "transcribe",
-      progress: Math.round(((i + 1) / windowCount) * 100),
+      progress: windowCount > 1 ? Math.round(((i + 1) / windowCount) * 100) : null,
     });
   }
 


### PR DESCRIPTION
Closes #317

Field-tested follow-up to #313, shipping as **0.6.7**. The branch history includes some download-resilience experiments that were ultimately **rolled back** in favour of simplicity (`723ae97`) — this describes the final state.

## Loader honesty

- Transcribe progress posts at window start, not only completion — previously the loader showed a stale "Downloading model… 100%" through the whole first inference (minutes on slow devices, reading as a hang).
- WebGPU warm-up runs under "Preparing model…", so shader compilation is attributed to the right phase and a GPU that fails at inference time is caught while falling back is still cheap.
- Single-window files (< 5 min) show "Transcribing… (elapsed)" instead of a frozen 0%; transcription duration and device are logged to the console.
- Dialog copy condensed so the TRANSCRIBE button sits above the fold.

## Device & dtype selection

- **Firefox prefers WASM** (UA check): its WebGPU initialises but measured *minutes vs 13 s* for the same clip against its own CPU path. Firefox users get a short notice at the top of the form recommending the smaller models — nothing is disabled.
- **GPU adapter pre-check**: browsers exposing `navigator.gpu` without a usable adapter (blocklisted GPUs, GPU-less machines — reproduced in the wild on Chrome) previously poisoned the worker so even the WASM fallback died. Ruled out before attempting, not after failing.
- **WASM prefers q4** — the only quantized `*_timestamped` variant that loads on the browser runtime (q8/int8/uint8/fp16 fail session creation, reported upstream as huggingface/transformers.js#1707) — with fp32 as fallback. Smaller downloads than the previous q8/fp32 mix.

## Language selection (Italian field test)

The model menu collapses to four sizes (Tiny/Base/Small/Turbo) plus a language selector defaulting to English: English uses the `.en` variants, anything else the multilingual ones with the language hint pinned. Without a hint, multilingual models re-detect language per 30 s chunk and can drift into **translating instead of transcribing** — an Italian file came back in English. Auto-detect remains available, no longer default; impossible combinations (Italian + English-only model) can no longer be expressed.

## Repetition guards (extends #313's set)

- **Cycle collapse**: looping decoders can creep timestamps forward, emitting the same word cycle at slightly advancing times — invisible to the same-instant collapse. Identical word sequences repeated ≥4× back-to-back (≥6 for single words, so "no, no, no" survives) collapse to their first occurrence, console-logged. Verified against field loops (6-word cycle ×15, 2-word cycle ×8).

## Tested in the field

Chrome (WebGPU) and Firefox (WASM) across tiny/base/small; English and Italian; the GPU-less poisoning failure reproduced on a third machine and covered by the pre-check. Known limit: Whisper in the browser lacks WhisperX-style VAD/temperature-fallback machinery, so hard audio on small models can still loop — the guards contain rather than prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
