### PR TITLE
Show transcription metadata (service, model, language, time) in the info modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,13 +325,17 @@ If you are creating an open source application under a license compatible with t
               <li><label for="file-import-vtt-dialog">Import VTT</label></li>
             </ul>
           </div>
-          <label for="info-modal" class="btn btn-ghost btn-primary gap-2 tooltip" data-tip="Summary and topics" aria-label="Summary and topics">
+          <label for="info-modal" class="btn btn-ghost btn-primary gap-2 tooltip" data-tip="Transcription info" aria-label="Transcription info">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-info"><circle cx="12" cy="12" r="10"></circle><line x1="12" x2="12" y1="16" y2="12"></line><line x1="12" x2="12.01" y1="8" y2="8"></line></svg>
           </label>
           <input type="checkbox" id="info-modal" class="modal-toggle" />
           <div class="modal">
             <div class="modal-box relative">
               <label for="info-modal" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+              <h3 class="text-lg font-bold">Transcription</h3>
+              <div id="transcription-info" class="py-4">
+                <p>Nothing transcribed yet – details of the service, model and processing time will appear here.</p>
+              </div>
               <h3 class="text-lg font-bold">Summary</h3>
               <p id="summary" class="py-4"></p>
               <h3 class="text-lg font-bold">Topics</h3>
@@ -695,6 +699,26 @@ If you are creating an open source application under a license compatible with t
   <script>
 
     console.log("version 3");
+
+  // Populates the Transcription section of the info modal. Called by the
+  // transcription modules (Whisper, Deepgram) when a transcription completes.
+  function setTranscriptionInfo(info) {
+    const container = document.getElementById("transcription-info");
+    if (container === null) {
+      return;
+    }
+    const rows = [];
+    if (info.service) rows.push(["Service", info.service]);
+    if (info.model) rows.push(["Model", info.model]);
+    if (info.language) rows.push(["Language", info.language]);
+    if (info.device) rows.push(["Processing", info.device]);
+    if (typeof info.seconds === "number") {
+      const minutes = Math.floor(info.seconds / 60);
+      const seconds = Math.round(info.seconds % 60);
+      rows.push(["Time taken", minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`]);
+    }
+    container.innerHTML = rows.map(([label, value]) => `<p><strong>${label}:</strong> ${value}</p>`).join("");
+  }
 
 
   let updateCaptionsFromTranscript = true;

--- a/js/hyperaudio-lite-editor-deepgram.js
+++ b/js/hyperaudio-lite-editor-deepgram.js
@@ -134,6 +134,13 @@ class DeepgramService extends HTMLElement {
     const token =  document.querySelector('#token').value;
     const file = document.querySelector('#deepgram-file').files[0];
 
+    transcriptionStart = Date.now();
+    transcriptionMeta = {
+      service: "Deepgram (cloud)",
+      model: document.querySelector('#language-model').selectedOptions[0]?.textContent || model,
+      language: document.querySelector('#language').selectedOptions[0]?.textContent || language,
+    };
+
     if (media.toLowerCase().startsWith("https://") === false && media.toLowerCase().startsWith("http://") === false) {
       media = "https://"+media;
     }
@@ -354,6 +361,9 @@ function getLanguageCode(json){
   return (language);
 }
 
+let transcriptionStart = 0;
+let transcriptionMeta = {};
+
 function parseData(json) {
 
   const maxWordsInPara = 100;
@@ -453,6 +463,10 @@ function parseData(json) {
 
   console.log("updating download html link");
   document.querySelector('#download-html').setAttribute('href', 'data:text/html,'+encodeURIComponent(hyperTranscript));
+
+  if (typeof setTranscriptionInfo === 'function' && transcriptionStart !== 0) {
+    setTranscriptionInfo({ ...transcriptionMeta, seconds: (Date.now() - transcriptionStart) / 1000 });
+  }
 
   const initEvent = new CustomEvent('hyperaudioInit');
   document.dispatchEvent(initEvent);

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -116,9 +116,13 @@ function loadWhisperClient(modal, workerBaseUrl) {
           break;
         case "device":
           console.log(`Whisper running on ${data.device} (${data.dtype})`);
+          lastDeviceLabel = data.device === "webgpu" ? "GPU (WebGPU)" : "CPU";
           break;
         case "result":
           stopProgressClock();
+          if (pendingInfo !== null && typeof setTranscriptionInfo === "function") {
+            setTranscriptionInfo({ ...pendingInfo, device: lastDeviceLabel, seconds: data.output.seconds });
+          }
           handleInferenceDone(data);
           break;
         case "error":
@@ -138,6 +142,8 @@ function loadWhisperClient(modal, workerBaseUrl) {
   let progressTicker = null;
   let progressStart = 0;
   let progressMessage = "";
+  let lastDeviceLabel = "";
+  let pendingInfo = null;
 
   // progress messages only arrive when a whole window completes, so a ticking
   // clock is the liveness signal in between
@@ -248,6 +254,15 @@ function loadWhisperClient(modal, workerBaseUrl) {
     };
     const model_name = (WHISPER_MODELS[size] || WHISPER_MODELS.base)[language === "en" ? "en" : "multi"];
     const file = fileUploadBtn.files[0];
+
+    const SIZE_LABELS = { tiny: "Whisper Tiny", base: "Whisper Base", small: "Whisper Small", turbo: "Whisper Large v3 Turbo" };
+    pendingInfo = {
+      service: "Whisper (local, in your browser)",
+      model: (SIZE_LABELS[size] || size) + (language === "en" && size !== "turbo" ? " (English)" : " (multilingual)"),
+      language: languageSelectionInput !== null && languageSelectionInput.selectedOptions.length > 0
+        ? languageSelectionInput.selectedOptions[0].textContent
+        : "Auto-detect",
+    };
 
     videoPlayer.src = URL.createObjectURL(file);
 

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -236,7 +236,7 @@ async function transcribe(pipe, audio, language) {
   const seconds = (Date.now() - startedAt) / 1000;
   console.log(`Whisper transcription took ${seconds.toFixed(1)}s for ${(audio.length / SAMPLE_RATE).toFixed(1)}s of audio (${cache.device})`);
 
-  return { text: chunks.map((c) => c.text).join(""), chunks };
+  return { text: chunks.map((c) => c.text).join(""), chunks, seconds };
 }
 
 // Whisper marks the start of a word with a leading space on the chunk text; a


### PR DESCRIPTION
Closes #320

The info modal gains a **Transcription** section (above Summary/Topics, which remain Deepgram-only) populated on every completed transcription via a shared `setTranscriptionInfo()` helper — each service reports what it honestly knows:

- **Whisper (local)**: service, model ("Whisper Base (English)"), language label, processing device (GPU (WebGPU) / CPU), time taken — the worker's measured duration now rides the result message instead of only the console.
- **Deepgram (cloud)**: service, model and language labels from the form, wall-clock request time. No device row.
- The "Import Deepgram JSON" path (which reuses `parseData` without transcribing) is guarded from writing stale info.
- Toolbar tooltip: "Summary and topics" → "Transcription info".

The Parakeet tab (#307) should populate the same section when it lands. Metadata is not yet persisted with the transcript across reloads — noted in #320 as a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)