### PR TITLE
Harden sanitise() and lock transcript editing during transcription

### DIFF
--- a/index.html
+++ b/index.html
@@ -720,6 +720,22 @@ If you are creating an open source application under a license compatible with t
     container.innerHTML = rows.map(([label, value]) => `<p><strong>${label}:</strong> ${value}</p>`).join("");
   }
 
+  // While a transcription is in flight the transcript container holds loader
+  // markup, not a transcript – typing into it would be silently destroyed
+  // when the result lands. Transcription modules call this around their work.
+  function setTranscriptBusy(busy) {
+    const transcript = document.getElementById("hypertranscript");
+    if (transcript === null) {
+      return;
+    }
+    transcript.setAttribute("contenteditable", String(!busy));
+    if (busy) {
+      transcript.setAttribute("aria-busy", "true");
+    } else {
+      transcript.removeAttribute("aria-busy");
+    }
+  }
+
 
   let updateCaptionsFromTranscript = true;
   let captionMode = false; // used to detect whether we need to sanitise amongst other things
@@ -843,13 +859,20 @@ If you are creating an open source application under a license compatible with t
         let d = new Date();
         let starttime = d.getTime();
 
+        // the container only holds a transcript when there are timed spans –
+        // during transcription it holds loader or error markup whose text
+        // nodes have no span siblings, and walking those used to throw
+        if (rootnode.querySelector("span[data-m]") === null) {
+          return;
+        }
+
         // check that transcript has the focus
 
         // check for focus
         let isTranscriptFocused = false;
         let isCaptionEditorFocused = false;
 
-        
+
         if (document.activeElement === rootnode) {
           isTranscriptFocused = true;
         }
@@ -863,11 +886,14 @@ If you are creating an open source application under a license compatible with t
               && walker.currentNode.parentElement.tagName !== "SPAN") {
 
             // if previousSibling is a span, add the textContent of currentNode to it
-            if (walker.currentNode.previousSibling.tagName === "SPAN") {
+            if (walker.currentNode.previousSibling !== null && walker.currentNode.previousSibling.tagName === "SPAN") {
               walker.currentNode.previousSibling.textContent += walker.currentNode.textContent;
-            } else {
+            } else if (walker.currentNode.nextSibling !== null) {
               // assume nextSibling is a span for now and add textContent of currentNode to that
               walker.currentNode.nextSibling.textContent += walker.currentNode.textContent;
+            } else {
+              // orphan text node with no siblings at all – leave it alone
+              continue;
             }
 
             // remove currentNode as we've merged its contents

--- a/js/hyperaudio-lite-editor-deepgram.js
+++ b/js/hyperaudio-lite-editor-deepgram.js
@@ -128,6 +128,9 @@ class DeepgramService extends HTMLElement {
     // #transcript-editor-btn is disabled in transcript mode, so this no-ops.
     document.querySelector('#transcript-editor-btn')?.click();
     document.querySelector('#hypertranscript').innerHTML = '<div class="vertically-centre"><center>Transcribing....</center><br/><img src="'+transcribingSvg+'" width="50" alt="transcribing" style="margin: auto; display: block;"></div>';
+    if (typeof setTranscriptBusy === 'function') {
+      setTranscriptBusy(true);
+    }
     const language = document.querySelector('#language').value;
     const model = document.querySelector('#language-model').value;
     let media =  document.querySelector('#deepgram-media').value;
@@ -155,6 +158,9 @@ class DeepgramService extends HTMLElement {
         fetchData(token, media, language, model);
       } else {
         document.querySelector('#hypertranscript').innerHTML = '<div class="vertically-centre"><img src="'+errorSvg+'" width="50" alt="error" style="margin: auto; display: block;"><br/><center>Please include both a link to the media and token in the form. </center></div>';
+        if (typeof setTranscriptBusy === 'function') {
+          setTranscriptBusy(false);
+        }
       }
     }
   }
@@ -310,6 +316,9 @@ function fetchDataLocal(token, file, language, model) {
         })
       } else {
         document.querySelector('#hypertranscript').innerHTML = '';
+        if (typeof setTranscriptBusy === 'function') {
+          setTranscriptBusy(false);
+        }
       }
     });
   });
