### PR TITLE
Disable the TRANSCRIBE buttons until media is selected

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@ If you are creating an open source application under a license compatible with t
   <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png">
   <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
  
-  <script src="js/hyperaudio-lite-editor-deepgram.js"></script>
+  <script src="js/hyperaudio-lite-editor-deepgram.js?v=0.6.7"></script>
   <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.7"></script>
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js"></script>
@@ -116,7 +116,7 @@ If you are creating an open source application under a license compatible with t
 
       </div>
       <div class="modal-action">
-        <label id="transcribe-btn" for="transcribe-modal" class="btn btn-primary">TRANSCRIBE</label>
+        <label id="transcribe-btn" for="transcribe-modal" class="btn btn-primary btn-disabled" aria-disabled="true">TRANSCRIBE</label>
       </div>
     </form>
   </template>
@@ -180,7 +180,7 @@ If you are creating an open source application under a license compatible with t
       </div>
       
       <div class="modal-action">
-        <label id="form-submit-btn" for="transcribe-modal" class="btn btn-primary">TRANSCRIBE</label>
+        <label id="form-submit-btn" for="transcribe-modal" class="btn btn-primary btn-disabled" aria-disabled="true">TRANSCRIBE</label>
       </div>
     </form>
   </template>

--- a/js/hyperaudio-lite-editor-deepgram.js
+++ b/js/hyperaudio-lite-editor-deepgram.js
@@ -1,5 +1,9 @@
-/*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 1.1.0 */
+/**
+ * hyperaudio-lite-editor-deepgram.js
+ * (C) The Hyperaudio Project
+ * @version 0.6.7 — last changed in release 0.6.7
+ * @license MIT
+ */
 
 const DEEPGRAM_LANGUAGE_LABELS = {
   "en": "English",
@@ -190,9 +194,28 @@ customElements.define('deepgram-service', DeepgramService);
 function addModalEventListeners(modal) {
   document.querySelector('#deepgram-file').addEventListener('change',modal.clearMediaUrl);
   document.querySelector('#deepgram-media').addEventListener('change',modal.clearFilePicker);
-  document.querySelector('#transcribe-btn').addEventListener('click', modal.getData);
+  document.querySelector('#transcribe-btn').addEventListener('click', (event) => {
+    if (document.querySelector('#transcribe-btn').classList.contains('btn-disabled')) {
+      return;
+    }
+    modal.getData(event);
+  });
   document.querySelector('#deepgram-file').addEventListener('change', modal.updatePlayerWithLocalFile);
   document.querySelector('#language-model').addEventListener('change', modal.updateDropdowns);
+
+  // the button is a styled <label>, so "disabled" is the btn-disabled class
+  // (pointer-events: none) plus the guard above. A token alone is not enough
+  // to transcribe – media is what enables the button.
+  const updateTranscribeState = () => {
+    const hasFile = document.querySelector('#deepgram-file').files.length > 0;
+    const hasMedia = document.querySelector('#deepgram-media').value.trim() !== '';
+    const button = document.querySelector('#transcribe-btn');
+    button.classList.toggle('btn-disabled', !(hasFile || hasMedia));
+    button.setAttribute('aria-disabled', String(!(hasFile || hasMedia)));
+  };
+  document.querySelector('#deepgram-file').addEventListener('change', updateTranscribeState);
+  document.querySelector('#deepgram-media').addEventListener('input', updateTranscribeState);
+  updateTranscribeState();
 }
 
 function fetchData(token, media, language, model) {

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -82,7 +82,20 @@ function loadWhisperClient(modal, workerBaseUrl) {
 
   let webWorker = createWorker();
 
+  // the button is a styled <label>, so "disabled" is the btn-disabled class
+  // (pointer-events: none) plus a guard in the handler
+  function updateSubmitState() {
+    const ready = fileUploadBtn.files.length > 0;
+    formSubmitBtn.classList.toggle("btn-disabled", !ready);
+    formSubmitBtn.setAttribute("aria-disabled", String(!ready));
+  }
+  fileUploadBtn.addEventListener("change", updateSubmitState);
+  updateSubmitState();
+
   formSubmitBtn.addEventListener("click", async (event2) => {
+    if (formSubmitBtn.classList.contains("btn-disabled")) {
+      return;
+    }
     await handleFormSubmission();
   });
 


### PR DESCRIPTION
Closes #319

Both TRANSCRIBE buttons are styled `<label>`s, so disabling = the `btn-disabled` class (set in the template markup, so buttons render disabled with no enabled-flash before JS runs) plus a click guard behind daisyUI's `pointer-events: none`.

- **Whisper (Local)**: enables when a file is selected.
- **Deepgram (Cloud)**: enables on a file **or** a non-empty media URL (reacts per keystroke); a token alone is not enough. The tab's existing mutual clearing of file/URL is respected — state recomputes after those handlers run.
- Housekeeping: deepgram module moved onto the JSDoc `@version 0.6.7` header convention, and its script tag gains `?v=0.6.7` cache-busting.

The Parakeet tab (#307, parked) should get the same treatment when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)