### PR TITLE
Parakeet 0.6.9: safe-default + GPU opt-in, lower memory, progress polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.8 (last changed in release 0.6.8) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.9 (last changed in release 0.6.9) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.8">
+  <meta name="version" content="0.6.9">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -26,8 +26,8 @@ If you are creating an open source application under a license compatible with t
   <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
  
   <script src="js/hyperaudio-lite-editor-deepgram.js?v=0.6.7"></script>
-  <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.7"></script>
-  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.6.8"></script>
+  <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.9"></script>
+  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.6.9"></script>
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js"></script>
 

--- a/js/hyperaudio-lite-editor-parakeet-local.js
+++ b/js/hyperaudio-lite-editor-parakeet-local.js
@@ -1,7 +1,7 @@
 /**
  * hyperaudio-lite-editor-parakeet-local.js
  * (C) The Hyperaudio Project
- * @version 0.6.8 — last changed in release 0.6.8
+ * @version 0.6.9 — last changed in release 0.6.9
  * @license MIT
  */
 
@@ -60,18 +60,53 @@ function loadParakeetClient(modal, workerBaseUrl) {
     workerBaseUrl = "./";
   }
 
-  const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=0.6.8";
+  const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=0.6.9";
 
-  // Firefox has no usable WebGPU here, so Parakeet runs on the CPU – it works
-  // but is several times slower than the audio. Say so up front, the same way
-  // the Whisper tab warns about Firefox.
-  if (/firefox/i.test(navigator.userAgent)) {
+  // On Chrome (Chromium) Parakeet runs fp16 on the GPU (WebGPU) – fast, and the
+  // default. Firefox's WebGPU underperforms here and Safari's can exhaust memory
+  // on the large encoder (it has locked up the whole machine), so both default
+  // to the smaller int8 encoder on the CPU – it works but is several times
+  // slower than the audio. We still let the user opt in to the GPU path with a
+  // proportional warning, so capable setups can use it and we can gather
+  // real-world cases for browser makers. `gpuOptIn` is read at submit time.
+  const ua = navigator.userAgent;
+  const isFirefox = /firefox/i.test(ua);
+  const isSafari = /safari/i.test(ua) && !/chrome|chromium|crios|edg|opr|android|fxios/i.test(ua);
+  let gpuOptIn = null;
+  if (isFirefox || isSafari) {
     const form = modal.querySelector("form");
     if (form !== null) {
+      const browser = isSafari ? "Safari" : "Firefox";
       const note = document.createElement("div");
       note.setAttribute("role", "alert");
       note.style.cssText = "background:#fff7e0; border-left:4px solid #f0a800; border-radius:4px; padding:8px 12px; margin-bottom:12px; font-size:85%;";
-      note.textContent = "Firefox: Parakeet runs on the CPU here and is much slower than the audio length – Chrome or Safari (GPU) is recommended.";
+
+      const intro = document.createElement("div");
+      intro.textContent = `${browser}: Parakeet runs on the CPU here and is much slower than the audio length – Chrome is recommended for GPU acceleration.`;
+      note.appendChild(intro);
+
+      const optLabel = document.createElement("label");
+      optLabel.style.cssText = "display:flex; align-items:center; gap:6px; margin-top:8px; cursor:pointer;";
+      gpuOptIn = document.createElement("input");
+      gpuOptIn.type = "checkbox";
+      gpuOptIn.id = "parakeet-gpu-optin";
+      optLabel.appendChild(gpuOptIn);
+      optLabel.appendChild(document.createTextNode("Try GPU acceleration (experimental)"));
+      note.appendChild(optLabel);
+
+      const warn = document.createElement("div");
+      warn.style.cssText = "display:none; margin-top:6px; font-weight:600; color:#9a3412;";
+      // Proportional to the failure mode: Safari can take the whole OS down;
+      // Firefox stays contained (errors / poor performance).
+      warn.textContent = isSafari
+        ? "⚠️ On Safari this can use enough memory to freeze your entire computer – you may lose unsaved work in other apps. Save everything first. Enabling it helps us report real-world cases to browser makers."
+        : "⚠️ Firefox's WebGPU is experimental here and may error or run poorly (it should not crash your OS). Enabling it helps us report real-world cases to browser makers.";
+      note.appendChild(warn);
+
+      gpuOptIn.addEventListener("change", () => {
+        warn.style.display = gpuOptIn.checked ? "block" : "none";
+      });
+
       form.prepend(note);
     }
   }
@@ -101,15 +136,19 @@ function loadParakeetClient(modal, workerBaseUrl) {
     worker.onmessage = (event) => {
       const data = event.data;
       switch (data.type) {
-        case "progress":
+        case "progress": {
+          // data.kind ("GPU"/"CPU") names the model build so it's clear which one
+          // is downloading – and obvious if both ever download in one session.
+          const model = data.kind ? `${data.kind} model` : "model";
           updateLoadingMessage(data.phase === "download"
-            ? `Downloading model… ${data.progress}%`
+            ? `Downloading ${model}… ${data.progress}%`
             : data.phase === "prepare"
-              ? "Preparing model…"
+              ? `Preparing ${model}…`
               : data.progress === null
                 ? "Transcribing…"
                 : `Transcribing… ${data.progress}%`);
           break;
+        }
         case "device":
           console.log(`Parakeet running on ${data.device} (${data.dtype})`);
           lastDeviceLabel = data.device === "webgpu" ? "GPU (WebGPU)" : "CPU";
@@ -226,8 +265,12 @@ function loadParakeetClient(modal, workerBaseUrl) {
       return;
     }
 
+    // forceGpu: the user explicitly opted in to the GPU path on a browser we'd
+    // otherwise keep on the CPU (only present on Firefox/Safari).
+    const forceGpu = gpuOptIn !== null && gpuOptIn.checked;
+
     // transfer the buffer rather than copying it
-    webWorker.postMessage({ type: "INFERENCE_REQUEST", audio }, [audio.buffer]);
+    webWorker.postMessage({ type: "INFERENCE_REQUEST", audio, forceGpu }, [audio.buffer]);
   }
 
   async function readAudioFrom(file) {

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -1,7 +1,7 @@
 /**
  * hyperaudio-lite-editor-whisper.js
  * (C) The Hyperaudio Project
- * @version 0.6.7 — last changed in release 0.6.7
+ * @version 0.6.9 — last changed in release 0.6.9
  * @license MIT
  */
 
@@ -168,7 +168,7 @@ function loadWhisperClient(modal, workerBaseUrl) {
   function renderLoadingMessage() {
     const msg = document.querySelector("#hypertranscript .transcribing-msg");
     if (msg !== null) {
-      msg.textContent = `${progressMessage} (${formatElapsed(Date.now() - progressStart)})`;
+      msg.innerHTML = `${progressMessage} <span style="font-size:80%; opacity:0.55">(${formatElapsed(Date.now() - progressStart)})</span>`;
     }
   }
 

--- a/js/parakeet.worker.js
+++ b/js/parakeet.worker.js
@@ -1,7 +1,7 @@
 /**
  * parakeet.worker.js
  * (C) The Hyperaudio Project
- * @version 0.6.8 — last changed in release 0.6.8
+ * @version 0.6.9 — last changed in release 0.6.9
  * @license MIT
  */
 
@@ -29,15 +29,22 @@ const MODELS = {
 };
 const CACHE_NAME = "parakeet-models-v1";
 
-let sessions = null;   // { mel, encoder, decoder, vocab, device }
+let sessions = null;        // { mel, encoder, decoder, vocab, device }
+let sessionsForceGpu = null; // the forceGpu flag the current sessions were built with
 
 self.addEventListener("message", async (event) => {
   if (event.data?.type !== "INFERENCE_REQUEST") {
     return;
   }
+  const forceGpu = event.data.forceGpu === true;
   try {
-    if (sessions === null) {
-      sessions = await loadSessions();
+    // Rebuild if the GPU opt-in changed since the sessions were created, so the
+    // user can toggle GPU/CPU without reloading the page.
+    if (sessions === null || sessionsForceGpu !== forceGpu) {
+      if (sessions !== null) await releaseSessions(sessions);
+      sessions = null;
+      sessions = await loadSessions(forceGpu);
+      sessionsForceGpu = forceGpu;
     }
     const output = await transcribe(sessions, event.data.audio);
     self.postMessage({ type: "result", output });
@@ -47,6 +54,13 @@ self.addEventListener("message", async (event) => {
     self.postMessage({ type: "error", stage, message: e?.message || String(e) });
   }
 });
+
+// Free the GPU/WASM buffers held by a session set before building a new one.
+async function releaseSessions(s) {
+  for (const k of ["mel", "encoder", "decoder"]) {
+    try { await s[k]?.release?.(); } catch (_) {}
+  }
+}
 
 // navigator.gpu existing does not mean a usable GPU exists (headless and
 // GPU-less machines expose the API but yield no adapter), so it must be
@@ -62,60 +76,104 @@ async function hasGpuAdapter() {
   }
 }
 
-// Fetch a model with progress, caching it so the (large) download is one-time.
-// A 652MB download holds one connection open for ~100s+, so a single mid-stream
-// network drop must not mean starting over: on failure we resume from the byte
-// we reached via an HTTP Range request, keeping the chunks already in hand.
+// Fetch a model, caching it so the (large) download is one-time.
+//
+// Preferred path streams the bytes straight into Cache Storage so the whole
+// model never sits in JS memory: the old "collect every chunk then copy into one
+// Uint8Array" assembly peaked at ~2× the file size (~2.5 GB for the fp16
+// encoder) and tripped Safari's per-tab memory limit even on a tiny audio file.
+// The session still needs the bytes, but only once (read back from cache), not
+// twice. We fall back to an in-memory download only if Cache Storage can't be
+// written (quota / private mode). Trade-off vs the previous code: a mid-stream
+// drop now retries the whole file rather than resuming from the dropped byte —
+// keeping the memory low matters more here than saving a re-download.
 const MAX_DOWNLOAD_ATTEMPTS = 5;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
 async function fetchModel(url, onProgress) {
+  const name = url.split("/").pop();
   const cache = await caches.open(CACHE_NAME);
   const hit = await cache.match(url);
   if (hit) {
+    console.log(`Parakeet: ${name} — from cache`);
     onProgress(url, 1, 1);
     return new Uint8Array(await hit.arrayBuffer());
   }
+  console.log(`Parakeet: downloading ${name}…`);
+  if (await streamDownloadToCache(cache, url, onProgress)) {
+    const stored = await cache.match(url);
+    if (stored) return new Uint8Array(await stored.arrayBuffer());
+  }
+  console.warn("Cache Storage unavailable — downloading model to memory for this session.");
+  return downloadToMemory(url, onProgress);
+}
 
-  let parts = [];
-  let loaded = 0, total = 0;
-  let lastErr = null;
-  let complete = false;
-  for (let attempt = 0; attempt < MAX_DOWNLOAD_ATTEMPTS && !complete; attempt++) {
-    if (attempt > 0) {
-      await new Promise((r) => setTimeout(r, 1000 * attempt));   // brief backoff before resuming
-    }
-    // cache:"no-store" bypasses the browser HTTP cache: we keep our own copy in
-    // Cache Storage, so a duplicate 652MB disk-cache entry only wastes space and
-    // (with HF's redirect to a signed CDN url) causes flaky partial reads and
-    // stale-redirect CORS failures on resume.
-    const init = { cache: "no-store" };
-    if (loaded > 0) init.headers = { Range: `bytes=${loaded}-` };
-    let resp;
+// Common request setup: bypass the browser HTTP cache (we keep our own copy in
+// Cache Storage; a duplicate disk-cache entry only wastes space and, with HF's
+// redirect to a signed CDN url, causes flaky partial reads). Returns the
+// response, or null to signal "retry", or throws on a fatal status.
+async function openModelStream(url) {
+  let resp;
+  try {
+    resp = await fetch(url, { cache: "no-store" });
+  } catch (e) {
+    return null;   // couldn't open the connection — retry
+  }
+  if (!resp.ok) {
+    if (resp.status >= 500 || resp.status === 429) return null;   // transient — retry
+    throw new Error(`Download failed (${resp.status}) for ${url.split("/").pop()}`);
+  }
+  return resp;
+}
+
+// Stream the download through a byte counter directly into the Cache. Returns
+// true once stored; false if the cache itself can't be written (→ caller falls
+// back to memory). Retries the whole file on a transient network drop.
+async function streamDownloadToCache(cache, url, onProgress) {
+  for (let attempt = 0; attempt < MAX_DOWNLOAD_ATTEMPTS; attempt++) {
+    if (attempt > 0) await sleep(1000 * attempt);
+    const resp = await openModelStream(url);
+    if (resp === null) continue;
+    const total = Number(resp.headers.get("content-length")) || 0;
+    let loaded = 0;
+    const counter = new TransformStream({
+      transform(chunk, controller) {
+        loaded += chunk.byteLength;
+        onProgress(url, loaded, total);
+        controller.enqueue(chunk);
+      },
+    });
     try {
-      resp = await fetch(url, init);
+      // The browser consumes this stream into (disk-backed) storage; chunks pass
+      // through the counter without being retained, so JS heap stays flat.
+      const body = new Response(resp.body.pipeThrough(counter), {
+        headers: total ? { "content-length": String(total) } : {},
+      });
+      await cache.put(url, body);
+      return true;
     } catch (e) {
-      lastErr = e;   // couldn't even open the connection — retry (same offset resumes)
-      continue;
+      try { await cache.delete(url); } catch (_) {}   // drop any partial entry
+      if (e?.name === "QuotaExceededError" || /quota|internal error/i.test(e?.message || "")) {
+        return false;   // cache can't hold it — let the caller use memory
+      }
+      // otherwise treat as a mid-stream drop and retry the whole file
     }
-    if (resp.status === 416) {
-      // our offset is at/past EOF: either we already hold the whole file, or
-      // `loaded` is stale — start over in that case.
-      if (total && loaded >= total) { complete = true; break; }
-      parts = []; loaded = 0; lastErr = new Error("range not satisfiable"); continue;
-    }
-    if (!resp.ok) {
-      // 5xx / 429 may be transient; anything else (404, 403…) is fatal, fail fast.
-      if (resp.status >= 500 || resp.status === 429) { lastErr = new Error(`status ${resp.status}`); continue; }
-      throw new Error(`Download failed (${resp.status}) for ${url.split("/").pop()}`);
-    }
-    // If we asked to resume but the server ignored Range (200, not 206), it is
-    // re-sending the whole file — discard what we had and start clean.
-    if (loaded > 0 && resp.status !== 206) { parts = []; loaded = 0; }
-    if (!total) {
-      const cr = resp.headers.get("content-range");   // "bytes start-end/total" on a 206
-      total = cr ? Number(cr.split("/")[1]) : (Number(resp.headers.get("content-length")) || 0);
-    }
+  }
+  throw new Error("Model download interrupted — please check your connection.");
+}
+
+// Fallback when Cache Storage is unavailable: download into memory (this session
+// only, re-downloaded next time). Higher peak, but better than failing outright.
+async function downloadToMemory(url, onProgress) {
+  for (let attempt = 0; attempt < MAX_DOWNLOAD_ATTEMPTS; attempt++) {
+    if (attempt > 0) await sleep(1000 * attempt);
+    const resp = await openModelStream(url);
+    if (resp === null) continue;
+    const total = Number(resp.headers.get("content-length")) || 0;
     try {
       const reader = resp.body.getReader();
+      const parts = [];
+      let loaded = 0;
       for (;;) {
         const { done, value } = await reader.read();
         if (done) break;
@@ -123,32 +181,21 @@ async function fetchModel(url, onProgress) {
         loaded += value.length;
         onProgress(url, loaded, total);
       }
-      complete = true;   // stream finished cleanly
+      const bytes = new Uint8Array(loaded);
+      let off = 0;
+      for (const p of parts) { bytes.set(p, off); off += p.length; }
+      return bytes;
     } catch (e) {
-      lastErr = e;   // stream dropped — but a drop right at the end may have left it whole
-      if (total && loaded >= total) complete = true;
-      // otherwise the next attempt resumes from `loaded`
+      // stream dropped — retry the whole file
     }
   }
-  if (!complete) {
-    console.error("Model download failed after retries:", lastErr?.message || lastErr);
-    throw new Error("Model download interrupted — please check your connection.");
-  }
-
-  const bytes = new Uint8Array(loaded);
-  let off = 0;
-  for (const p of parts) { bytes.set(p, off); off += p.length; }
-  try {
-    await cache.put(url, new Response(bytes, { headers: { "content-length": String(loaded) } }));
-  } catch (e) {
-    // QuotaExceededError etc. – use the in-memory bytes this session, re-download next time
-    console.warn("Model cache write failed (will re-download next time):", e?.message || e);
-  }
-  return bytes;
+  throw new Error("Model download interrupted — please check your connection.");
 }
 
-// Aggregate download progress across the model files (encoder dominates).
-function makeDownloadProgress() {
+// Aggregate download progress across the model files (encoder dominates). `kind`
+// ("GPU"/"CPU") is surfaced to the user and the console so it's clear which model
+// build is being fetched — and obvious if both ever download in one session.
+function makeDownloadProgress(kind) {
   const files = new Map();
   let last = -1;
   return (url, loaded, total) => {
@@ -159,21 +206,37 @@ function makeDownloadProgress() {
     const percent = Math.floor((l / t) * 100);
     if (percent !== last) {
       last = percent;
-      self.postMessage({ type: "progress", phase: "download", progress: percent });
+      self.postMessage({ type: "progress", phase: "download", kind, progress: percent });
     }
   };
 }
 
-async function loadSessions() {
-  const onProgress = makeDownloadProgress();
-  const useWebGpu = !/firefox/i.test(self.navigator?.userAgent || "") && (await hasGpuAdapter());
+async function loadSessions(forceGpu) {
+  const ua = self.navigator?.userAgent || "";
+  const isFirefox = /firefox/i.test(ua);
+  // Safari (desktop or iOS), excluding the other engines that also say "Safari".
+  const isSafari = /safari/i.test(ua) && !/chrome|chromium|crios|edg|opr|android|fxios/i.test(ua);
+  // Default: WebGPU (fp16) only on engines where it's safe and fast (Chromium).
+  // Firefox's WebGPU underperforms here, and Safari's stands the 1.24 GB fp16
+  // encoder up in unified memory and has spiked the whole machine into swap — a
+  // hard OS lockup on the very first window — so both default to the smaller
+  // int8 encoder on WASM. The user can explicitly opt in to the GPU path
+  // (forceGpu) despite the warning, which is how we gather real-world cases for
+  // browser makers; an adapter must still exist for it to take effect.
+  const useWebGpu = (forceGpu || (!isFirefox && !isSafari)) && (await hasGpuAdapter());
+  const kind = useWebGpu ? "GPU" : "CPU";
+  const onProgress = makeDownloadProgress(kind);
 
   // mel + decoder always run on WASM (decoder loop is sequential and cheap –
-  // keeping it off the GPU avoids per-token round-trips).
+  // keeping it off the GPU avoids per-token round-trips). These three files are
+  // ~20 MB combined vs the ~650 MB–1.2 GB encoder, so they download without a
+  // progress callback: counting them would make the bar race to 100% and then
+  // reset to ~0 once the encoder's far larger content-length enters the total.
+  const noProgress = () => {};
   const [melBytes, decBytes, vocabBytes] = await Promise.all([
-    fetchModel(MODELS.mel, onProgress),
-    fetchModel(MODELS.decoder, onProgress),
-    fetchModel(MODELS.vocab, onProgress),
+    fetchModel(MODELS.mel, noProgress),
+    fetchModel(MODELS.decoder, noProgress),
+    fetchModel(MODELS.vocab, noProgress),
   ]);
   const mel = await ort.InferenceSession.create(melBytes, { executionProviders: ["wasm"] });
   const decoder = await ort.InferenceSession.create(decBytes, { executionProviders: ["wasm"] });
@@ -183,7 +246,7 @@ async function loadSessions() {
   if (useWebGpu) {
     try {
       const encBytes = await fetchModel(MODELS.encoderFp16, onProgress);
-      self.postMessage({ type: "progress", phase: "prepare" });
+      self.postMessage({ type: "progress", phase: "prepare", kind: "GPU" });
       encoder = await ort.InferenceSession.create(encBytes, { executionProviders: ["webgpu"] });
       await warmUp(encoder);
       device = "webgpu"; dtype = "fp16";
@@ -193,8 +256,11 @@ async function loadSessions() {
     }
   }
   if (!encoder) {
-    const encBytes = await fetchModel(MODELS.encoderInt8, onProgress);
-    self.postMessage({ type: "progress", phase: "prepare" });
+    // Fresh CPU-labelled progress so a GPU→CPU fallback reads as a distinct
+    // "Downloading CPU model…" pass rather than continuing the GPU one.
+    const onProgressCpu = makeDownloadProgress("CPU");
+    const encBytes = await fetchModel(MODELS.encoderInt8, onProgressCpu);
+    self.postMessage({ type: "progress", phase: "prepare", kind: "CPU" });
     encoder = await ort.InferenceSession.create(encBytes, { executionProviders: ["wasm"] });
     device = "wasm"; dtype = "int8";
   }
@@ -255,15 +321,21 @@ async function transcribe(s, audio) {
 }
 
 async function transcribeWindow(s, samples, offsetSeconds) {
+  // Every ort.Tensor we create or receive holds a buffer (a GPU buffer on the
+  // WebGPU path). Without explicit dispose() they only go when GC runs, which on
+  // Safari is far too late — memory ratchets up window-over-window until the tab
+  // is killed. So we release each one the moment we're done with it.
+
   // 1. mel features
-  const mel = await s.mel.run({
-    waveforms: new ort.Tensor("float32", samples.slice(), [1, samples.length]),
-    waveforms_lens: new ort.Tensor("int64", BigInt64Array.from([BigInt(samples.length)]), [1]),
-  });
+  const wf = new ort.Tensor("float32", samples.slice(), [1, samples.length]);
+  const wfLen = new ort.Tensor("int64", BigInt64Array.from([BigInt(samples.length)]), [1]);
+  const mel = await s.mel.run({ waveforms: wf, waveforms_lens: wfLen });
+  wf.dispose(); wfLen.dispose();
   // 2. encoder
   const encT0 = Date.now();
   const enc = await s.encoder.run({ audio_signal: mel.features, length: mel.features_lens });
-  const encData = enc.outputs.data;            // [1, D, T']
+  mel.features.dispose(); mel.features_lens.dispose();
+  const encData = enc.outputs.data;            // [1, D, T'] (downloaded to CPU here)
   const Tp = enc.outputs.dims[2];
   const encLen = Number(enc.encoded_lengths.data[0]);
   const encMs = Date.now() - encT0;
@@ -276,10 +348,13 @@ async function transcribeWindow(s, samples, offsetSeconds) {
   const tokens = [], stamps = [];
   let t = 0, emitted = 0, last = BLANK;
   while (t < encLen) {
+    const encIn = new ort.Tensor("float32", frame(t), [1, D, 1]);
+    const tgtIn = new ort.Tensor("int32", Int32Array.from([last]), [1, 1]);
+    const tgtLenIn = new ort.Tensor("int32", Int32Array.from([1]), [1]);
     const r = await s.decoder.run({
-      encoder_outputs: new ort.Tensor("float32", frame(t), [1, D, 1]),
-      targets: new ort.Tensor("int32", Int32Array.from([last]), [1, 1]),
-      target_length: new ort.Tensor("int32", Int32Array.from([1]), [1]),
+      encoder_outputs: encIn,
+      targets: tgtIn,
+      target_length: tgtLenIn,
       input_states_1: s1,
       input_states_2: s2,
     });
@@ -288,10 +363,22 @@ async function transcribeWindow(s, samples, offsetSeconds) {
     for (let i = 0; i < VOCAB_SIZE; i++) if (o[i] > bv) { bv = o[i]; tok = i; }
     let step = 0, dv = -Infinity;
     for (let i = VOCAB_SIZE; i < o.length; i++) if (o[i] > dv) { dv = o[i]; step = i - VOCAB_SIZE; }
-    if (tok !== BLANK) { s1 = r.output_states_1; s2 = r.output_states_2; tokens.push(tok); stamps.push(t); last = tok; emitted++; }
+    if (tok !== BLANK) {
+      // adopt the new states; release the ones they replace
+      s1.dispose(); s2.dispose();
+      s1 = r.output_states_1; s2 = r.output_states_2;
+      tokens.push(tok); stamps.push(t); last = tok; emitted++;
+    } else {
+      // states unchanged this step — the fresh outputs are dead, drop them
+      r.output_states_1.dispose(); r.output_states_2.dispose();
+    }
+    r.outputs.dispose();
+    encIn.dispose(); tgtIn.dispose(); tgtLenIn.dispose();
     if (step > 0) { t += step; emitted = 0; }
     else if (tok === BLANK || emitted === MAX_SYMBOLS) { t += 1; emitted = 0; }
   }
+  s1.dispose(); s2.dispose();
+  enc.outputs.dispose(); enc.encoded_lengths.dispose();
 
   console.log(`  window: encoder ${encMs}ms, decode ${Date.now() - decT0}ms (${encLen} frames)`);
 


### PR DESCRIPTION
Addresses #327 (Safari whole-OS lockup when transcribing with Parakeet).

## Why
Safari's WebGPU stands the 1.24 GB fp16 encoder up in unified memory and can spike the whole machine into swap — a hard OS lockup, on the very first window, so it can't be tuned around with smaller windows. This gates the GPU path to Chromium by default; Firefox and Safari run the smaller int8 encoder on WASM. Users can still **opt in** to the GPU path behind an explicit, proportional warning (severe on Safari, mild on Firefox) so capable setups can use it and we can gather real-world cases for browser makers.

Note: the underlying Safari/WebKit bug (a page being able to hang the OS) is not fixed here — the default just stops users hitting it, and the opt-in reproduces it intentionally. Leaving #327 open for the upstream report / future int8-on-WebGPU follow-up.

## Changes
**Worker (`js/parakeet.worker.js`)**
- Stream the model download straight into Cache Storage (no ~2× in-memory peak)
- Dispose mel/encoder/decoder tensors per window and per decode step (WebGPU buffers were lingering until GC, ratcheting memory up)
- Safe-default device selection + `forceGpu` opt-in; sessions rebuild in place (releasing the old set) when the opt-in is toggled
- Label download/prepare progress CPU vs GPU; log each model file as cached/downloading
- Drive the progress bar off the encoder only, so it climbs monotonically instead of racing to 100% then resetting when the encoder size lands

**Parakeet client (`js/hyperaudio-lite-editor-parakeet-local.js`)**
- GPU opt-in checkbox + proportional warning on Firefox/Safari
- Pass `forceGpu` to the worker; show CPU/GPU model in loader messages

**Whisper client (`js/hyperaudio-lite-editor-whisper.js`)**
- Elapsed timer now renders small/grey, matching Parakeet

Bumps changed files + `index.html` to **0.6.9** with cache-busts.

## Verification
Verified headless (Chromium, CPU/int8 path — the path Safari now uses): correct transcript + word timings with disposal active, opt-in plumbing rebuilds/releases sessions cleanly, and the download bar is monotonic with no reset. Real-GPU WebGPU and live Safari behaviour confirmed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)