@@ -321,6 +330,9 @@ function getApiUrl(language, model) {
 }
 
 function displayAppropriateErrorMessage(error) {
+  if (typeof setTranscriptBusy === 'function') {
+    setTranscriptBusy(false);
+  }
   console.dir("error is : " + error);
   error = error + "";
 
@@ -340,6 +352,9 @@ function displayGenericError() {
 }
 
 function displayNoWordsError() {
+  if (typeof setTranscriptBusy === 'function') {
+    setTranscriptBusy(false);
+  }
   document.querySelector('#hypertranscript').innerHTML = '<div class="vertically-centre"><img src="'+errorSvg+'" width="50" alt="error" style="margin: auto; display: block;"><br/><center>Sorry.<br/>No words were detected.<br/>Please verify that audio contains speech.</center></div>';
 }
 
@@ -466,6 +481,9 @@ function parseData(json) {
 
   if (typeof setTranscriptionInfo === 'function' && transcriptionStart !== 0) {
     setTranscriptionInfo({ ...transcriptionMeta, seconds: (Date.now() - transcriptionStart) / 1000 });
+  }
+  if (typeof setTranscriptBusy === 'function') {
+    setTranscriptBusy(false);
   }
 
   const initEvent = new CustomEvent('hyperaudioInit');

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -179,6 +179,9 @@ function loadWhisperClient(modal, workerBaseUrl) {
 
   function handleError(message) {
     stopProgressClock();
+    if (typeof setTranscriptBusy === "function") {
+      setTranscriptBusy(false);
+    }
     console.error("Whisper error: " + message);
     const detail = message ? '<br/><span style="font-size:80%; opacity:0.7">'+String(message).slice(0, 200)+'</span>' : '';
     document.getElementById("hypertranscript").innerHTML =
@@ -187,6 +190,9 @@ function loadWhisperClient(modal, workerBaseUrl) {
 
   function handleInferenceDone(results) {
 
+    if (typeof setTranscriptBusy === "function") {
+      setTranscriptBusy(false);
+    }
     videoPlayer.currentTime = 0;
 
     let hypertranscript = "";
@@ -272,6 +278,9 @@ function loadWhisperClient(modal, workerBaseUrl) {
 
     const loadingMessageContainer = document.getElementById("hypertranscript");
     loadingMessageContainer.innerHTML = '<div class="vertically-centre"><center class="transcribing-msg">Preparing model…</center><br/><img src="'+transcribingSvg+'" width="50" alt="transcribing" style="margin: auto; display: block;"></div>';
+    if (typeof setTranscriptBusy === "function") {
+      setTranscriptBusy(true);
+    }
     progressMessage = "Preparing model…";
     startProgressClock();
 


### PR DESCRIPTION
Closes #310, closes #312 — two halves of the same wound: loader/error markup sits in an editable container while a 1s timer walks it assuming transcript structure.

**#310** — `sanitise()` now returns early when `#hypertranscript` contains no `span[data-m]` (loader/error states skip the walk entirely — this was the once-per-second TypeError in every error-path console log), and the text-node merge branch null-guards `previousSibling`/`nextSibling` so orphan nodes during real edits are left alone instead of throwing.

**#312** — new `setTranscriptBusy()` helper toggles `contenteditable`/`aria-busy` on the transcript container. Whisper and Deepgram set busy when writing their loaders and release on every terminal state (result, error screens, no-words, missing-input message, empty-token bail), so nothing typed during a transcription can be silently destroyed.

The Parakeet tab (#307) should adopt `setTranscriptBusy()` when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)