### PR TITLE
0.6.11: enable transcript autoscroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.10 (last changed in release 0.6.10) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.11 (last changed in release 0.6.11) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.10">
+  <meta name="version" content="0.6.11">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -725,7 +725,7 @@ If you are creating an open source application under a license compatible with t
 
 
   <script src="js/hyperaudio-push-notification.js"></script>
-  <script src="js/hyperaudio-lite.js"></script>
+  <script src="js/hyperaudio-lite.js?v=2.4.0"></script>
   <script src="js/hyperaudio-lite-extension.js"></script>
   <script src="js/caption-modified.js"></script>
   <script>
@@ -850,7 +850,7 @@ If you are creating an open source application under a license compatible with t
 
   function hyperaudio() {
     const minimizedMode = false;
-    const autoScroll = false;
+    const autoScroll = true;
     const doubleClick = true;
     const webMonetization = false;
     const playOnClick = false;
@@ -874,6 +874,34 @@ If you are creating an open source application under a license compatible with t
     };
 
     window.hyperaudioInstance = hyperaudioInstance;
+
+    // Autoscroll target: the element that actually scrolls is .transcript-holder,
+    // not #hypertranscript (the library's default scrollContainer, which is
+    // absolutely positioned and doesn't scroll here).
+    const scrollHolder = document.querySelector('.transcript-holder');
+    if (scrollHolder !== null) {
+      hyperaudioInstance.scrollContainer = scrollHolder;
+    }
+
+    // Pause autoscroll while the user is actively typing so it doesn't yank the
+    // view mid-edit; resume shortly after. Uses 'input' (content changes) so
+    // clicking a word to seek still autoscrolls. Attach once per transcript node.
+    const transcriptEl = document.querySelector('#hypertranscript');
+    if (transcriptEl !== null && transcriptEl.dataset.autoscrollPause !== '1') {
+      transcriptEl.dataset.autoscrollPause = '1';
+      let typingResume = null;
+      transcriptEl.addEventListener('input', () => {
+        if (window.hyperaudioInstance) {
+          window.hyperaudioInstance.autoscroll = false;
+        }
+        clearTimeout(typingResume);
+        typingResume = setTimeout(() => {
+          if (window.hyperaudioInstance) {
+            window.hyperaudioInstance.autoscroll = true;
+          }
+        }, 1500);
+      });
+    }
 
     const sanitisationCheck = function () {
 

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.3.2 */
+/*! Version 2.4.0 */
 
 'use strict';
 
@@ -309,7 +309,6 @@ class HyperaudioLite {
     this.minimizedMode = minimizedMode;
     this.autoscroll = autoscroll;
     this.webMonetization = webMonetization;
-    this.scrollerContainer = this.transcript;
   }
 
   // Setup hash for transcript selection
@@ -407,13 +406,8 @@ class HyperaudioLite {
   }
 
   setupAutoScroll(autoscroll) {
-    if (autoscroll) {
-      if (window.Velocity) {
-        this.scroller = window.Velocity;
-      } else if (window.jQuery && window.jQuery.Velocity) {
-          this.scroller = window.jQuery.Velocity;
-      }
-    }
+    this.autoscroll = autoscroll;
+    this.scrollContainer = this.transcript;
   }
 
   // Setup event listeners for interactions
@@ -608,28 +602,44 @@ class HyperaudioLite {
     }
   }
 
