### PR TITLE
Add Parakeet (Local) transcription tab — in-browser TDT v3 (#325)

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@ If you are creating an open source application under a license compatible with t
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
         <input id="deepgram-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
         <span class="label-text">or</span>
-        <input id="deepgram-file" name="file" type="file" class="file-input w-full max-w-xs" />
+        <input id="deepgram-file" name="file" type="file" class="file-input w-full max-w-xs" title="" />
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
   
         <span class="label-text">Model</span>
@@ -127,7 +127,7 @@ If you are creating an open source application under a license compatible with t
       <div class="mb-3">
         <input id="media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" disabled />
         <span style="display:block; padding:16px" class="label-text">or</span>
-        <input id="file-input" name="file" type="file" class="file-input w-full max-w-xs" />
+        <input id="file-input" name="file" type="file" class="file-input w-full max-w-xs" title="" />
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
       </div>
       <div class="mb-3">
@@ -189,7 +189,7 @@ If you are creating an open source application under a license compatible with t
   <template id="parakeet-local-template">
     <form>
       <div class="mb-3">
-        <input id="parakeet-file-input" name="file" type="file" class="file-input w-full max-w-xs" />
+        <input id="parakeet-file-input" name="file" type="file" class="file-input w-full max-w-xs" title="" />
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
       </div>
       <div class="form-text" style="font-size: 90%;">

--- a/index.html
+++ b/index.html
@@ -195,6 +195,7 @@ If you are creating an open source application under a license compatible with t
       <div class="form-text" style="font-size: 90%;">
         <p style="padding-top:8px">Parakeet TDT v3 runs entirely in your browser — no token, nothing uploaded.</p>
         <p>The model downloads once and is cached (~650&nbsp;MB on CPU, ~1.2&nbsp;GB on GPU). Multilingual — the language is detected automatically.</p>
+        <p>Runs on your GPU when available — a GPU browser (Chrome or Safari) is recommended. Without WebGPU (e.g. Firefox) it falls back to the CPU and is several times slower.</p>
         <p id="parakeet-device" style="opacity:0.7"></p>
       </div>
       <div class="modal-action">
@@ -601,24 +602,24 @@ If you are creating an open source application under a license compatible with t
 
   <input type="checkbox" id="transcribe-modal" class="modal-toggle" />
   <div class="modal">
-    <div class="modal-box" style="max-width:34rem">
+    <div class="modal-box" style="max-width:36rem">
       <label id="close-modal" for="transcribe-modal" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
       <h3 class="font-bold text-lg"  style="margin-bottom:16px">Transcribe</h3>
       <div role="tablist" class="tabs tabs-lifted">
 
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:150px" aria-label="Whisper (Local)" checked />
+        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:165px; white-space:nowrap" aria-label="Parakeet (Beta)" checked />
+        <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
+          <client-parakeet-service templateSelector="#parakeet-local-template"></client-parakeet-service>
+        </div>
+
+        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:165px; white-space:nowrap" aria-label="Whisper (Beta)"  />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
           <client-whisper-service templateSelector="#whisper-client-template"></client-whisper-service>
         </div>
 
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:150px" aria-label="Deepgram (Cloud)"  />
+        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:165px; white-space:nowrap" aria-label="Deepgram"  />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
           <deepgram-service templateSelector="#deepgram-modal-template"></deepgram-service>
-        </div>
-
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:150px" aria-label="Parakeet (Local)"  />
-        <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
-          <client-parakeet-service templateSelector="#parakeet-local-template"></client-parakeet-service>
         </div>
 
       </div>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.7 (last changed in release 0.6.7) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.8 (last changed in release 0.6.8) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.7">
+  <meta name="version" content="0.6.8">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -27,6 +27,7 @@ If you are creating an open source application under a license compatible with t
  
   <script src="js/hyperaudio-lite-editor-deepgram.js?v=0.6.7"></script>
   <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.7"></script>
+  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.6.8"></script>
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js"></script>
 
@@ -181,6 +182,23 @@ If you are creating an open source application under a license compatible with t
       
       <div class="modal-action">
         <label id="form-submit-btn" for="transcribe-modal" class="btn btn-primary btn-disabled" aria-disabled="true">TRANSCRIBE</label>
+      </div>
+    </form>
+  </template>
+
+  <template id="parakeet-local-template">
+    <form>
+      <div class="mb-3">
+        <input id="parakeet-file-input" name="file" type="file" class="file-input w-full max-w-xs" />
+        <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
+      </div>
+      <div class="form-text" style="font-size: 90%;">
+        <p style="padding-top:8px">Parakeet TDT v3 runs entirely in your browser — no token, nothing uploaded.</p>
+        <p>The model downloads once and is cached (~650&nbsp;MB on CPU, ~1.2&nbsp;GB on GPU). Multilingual — the language is detected automatically.</p>
+        <p id="parakeet-device" style="opacity:0.7"></p>
+      </div>
+      <div class="modal-action">
+        <label id="parakeet-form-submit-btn" for="transcribe-modal" class="btn btn-primary btn-disabled" aria-disabled="true">TRANSCRIBE</label>
       </div>
     </form>
   </template>
@@ -583,19 +601,24 @@ If you are creating an open source application under a license compatible with t
 
   <input type="checkbox" id="transcribe-modal" class="modal-toggle" />
   <div class="modal">
-    <div class="modal-box">
+    <div class="modal-box" style="max-width:34rem">
       <label id="close-modal" for="transcribe-modal" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
       <h3 class="font-bold text-lg"  style="margin-bottom:16px">Transcribe</h3>
       <div role="tablist" class="tabs tabs-lifted">
 
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:160px" aria-label="Whisper (Local)" checked />
+        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:150px" aria-label="Whisper (Local)" checked />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
           <client-whisper-service templateSelector="#whisper-client-template"></client-whisper-service>
         </div>
-      
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:160px" aria-label="Deepgram (Cloud)"  />
+
+        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:150px" aria-label="Deepgram (Cloud)"  />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
           <deepgram-service templateSelector="#deepgram-modal-template"></deepgram-service>
+        </div>
+
+        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:150px" aria-label="Parakeet (Local)"  />
+        <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
+          <client-parakeet-service templateSelector="#parakeet-local-template"></client-parakeet-service>
         </div>
 
       </div>

--- a/js/hyperaudio-lite-editor-parakeet-local.js
+++ b/js/hyperaudio-lite-editor-parakeet-local.js
@@ -62,6 +62,20 @@ function loadParakeetClient(modal, workerBaseUrl) {
 
   const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=0.6.8";
 
+  // Firefox has no usable WebGPU here, so Parakeet runs on the CPU – it works
+  // but is several times slower than the audio. Say so up front, the same way
+  // the Whisper tab warns about Firefox.
+  if (/firefox/i.test(navigator.userAgent)) {
+    const form = modal.querySelector("form");
+    if (form !== null) {
+      const note = document.createElement("div");
+      note.setAttribute("role", "alert");
+      note.style.cssText = "background:#fff7e0; border-left:4px solid #f0a800; border-radius:4px; padding:8px 12px; margin-bottom:12px; font-size:85%;";
+      note.textContent = "Firefox: Parakeet runs on the CPU here and is much slower than the audio length – Chrome or Safari (GPU) is recommended.";
+      form.prepend(note);
+    }
+  }
+
   let webWorker = createWorker();
 
   // the button is a styled <label>, so "disabled" is the btn-disabled class
@@ -155,7 +169,7 @@ function loadParakeetClient(modal, workerBaseUrl) {
   function renderLoadingMessage() {
     const msg = document.querySelector("#hypertranscript .transcribing-msg");
     if (msg !== null) {
-      msg.textContent = `${progressMessage} (${formatElapsed(Date.now() - progressStart)})`;
+      msg.innerHTML = `${progressMessage} <span style="font-size:80%; opacity:0.55">(${formatElapsed(Date.now() - progressStart)})</span>`;
     }
   }
 

--- a/js/hyperaudio-lite-editor-parakeet-local.js
+++ b/js/hyperaudio-lite-editor-parakeet-local.js
@@ -1,0 +1,275 @@
+/**
+ * hyperaudio-lite-editor-parakeet-local.js
+ * (C) The Hyperaudio Project
+ * @version 0.6.8 — last changed in release 0.6.8
+ * @license MIT
+ */
+
+class ParakeetLocalService extends HTMLElement {
+
+  constructor() {
+    super();
+  }
+
+  connectedCallback() {
+
+    let template = null;
+    let modal = this;
+
+    const templateUrl = this.getAttribute("templateUrl");
+    const templateSelector = this.getAttribute("templateSelector");
+    const workerBaseUrl = this.getAttribute("workerBaseUrl");
+
+    if (templateUrl !== null) {
+      fetch(templateUrl)
+        .then(function(response) {
+            return response.text()
+        })
+        .then(function(html) {
+          let parser = new DOMParser();
+          template = parser.parseFromString(html, "text/html");
+          let parakeetTempl = template.querySelector('#parakeet-local-template').cloneNode(true);
+          modal.innerHTML = parakeetTempl.innerHTML;
+          loadParakeetClient(modal, workerBaseUrl);
+        })
+        .catch(function(err) {
+          console.log('Template error: ', err);
+        });
+    } else {
+      modal.innerHTML = document.querySelector(templateSelector).innerHTML;
+      document.querySelector(templateSelector).remove();
+      loadParakeetClient(modal, workerBaseUrl);
+    }
+  }
+}
+
+customElements.define('client-parakeet-service', ParakeetLocalService);
+
+function loadParakeetClient(modal, workerBaseUrl) {
+
+  console.log("loading parakeet local client");
+
+  // Distinct IDs from the Whisper tab: both templates live in the modal DOM
+  // at the same time, so shared IDs would collide.
+  const fileUploadBtn = document.getElementById("parakeet-file-input");
+  const formSubmitBtn = document.getElementById("parakeet-form-submit-btn");
+  const deviceLabel = document.getElementById("parakeet-device");
+  const videoPlayer = document.getElementById("hyperplayer");
+
+  if (workerBaseUrl === undefined || workerBaseUrl === null) {
+    workerBaseUrl = "./";
+  }
+
+  const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=0.6.8";
+
+  let webWorker = createWorker();
+
+  // the button is a styled <label>, so "disabled" is the btn-disabled class
+  // (pointer-events: none) plus a guard in the handler
+  function updateSubmitState() {
+    const ready = fileUploadBtn.files.length > 0;
+    formSubmitBtn.classList.toggle("btn-disabled", !ready);
+    formSubmitBtn.setAttribute("aria-disabled", String(!ready));
+  }
+  fileUploadBtn.addEventListener("change", updateSubmitState);
+  updateSubmitState();
+
+  formSubmitBtn.addEventListener("click", async () => {
+    if (formSubmitBtn.classList.contains("btn-disabled")) {
+      return;
+    }
+    await handleFormSubmission();
+  });
+
+  function createWorker() {
+    const worker = new Worker(parakeetWorkerPath, { type: "module" });
+
+    worker.onmessage = (event) => {
+      const data = event.data;
+      switch (data.type) {
+        case "progress":
+          updateLoadingMessage(data.phase === "download"
+            ? `Downloading model… ${data.progress}%`
+            : data.phase === "prepare"
+              ? "Preparing model…"
+              : data.progress === null
+                ? "Transcribing…"
+                : `Transcribing… ${data.progress}%`);
+          break;
+        case "device":
+          console.log(`Parakeet running on ${data.device} (${data.dtype})`);
+          lastDeviceLabel = data.device === "webgpu" ? "GPU (WebGPU)" : "CPU";
+          if (deviceLabel !== null) {
+            deviceLabel.textContent = `Running on ${lastDeviceLabel}`;
+          }
+          break;
+        case "result":
+          stopProgressClock();
+          if (typeof setTranscriptBusy === "function") {
+            setTranscriptBusy(false);
+          }
+          if (pendingInfo !== null && typeof setTranscriptionInfo === "function") {
+            setTranscriptionInfo({ ...pendingInfo, device: lastDeviceLabel, seconds: data.output.seconds });
+          }
+          videoPlayer.currentTime = 0;
+          parakeetParseData(data.output);
+          break;
+        case "error":
+          handleError(data.message);
+          break;
+      }
+    };
+
+    worker.onerror = (event) => {
+      console.error(event);
+      handleError(event.message || "The transcription worker crashed.");
+    };
+
+    return worker;
+  }
+
+  let progressTicker = null;
+  let progressStart = 0;
+  let progressMessage = "";
+  let lastDeviceLabel = "";
+  let pendingInfo = null;
+
+  function startProgressClock() {
+    progressStart = Date.now();
+    clearInterval(progressTicker);
+    progressTicker = setInterval(renderLoadingMessage, 1000);
+  }
+
+  function stopProgressClock() {
+    clearInterval(progressTicker);
+    progressTicker = null;
+  }
+
+  function formatElapsed(ms) {
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+  }
+
+  function renderLoadingMessage() {
+    const msg = document.querySelector("#hypertranscript .transcribing-msg");
+    if (msg !== null) {
+      msg.textContent = `${progressMessage} (${formatElapsed(Date.now() - progressStart)})`;
+    }
+  }
+
+  function updateLoadingMessage(message) {
+    progressMessage = message;
+    renderLoadingMessage();
+  }
+
+  function handleError(message) {
+    stopProgressClock();
+    if (typeof setTranscriptBusy === "function") {
+      setTranscriptBusy(false);
+    }
+    console.error("Parakeet error: " + message);
+    const detail = message ? '<br/><span style="font-size:80%; opacity:0.7">'+String(message).slice(0, 200)+'</span>' : '';
+    document.getElementById("hypertranscript").innerHTML =
+      '<div class="vertically-centre"><img src="'+errorSvg+'" width="50" alt="error" style="margin: auto; display: block;"><br/><center>Sorry.<br/>Transcription failed.<br/>Reload the page and try again.'+detail+'</center></div>';
+  }
+
+  async function handleFormSubmission() {
+
+    // If the user is in caption mode, switch back to transcript view so the
+    // transcribing loader is visible and the result lands in the right place.
+    document.querySelector('#transcript-editor-btn')?.click();
+
+    const file = fileUploadBtn.files[0];
+
+    pendingInfo = {
+      service: "Parakeet (local, in your browser)",
+      model: "Parakeet TDT 0.6B v3 (multilingual)",
+      language: "Auto-detect",
+    };
+
+    videoPlayer.src = URL.createObjectURL(file);
+
+    if (document.querySelector('#transcribe-dialog') !== null){
+      document.querySelector('#transcribe-dialog').close();
+    }
+
+    const loadingMessageContainer = document.getElementById("hypertranscript");
+    loadingMessageContainer.innerHTML = '<div class="vertically-centre"><center class="transcribing-msg">Preparing model…</center><br/><img src="'+transcribingSvg+'" width="50" alt="transcribing" style="margin: auto; display: block;"></div>';
+    if (typeof setTranscriptBusy === "function") {
+      setTranscriptBusy(true);
+    }
+    progressMessage = "Preparing model…";
+    startProgressClock();
+
+    let audio;
+    try {
+      audio = await readAudioFrom(file);
+    } catch (e) {
+      console.error(e);
+      handleError("Could not decode the media file.");
+      return;
+    }
+
+    // transfer the buffer rather than copying it
+    webWorker.postMessage({ type: "INFERENCE_REQUEST", audio }, [audio.buffer]);
+  }
+
+  async function readAudioFrom(file) {
+    const sampling_rate = 16e3;
+    const audioCTX = new AudioContext({ sampleRate: sampling_rate });
+    try {
+      const response = await file.arrayBuffer();
+      const decoded = await audioCTX.decodeAudioData(response);
+      return decoded.getChannelData(0);
+    } finally {
+      audioCTX.close();
+    }
+  }
+}
+
+// Build the editor's word-span HTML from { words: [{ word, start, end }] }.
+// Adapted from the cloud Parakeet module (#307): local transcription has no
+// diarization, so there are no speaker spans and no VTT language label.
+function parakeetParseData(json) {
+
+  const maxWordsInPara = 100;
+  const significantGapInSeconds = 4.0;
+
+  const wordData = json.words;
+  const ms = (s) => Math.round(s * 1000);
+
+  let hyperTranscript = "<article>\n <section>\n  <p>\n   ";
+  let previousElementEnd = 0;
+  let wordsInPara = 0;
+
+  wordData.forEach((element, index) => {
+    const currentWord = element.word;
+    wordsInPara++;
+
+    // split into a new paragraph on a significant silence gap after sentence-end
+    if (previousElementEnd !== 0 && (element.start - previousElementEnd) > significantGapInSeconds || wordsInPara > maxWordsInPara) {
+      const previousWord = wordData[index - 1].word;
+      const previousWordLastChar = previousWord.charAt(previousWord.length - 1);
+      if (previousWordLastChar === "." || previousWordLastChar === "?" || previousWordLastChar === "!") {
+        hyperTranscript += "\n  </p>\n  <p>\n   ";
+        wordsInPara = 0;
+      }
+    }
+
+    hyperTranscript += `<span data-m='${ms(element.start)}' data-d='${ms(element.end - element.start)}'>${currentWord} </span>`;
+    previousElementEnd = element.end;
+  });
+
+  hyperTranscript += "\n </p> \n </section>\n</article>\n ";
+  hyperTranscript = hyperTranscript.replace(/<p>\s*<\/p>\s*/g, '');
+
+  document.querySelector("#hypertranscript").innerHTML = hyperTranscript;
+  document.querySelector('#download-html').setAttribute('href', 'data:text/html,' + encodeURIComponent(hyperTranscript));
+
+  const initEvent = new CustomEvent('hyperaudioInit');
+  document.dispatchEvent(initEvent);
+  const capEvent = new CustomEvent('hyperaudioGenerateCaptionsFromTranscript');
+  document.dispatchEvent(capEvent);
+}

--- a/js/parakeet.worker.js
+++ b/js/parakeet.worker.js
@@ -63,6 +63,10 @@ async function hasGpuAdapter() {
 }
 
 // Fetch a model with progress, caching it so the (large) download is one-time.
+// A 652MB download holds one connection open for ~100s+, so a single mid-stream
+// network drop must not mean starting over: on failure we resume from the byte
+// we reached via an HTTP Range request, keeping the chunks already in hand.
+const MAX_DOWNLOAD_ATTEMPTS = 5;
 async function fetchModel(url, onProgress) {
   const cache = await caches.open(CACHE_NAME);
   const hit = await cache.match(url);
@@ -70,21 +74,67 @@ async function fetchModel(url, onProgress) {
     onProgress(url, 1, 1);
     return new Uint8Array(await hit.arrayBuffer());
   }
-  const resp = await fetch(url);
-  if (!resp.ok) {
-    throw new Error(`Download failed (${resp.status}) for ${url.split("/").pop()}`);
+
+  let parts = [];
+  let loaded = 0, total = 0;
+  let lastErr = null;
+  let complete = false;
+  for (let attempt = 0; attempt < MAX_DOWNLOAD_ATTEMPTS && !complete; attempt++) {
+    if (attempt > 0) {
+      await new Promise((r) => setTimeout(r, 1000 * attempt));   // brief backoff before resuming
+    }
+    // cache:"no-store" bypasses the browser HTTP cache: we keep our own copy in
+    // Cache Storage, so a duplicate 652MB disk-cache entry only wastes space and
+    // (with HF's redirect to a signed CDN url) causes flaky partial reads and
+    // stale-redirect CORS failures on resume.
+    const init = { cache: "no-store" };
+    if (loaded > 0) init.headers = { Range: `bytes=${loaded}-` };
+    let resp;
+    try {
+      resp = await fetch(url, init);
+    } catch (e) {
+      lastErr = e;   // couldn't even open the connection — retry (same offset resumes)
+      continue;
+    }
+    if (resp.status === 416) {
+      // our offset is at/past EOF: either we already hold the whole file, or
+      // `loaded` is stale — start over in that case.
+      if (total && loaded >= total) { complete = true; break; }
+      parts = []; loaded = 0; lastErr = new Error("range not satisfiable"); continue;
+    }
+    if (!resp.ok) {
+      // 5xx / 429 may be transient; anything else (404, 403…) is fatal, fail fast.
+      if (resp.status >= 500 || resp.status === 429) { lastErr = new Error(`status ${resp.status}`); continue; }
+      throw new Error(`Download failed (${resp.status}) for ${url.split("/").pop()}`);
+    }
+    // If we asked to resume but the server ignored Range (200, not 206), it is
+    // re-sending the whole file — discard what we had and start clean.
+    if (loaded > 0 && resp.status !== 206) { parts = []; loaded = 0; }
+    if (!total) {
+      const cr = resp.headers.get("content-range");   // "bytes start-end/total" on a 206
+      total = cr ? Number(cr.split("/")[1]) : (Number(resp.headers.get("content-length")) || 0);
+    }
+    try {
+      const reader = resp.body.getReader();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        parts.push(value);
+        loaded += value.length;
+        onProgress(url, loaded, total);
+      }
+      complete = true;   // stream finished cleanly
+    } catch (e) {
+      lastErr = e;   // stream dropped — but a drop right at the end may have left it whole
+      if (total && loaded >= total) complete = true;
+      // otherwise the next attempt resumes from `loaded`
+    }
   }
-  const total = Number(resp.headers.get("content-length")) || 0;
-  const reader = resp.body.getReader();
-  const parts = [];
-  let loaded = 0;
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    parts.push(value);
-    loaded += value.length;
-    onProgress(url, loaded, total);
+  if (!complete) {
+    console.error("Model download failed after retries:", lastErr?.message || lastErr);
+    throw new Error("Model download interrupted — please check your connection.");
   }
+
   const bytes = new Uint8Array(loaded);
   let off = 0;
   for (const p of parts) { bytes.set(p, off); off += p.length; }

--- a/js/parakeet.worker.js
+++ b/js/parakeet.worker.js
@@ -183,7 +183,15 @@ async function transcribe(s, audio) {
     const offsetSeconds = offsetSamples / SAMPLE_RATE;
     const win = audio.subarray(offsetSamples, offsetSamples + windowSamples);
     const windowWords = await transcribeWindow(s, win, offsetSeconds);
-    words = i === 0 ? windowWords : dedupeSeam(words, windowWords);
+    if (i === 0) {
+      words = windowWords;
+    } else {
+      // both windows transcribe the OVERLAP_S overlap [offsetSeconds, offsetSeconds+OVERLAP_S];
+      // cut at its midpoint so each word survives exactly once (time-based, so
+      // legitimate within-window repeats are untouched)
+      const cut = offsetSeconds + OVERLAP_S / 2;
+      words = words.filter((w) => w.start < cut).concat(windowWords.filter((w) => w.start >= cut));
+    }
     self.postMessage({
       type: "progress",
       phase: "transcribe",
@@ -255,15 +263,3 @@ async function transcribeWindow(s, samples, offsetSeconds) {
   return words;
 }
 
-// Merge two overlapping windows: drop a word from the new window if it repeats
-// the previous kept word within 0.5s (the overlap is transcribed by both).
-function dedupeSeam(prev, next) {
-  if (next.length === 0) return prev;
-  const merged = prev.slice();
-  for (const w of next) {
-    const tail = merged[merged.length - 1];
-    if (tail && w.word === tail.word && Math.abs(w.start - tail.start) < 0.5) continue;
-    merged.push(w);
-  }
-  return merged;
-}

--- a/js/parakeet.worker.js
+++ b/js/parakeet.worker.js
@@ -1,0 +1,269 @@
+/**
+ * parakeet.worker.js
+ * (C) The Hyperaudio Project
+ * @version 0.6.8 — last changed in release 0.6.8
+ * @license MIT
+ */
+
+import * as ort from "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0/dist/ort.all.min.mjs";
+ort.env.wasm.wasmPaths = "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0/dist/";
+ort.env.wasm.numThreads = self.crossOriginIsolated ? (self.navigator?.hardwareConcurrency || 4) : 1;
+
+const SAMPLE_RATE = 16000;
+const WINDOW_S = 300;        // 5-minute windows to bound memory
+const OVERLAP_S = 10;        // each seam transcribed by both windows
+const D = 1024;              // encoder hidden dim
+const VOCAB_SIZE = 8193;     // token logits; index 8192 is <blk>
+const BLANK = 8192;
+const STATE_DIM = 640;       // decoder predict-net state width
+const MAX_SYMBOLS = 10;      // max tokens emitted on a single frame
+const FRAME_SEC = 0.08;      // 8x subsampling * 10ms hop
+
+const HF = "https://huggingface.co";
+const MODELS = {
+  mel: `${HF}/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/nemo128.onnx`,
+  decoder: `${HF}/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/decoder_joint-model.int8.onnx`,
+  vocab: `${HF}/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/vocab.txt`,
+  encoderInt8: `${HF}/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/encoder-model.int8.onnx`,
+  encoderFp16: `${HF}/ako101/parakeet-tdt-0.6b-v3-sherpa-onnx-fp16/resolve/main/encoder.fp16.onnx`,
+};
+const CACHE_NAME = "parakeet-models-v1";
+
+let sessions = null;   // { mel, encoder, decoder, vocab, device }
+
+self.addEventListener("message", async (event) => {
+  if (event.data?.type !== "INFERENCE_REQUEST") {
+    return;
+  }
+  try {
+    if (sessions === null) {
+      sessions = await loadSessions();
+    }
+    const output = await transcribe(sessions, event.data.audio);
+    self.postMessage({ type: "result", output });
+  } catch (e) {
+    console.error(e);
+    const stage = sessions === null ? "load" : "transcribe";
+    self.postMessage({ type: "error", stage, message: e?.message || String(e) });
+  }
+});
+
+// navigator.gpu existing does not mean a usable GPU exists (headless and
+// GPU-less machines expose the API but yield no adapter), so it must be
+// ruled out before attempting a WebGPU session, not after failing.
+async function hasGpuAdapter() {
+  try {
+    if (!self.navigator?.gpu) {
+      return false;
+    }
+    return (await self.navigator.gpu.requestAdapter()) !== null;
+  } catch (e) {
+    return false;
+  }
+}
+
+// Fetch a model with progress, caching it so the (large) download is one-time.
+async function fetchModel(url, onProgress) {
+  const cache = await caches.open(CACHE_NAME);
+  const hit = await cache.match(url);
+  if (hit) {
+    onProgress(url, 1, 1);
+    return new Uint8Array(await hit.arrayBuffer());
+  }
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    throw new Error(`Download failed (${resp.status}) for ${url.split("/").pop()}`);
+  }
+  const total = Number(resp.headers.get("content-length")) || 0;
+  const reader = resp.body.getReader();
+  const parts = [];
+  let loaded = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    parts.push(value);
+    loaded += value.length;
+    onProgress(url, loaded, total);
+  }
+  const bytes = new Uint8Array(loaded);
+  let off = 0;
+  for (const p of parts) { bytes.set(p, off); off += p.length; }
+  try {
+    await cache.put(url, new Response(bytes, { headers: { "content-length": String(loaded) } }));
+  } catch (e) {
+    // QuotaExceededError etc. – use the in-memory bytes this session, re-download next time
+    console.warn("Model cache write failed (will re-download next time):", e?.message || e);
+  }
+  return bytes;
+}
+
+// Aggregate download progress across the model files (encoder dominates).
+function makeDownloadProgress() {
+  const files = new Map();
+  let last = -1;
+  return (url, loaded, total) => {
+    if (!total) return;
+    files.set(url, { loaded, total });
+    let l = 0, t = 0;
+    files.forEach((f) => { l += f.loaded; t += f.total; });
+    const percent = Math.floor((l / t) * 100);
+    if (percent !== last) {
+      last = percent;
+      self.postMessage({ type: "progress", phase: "download", progress: percent });
+    }
+  };
+}
+
+async function loadSessions() {
+  const onProgress = makeDownloadProgress();
+  const useWebGpu = !/firefox/i.test(self.navigator?.userAgent || "") && (await hasGpuAdapter());
+
+  // mel + decoder always run on WASM (decoder loop is sequential and cheap –
+  // keeping it off the GPU avoids per-token round-trips).
+  const [melBytes, decBytes, vocabBytes] = await Promise.all([
+    fetchModel(MODELS.mel, onProgress),
+    fetchModel(MODELS.decoder, onProgress),
+    fetchModel(MODELS.vocab, onProgress),
+  ]);
+  const mel = await ort.InferenceSession.create(melBytes, { executionProviders: ["wasm"] });
+  const decoder = await ort.InferenceSession.create(decBytes, { executionProviders: ["wasm"] });
+  const vocab = new TextDecoder().decode(vocabBytes).split("\n").map((l) => l.slice(0, l.lastIndexOf(" ")));
+
+  let encoder, device, dtype;
+  if (useWebGpu) {
+    try {
+      const encBytes = await fetchModel(MODELS.encoderFp16, onProgress);
+      self.postMessage({ type: "progress", phase: "prepare" });
+      encoder = await ort.InferenceSession.create(encBytes, { executionProviders: ["webgpu"] });
+      await warmUp(encoder);
+      device = "webgpu"; dtype = "fp16";
+    } catch (e) {
+      console.warn("WebGPU encoder unavailable, falling back to WASM/int8:", e?.message || e);
+      encoder = null;
+    }
+  }
+  if (!encoder) {
+    const encBytes = await fetchModel(MODELS.encoderInt8, onProgress);
+    self.postMessage({ type: "progress", phase: "prepare" });
+    encoder = await ort.InferenceSession.create(encBytes, { executionProviders: ["wasm"] });
+    device = "wasm"; dtype = "int8";
+  }
+
+  console.log(`Parakeet ready on ${device} (${dtype})`);
+  self.postMessage({ type: "device", device, dtype });
+  return { mel, encoder, decoder, vocab, device };
+}
+
+// Push a short silent clip through the encoder so WebGPU shader compilation
+// (and any inference-time failure) happens now, under "Preparing model…".
+async function warmUp(encoder) {
+  const len = 100;
+  await encoder.run({
+    audio_signal: new ort.Tensor("float32", new Float32Array(128 * len), [1, 128, len]),
+    length: new ort.Tensor("int64", BigInt64Array.from([BigInt(len)]), [1]),
+  });
+}
+
+async function transcribe(s, audio) {
+  const startedAt = Date.now();
+  const windowSamples = WINDOW_S * SAMPLE_RATE;
+  const stepSamples = (WINDOW_S - OVERLAP_S) * SAMPLE_RATE;
+  const windowCount = audio.length <= windowSamples
+    ? 1
+    : Math.ceil((audio.length - windowSamples) / stepSamples) + 1;
+
+  let words = [];
+  for (let i = 0; i < windowCount; i++) {
+    self.postMessage({
+      type: "progress",
+      phase: "transcribe",
+      progress: windowCount > 1 ? Math.round((i / windowCount) * 100) : null,
+    });
+    const offsetSamples = i * stepSamples;
+    const offsetSeconds = offsetSamples / SAMPLE_RATE;
+    const win = audio.subarray(offsetSamples, offsetSamples + windowSamples);
+    const windowWords = await transcribeWindow(s, win, offsetSeconds);
+    words = i === 0 ? windowWords : dedupeSeam(words, windowWords);
+    self.postMessage({
+      type: "progress",
+      phase: "transcribe",
+      progress: windowCount > 1 ? Math.round(((i + 1) / windowCount) * 100) : null,
+    });
+  }
+
+  const seconds = (Date.now() - startedAt) / 1000;
+  console.log(`Parakeet transcription took ${seconds.toFixed(1)}s for ${(audio.length / SAMPLE_RATE).toFixed(1)}s of audio (${s.device})`);
+  return { words, seconds };
+}
+
+async function transcribeWindow(s, samples, offsetSeconds) {
+  // 1. mel features
+  const mel = await s.mel.run({
+    waveforms: new ort.Tensor("float32", samples.slice(), [1, samples.length]),
+    waveforms_lens: new ort.Tensor("int64", BigInt64Array.from([BigInt(samples.length)]), [1]),
+  });
+  // 2. encoder
+  const encT0 = Date.now();
+  const enc = await s.encoder.run({ audio_signal: mel.features, length: mel.features_lens });
+  const encData = enc.outputs.data;            // [1, D, T']
+  const Tp = enc.outputs.dims[2];
+  const encLen = Number(enc.encoded_lengths.data[0]);
+  const encMs = Date.now() - encT0;
+  const decT0 = Date.now();
+  const frame = (t) => { const f = new Float32Array(D); for (let d = 0; d < D; d++) f[d] = encData[d * Tp + t]; return f; };
+
+  // 3. TDT greedy decode loop
+  const mkState = () => new ort.Tensor("float32", new Float32Array(2 * STATE_DIM), [2, 1, STATE_DIM]);
+  let s1 = mkState(), s2 = mkState();
+  const tokens = [], stamps = [];
+  let t = 0, emitted = 0, last = BLANK;
+  while (t < encLen) {
+    const r = await s.decoder.run({
+      encoder_outputs: new ort.Tensor("float32", frame(t), [1, D, 1]),
+      targets: new ort.Tensor("int32", Int32Array.from([last]), [1, 1]),
+      target_length: new ort.Tensor("int32", Int32Array.from([1]), [1]),
+      input_states_1: s1,
+      input_states_2: s2,
+    });
+    const o = r.outputs.data;
+    let tok = 0, bv = -Infinity;
+    for (let i = 0; i < VOCAB_SIZE; i++) if (o[i] > bv) { bv = o[i]; tok = i; }
+    let step = 0, dv = -Infinity;
+    for (let i = VOCAB_SIZE; i < o.length; i++) if (o[i] > dv) { dv = o[i]; step = i - VOCAB_SIZE; }
+    if (tok !== BLANK) { s1 = r.output_states_1; s2 = r.output_states_2; tokens.push(tok); stamps.push(t); last = tok; emitted++; }
+    if (step > 0) { t += step; emitted = 0; }
+    else if (tok === BLANK || emitted === MAX_SYMBOLS) { t += 1; emitted = 0; }
+  }
+
+  console.log(`  window: encoder ${encMs}ms, decode ${Date.now() - decT0}ms (${encLen} frames)`);
+
+  // 4. tokens -> words (▁ marks a word start); times offset by window start
+  const words = [];
+  let cur = null;
+  for (let i = 0; i < tokens.length; i++) {
+    const piece = s.vocab[tokens[i]] ?? "";
+    const sec = offsetSeconds + stamps[i] * FRAME_SEC;
+    if (piece.startsWith("▁") || !cur) {
+      if (cur) words.push(cur);
+      cur = { word: piece.replace(/▁/g, ""), start: sec, end: sec + FRAME_SEC };
+    } else {
+      cur.word += piece;
+      cur.end = sec + FRAME_SEC;
+    }
+  }
+  if (cur) words.push(cur);
+  return words;
+}
+
+// Merge two overlapping windows: drop a word from the new window if it repeats
+// the previous kept word within 0.5s (the overlap is transcribed by both).
+function dedupeSeam(prev, next) {
+  if (next.length === 0) return prev;
+  const merged = prev.slice();
+  for (const w of next) {
+    const tail = merged[merged.length - 1];
+    if (tail && w.word === tail.word && Math.abs(w.start - tail.start) < 0.5) continue;
+    merged.push(w);
+  }
+  return merged;
+}


### PR DESCRIPTION
## Summary

Adds a third transcribe-modal tab, **Parakeet (Beta)** — NVIDIA Parakeet TDT 0.6B v3 running entirely in the browser via onnxruntime-web, zero-token, nothing uploaded — alongside Whisper (Beta) and Deepgram. Targets the **0.6.8** release. Closes #325.

## What it does

- **WebGPU (fp16)** on Chrome/Safari (~20× realtime on an M4 Pro); **WASM (int8)** CPU fallback elsewhere. Capability detection mirrors the Whisper tab; Firefox is forced to WASM (its WebGPU underperforms).
- Multilingual, language **auto-detected** — no model/language selectors.
- **5-minute windowed inference** with a time-based seam cut for long files (verified on a 44-min file).
- **One-time model download** (~650 MB CPU / ~1.2 GB GPU), cached in Cache Storage.

## Pipeline

`mel (nemo128)` → `encoder (fp16 webgpu / int8 wasm)` → **TDT greedy decode loop** → words with timings. Models: istupakov int8 + ako101 fp16 encoder, fetched from HuggingFace `resolve/main` (CORS-open, not mirrored).

## Reliability

- **Resilient model download**: resumes a dropped 652 MB download from the last byte via HTTP `Range`; bypasses the browser HTTP cache (`no-store`) to avoid a duplicate disk copy and stale-redirect/partial-read failures; treats `416` as complete-or-restart rather than fatal; surfaces a clear "download interrupted" message.

## UI

- Tabs reordered to **Parakeet (Beta) · Whisper (Beta) · Deepgram**, Parakeet default.
- Prominent **Firefox-only CPU warning** banner (mirrors Whisper).
- Elapsed timer rendered small/grey so a slow CPU run does not look parked at 0%.
- Suppressed the lingering native file-input tooltip.

## Verification

- Headless Chromium **and Firefox** e2e: correct transcript + word spans, editing locked during run, no regressions to Whisper/Deepgram.
- Range-resume: forced a 300 MB mid-stream drop → reassembled file is **SHA-256 identical** to the original.
- Real-browser (M4 Pro Chrome): WebGPU fp16 path, 58s file ≈ 2.7s, 44-min file ≈ 2m32s.
- Firefox WASM path works (~4.7× audio length on CPU) with the warning shown.

## Notes

- New files at `@version 0.6.8` with `?v=0.6.8` cache-busts; Whisper/Deepgram untouched (still 0.6.7).
- The TDT decode loop and both model sets were validated during the #309 spike.