-  // Scroll to the paragraph containing the current word
   scrollToParagraph(currentParentElementIndex, index) {
-
-    const scrollNode = this.wordArr[index - 1].n.closest('p') || this.wordArr[index - 1].n;
-
     if (currentParentElementIndex !== this.parentElementIndex) {
-      if (this.autoscroll && typeof this.scroller !== 'undefined') {
-        if (scrollNode) {
-          this.scroller(scrollNode, 'scroll', {
-            container: this.scrollerContainer,
-            duration: this.scrollerDuration,
-            delay: this.scrollerDelay,
-            offset: this.scrollerOffset,
-          });
-        } else {
-          this.wordArr = this.createWordArray(this.transcript.querySelectorAll('[data-m]'));
-          this.parentElements = this.transcript.getElementsByTagName(this.parentTag);
+      if (this.autoscroll) {
+        const currentParagraph = this.parentElements[currentParentElementIndex];
+        if (currentParagraph) {
+          const containerRect = this.scrollContainer.getBoundingClientRect();
+          const paragraphRect = currentParagraph.getBoundingClientRect();
+          const targetTop = this.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top);
+          this.smoothScrollTo(this.scrollContainer, targetTop, 800);
         }
       }
       this.parentElementIndex = currentParentElementIndex;
     }
   }
+
+  smoothScrollTo(container, targetTop, duration) {
+    if (this.scrollAnimationId) {
+      cancelAnimationFrame(this.scrollAnimationId);
+    }
+    const startTop = container.scrollTop;
+    const distance = targetTop - startTop;
+    if (distance === 0) return;
+    const startTime = performance.now();
+    const easeInOutCubic = t => t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+    const step = now => {
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      container.scrollTop = startTop + distance * easeInOutCubic(progress);
+      if (progress < 1) {
+        this.scrollAnimationId = requestAnimationFrame(step);
+      } else {
+        this.scrollAnimationId = null;
+      }
+    };
+    this.scrollAnimationId = requestAnimationFrame(step);
+  }
+
 
   // Check the status of the playhead and update the transcript
   checkStatus() {
@@ -663,21 +673,18 @@ class HyperaudioLite {
         }
 
         if (this.webMonetization === true) {
-          //check for payment pointer
           let activeElements = this.transcript.getElementsByClassName('active');
           let paymentPointer = this.checkPaymentPointer(activeElements[activeElements.length - 1]);
-    
+
           if (paymentPointer !== null) {
-            let metaElements = document.getElementsByTagName('meta');
-            let wmMeta = document.querySelector("meta[name='monetization']");
-            if (wmMeta === null) {
-              wmMeta = document.createElement('meta');
-              wmMeta.name = 'monetization';
-              wmMeta.content = paymentPointer;
-              document.getElementsByTagName('head')[0].appendChild(wmMeta);
+            let wmLink = document.querySelector("link[rel='monetization']");
+            if (wmLink === null) {
+              wmLink = document.createElement('link');
+              wmLink.rel = 'monetization';
+              wmLink.href = paymentPointer;
+              document.getElementsByTagName('head')[0].appendChild(wmLink);
             } else {
-              wmMeta.name = 'monetization';
-              wmMeta.content = paymentPointer;
+              wmLink.href = paymentPointer;
             }
           }
         }


### PR DESCRIPTION
Closes #332.

Enables transcript autoscroll, which had been disabled since 2022 (and its Velocity dependency was never loaded).

- **Bumped vendored `js/hyperaudio-lite.js` 2.3.2 → 2.4.0**, the upstream version that replaced Velocity with a vanilla `smoothScrollTo` (requestAnimationFrame + easing) — so no new dependency. API-compatible with how the editor calls in (`updateTranscriptVisualState`, `scrollToParagraph`, `checkPlayHead`, constructor).
- **`autoScroll = true`** on the HyperaudioLite instance.
- **`scrollContainer` pointed at `.transcript-holder`** — the element that actually scrolls (the library defaults to `#hypertranscript`, which is absolutely positioned and does not scroll here).
- **Scrubbing the play bar** now scrolls the transcript (already wired via `scrollToParagraph`, previously gated off by the autoscroll flag).
- **Pause while typing:** an `input` listener pauses autoscroll while editing and resumes ~1.5s after; keyed off `input` (not focus) so clicking a word to seek still autoscrolls.

Cache-busts the library (`?v=2.4.0`); bumps `index.html` to 0.6.11.