### PR TITLE
0.6.13: bump hyperaudio-lite to 2.4.8, move seek-follow into the library

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.12 (last changed in release 0.6.12) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.13 (last changed in release 0.6.13) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.12">
+  <meta name="version" content="0.6.13">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -725,10 +725,10 @@ If you are creating an open source application under a license compatible with t
 
 
   <script src="js/hyperaudio-push-notification.js"></script>
-  <script src="js/hyperaudio-lite.js?v=2.4.0"></script>
+  <script src="js/hyperaudio-lite.js?v=2.4.8"></script>
   <script src="js/hyperaudio-lite-extension.js"></script>
   <script src="js/caption-modified.js"></script>
-  <script src="js/editor-core.js?v=0.6.12"></script>
+  <script src="js/editor-core.js?v=0.6.13"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -807,7 +807,7 @@ If you are creating an open source application under a license compatible with t
     }
 
   </style>
-  <script src="js/editor-main.js?v=0.6.12"></script>
+  <script src="js/editor-main.js?v=0.6.13"></script>
   <!-- end of caption editor additions -->
 
   <!-- service worker script for PWA -->

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -133,14 +133,15 @@
     // Strip detached entries before delegating — the next debounced
     // refreshHyperaudioInstance will rebuild wordArr from the live DOM.
     const originalUpdateVisualState = hyperaudioInstance.updateTranscriptVisualState.bind(hyperaudioInstance);
-    hyperaudioInstance.updateTranscriptVisualState = function (currentTime) {
+    hyperaudioInstance.updateTranscriptVisualState = function (...args) {
       if (hyperaudioInstance.wordArr) {
         const live = hyperaudioInstance.wordArr.filter(w => w.n && w.n.parentNode);
         if (live.length !== hyperaudioInstance.wordArr.length) {
           hyperaudioInstance.wordArr = live;
         }
       }
-      return originalUpdateVisualState(currentTime);
+      // forward all args (e.g. the second "force" flag the library passes on seek)
+      return originalUpdateVisualState(...args);
     };
 
     window.hyperaudioInstance = hyperaudioInstance;
@@ -153,6 +154,29 @@
       hyperaudioInstance.scrollContainer = scrollHolder;
     }
 
+    // The library scrolls the active paragraph flush to the top of the scroll
+    // container, which tucks it under the navbar. Override scrollToParagraph to
+    // leave a small gap at the top. (Stopgap until hyperaudio-lite supports a
+    // configurable scroll offset.)
+    const SCROLL_TOP_GAP = 24;
+    hyperaudioInstance.scrollToParagraph = function (currentParentElementIndex, index) {
+      if (currentParentElementIndex === this.parentElementIndex) {
+        return;
+      }
+      this.parentElementIndex = currentParentElementIndex;
+      if (!this.autoscroll) {
+        return;
+      }
+      const paragraph = this.parentElements[currentParentElementIndex];
+      if (!paragraph) {
+        return;
+      }
+      const containerRect = this.scrollContainer.getBoundingClientRect();
+      const paragraphRect = paragraph.getBoundingClientRect();
+      const target = this.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top) - SCROLL_TOP_GAP;
+      this.smoothScrollTo(this.scrollContainer, Math.max(0, target), 800);
+    };
+
     // Pause autoscroll while the user is actively typing so it doesn't yank the
     // view mid-edit; resume shortly after. Uses 'input' (content changes) so
     // clicking a word to seek still autoscrolls. Attach once per transcript node.
@@ -161,13 +185,15 @@
       transcriptEl.dataset.autoscrollPause = '1';
       let typingResume = null;
       transcriptEl.addEventListener('input', () => {
-        if (window.hyperaudioInstance) {
-          window.hyperaudioInstance.autoscroll = false;
+        const hla = window.hyperaudioInstance;
+        if (hla && typeof hla.pauseAutoscroll === 'function') {
+          hla.pauseAutoscroll();
         }
         clearTimeout(typingResume);
         typingResume = setTimeout(() => {
-          if (window.hyperaudioInstance) {
-            window.hyperaudioInstance.autoscroll = true;
+          const inst = window.hyperaudioInstance;
+          if (inst && typeof inst.resumeAutoscroll === 'function') {
+            inst.resumeAutoscroll();
           }
         }, 1500);
       });

--- a/js/editor-main.js
+++ b/js/editor-main.js
@@ -311,36 +311,20 @@
       // as the user drags. HyperaudioLite only runs its play-head loop while
       // playing, so we call checkPlayHead() to update the transcript when
       // scrubbing — including while paused, when that loop is stopped.
-      // Reconcile the transcript to a given time: highlight + greying + scroll.
-      // checkStatus() short-circuits while paused, so call the same updates it
-      // makes when playing, directly.
-      const syncTranscript = (t) => {
-        const hla = window.hyperaudioInstance;
-        if (hla && typeof hla.updateTranscriptVisualState === 'function') {
-          const indices = hla.updateTranscriptVisualState(t);
-          if (indices && indices.currentWordIndex > 0 && hla.autoscroll &&
-              typeof hla.scrollToParagraph === 'function') {
-            hla.scrollToParagraph(indices.currentParentElementIndex, indices.currentWordIndex);
-          }
-        }
-      };
-
+      // Move playback to the scrubbed position. Setting currentTime fires the
+      // media 'seeked' event, which hyperaudio-lite (>= 2.4.x) handles itself to
+      // follow the transcript (highlight + scroll), so we don't reconcile here.
       const scrubTo = (commit) => {
         if (video.duration > 0) {
           const t = (seek.value / SEEK_MAX) * video.duration;
           video.currentTime = t;
           timeEl.textContent = fmt(t) + ' / ' + fmt(video.duration);
-          syncTranscript(t);
         }
         if (commit) {
           seeking = false;
         }
       };
 
-      // After any seek settles, reconcile to the media's actual position. Fast
-      // scrubs coalesce intermediate updates, so the final 'seeked' is what
-      // guarantees every word you passed gets the correct read/greyed state.
-      video.addEventListener('seeked', () => syncTranscript(video.currentTime));
       seek.addEventListener('input', () => {
         seeking = true;
         scrubTo(false);

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.4.0 */
+/*! Version 2.4.8 */
 
 'use strict';
 
@@ -22,6 +22,7 @@ class BasePlayer {
   attachEventListeners(instance) {
     this.player.addEventListener('pause', instance.pausePlayHead.bind(instance), false);
     this.player.addEventListener('play', instance.preparePlayHead.bind(instance), false);
+    this.player.addEventListener('seeked', instance.handleSeeked.bind(instance), false);
   }
 
   // Method to get the current time of the player
@@ -141,8 +142,19 @@ class YouTubePlayer extends BasePlayer {
       firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
     }
 
-    // Set the global callback for the YouTube IFrame API
-    window.onYouTubeIframeAPIReady = this.onYouTubeIframeAPIReady.bind(this, instance);
+    // If the API has already loaded (e.g. another instance was created first
+    // and the script has finished loading), wire up immediately. Otherwise
+    // chain onto any existing onYouTubeIframeAPIReady so multiple instances on
+    // the same page don't clobber each other's setup.
+    if (window.YT && window.YT.Player) {
+      this.onYouTubeIframeAPIReady(instance);
+    } else {
+      const prev = window.onYouTubeIframeAPIReady;
+      window.onYouTubeIframeAPIReady = () => {
+        if (typeof prev === 'function') prev();
+        this.onYouTubeIframeAPIReady(instance);
+      };
+    }
   }
 
   // Callback when YouTube IFrame API is ready
@@ -295,6 +307,7 @@ class HyperaudioLite {
     this.setPlayHead = this.setPlayHead.bind(this);
     this.checkPlayHead = this.checkPlayHead.bind(this);
     this.clearTimer = this.clearTimer.bind(this);
+    this.handleSeeked = this.handleSeeked.bind(this);
   }
 
   // Initialize the HyperaudioLite instance
@@ -544,13 +557,17 @@ class HyperaudioLite {
     this.highlightedText = false;
     this.clearActiveClasses();
 
+    const timeSecs = parseInt(target.dataset.m) / 1000;
+    this.updateTranscriptVisualState(timeSecs);
+
+    // Mark the clicked word as active AFTER updateTranscriptVisualState (which
+    // now wipes stale .active in its else-branch to fix #231). When playing,
+    // the playback loop owns the active word; when paused, we explicitly mark
+    // the clicked word so the user sees what they clicked.
     if (this.myPlayer.paused && target.dataset.m) {
       target.classList.add('active');
       target.parentNode.classList.add('active');
     }
-
-    const timeSecs = parseInt(target.dataset.m) / 1000;
-    this.updateTranscriptVisualState(timeSecs);
 
     if (!isNaN(timeSecs)) {
       this.end = null;
@@ -577,6 +594,29 @@ class HyperaudioLite {
   pausePlayHead() {
     this.clearTimer();
     this.myPlayer.paused = true;
+  }
+
+  // Update transcript visual state + scroll position to match a seek (works while paused).
+  // Forces the word-level `.active` class — without this, the default
+  // `.active > .active` CSS shows nothing on scrub-while-paused.
+  handleSeeked() {
+    (async () => {
+      this.currentTime = await this.myPlayer.getTime();
+      const indices = this.updateTranscriptVisualState(this.currentTime, true);
+      if (indices.currentWordIndex > 0 && this.autoscroll) {
+        this.scrollToParagraph(indices.currentParentElementIndex, indices.currentWordIndex);
+      }
+    })();
+  }
+
+  // Temporarily disable autoscroll (e.g. while a user is editing the transcript).
+  pauseAutoscroll() {
+    this.autoscroll = false;
+  }
+
+  // Re-enable autoscroll after a pauseAutoscroll() call.
+  resumeAutoscroll() {
+    this.autoscroll = true;
   }
 
   // Check the playhead position and update the transcript
@@ -726,7 +766,7 @@ class HyperaudioLite {
   }
 
   // Update the visual state of the transcript based on the current time
-  updateTranscriptVisualState(currentTime) {
+  updateTranscriptVisualState(currentTime, forceActiveWord = false) {
     let index = 0;
     let words = this.wordArr.length - 1;
 
@@ -754,7 +794,7 @@ class HyperaudioLite {
         parentClassList.remove('active');
       } else {
         classList.add('unread');
-        classList.remove('read');
+        classList.remove('read', 'active');
       }
     });
 
@@ -762,7 +802,7 @@ class HyperaudioLite {
     Array.from(this.parentElements).forEach(el => el.classList.remove('active'));
 
     if (index > 0) {
-      if (!this.myPlayer.paused) {
+      if (!this.myPlayer.paused || forceActiveWord) {
         this.wordArr[index - 1].n.classList.add('active');
       }
       this.wordArr[index - 1].n.parentNode.classList.add('active');


### PR DESCRIPTION
Adopts hyperaudio-lite **2.4.8** and removes the editor-side scroll glue it now makes redundant.

### Library
- Vendored `js/hyperaudio-lite.js` **2.4.0 → 2.4.8** (`?v=2.4.8`). 2.4.8:
  - follows the media on `seeked` (including while paused) — #222
  - exposes `pauseAutoscroll()` / `resumeAutoscroll()`
  - fixes the stale-`active`-on-rewind bug (no more `active unread` trail) — #231

### Editor
- `editor-main.js`: removed the editor's own seek-follow glue (`syncTranscript` + the `seeked` listener); scrubbing the play bar just sets `currentTime` and the library follows.
- `editor-core.js`: typing-pause now uses `pauseAutoscroll()`/`resumeAutoscroll()`; the `updateTranscriptVisualState` wrapper forwards all args (the new `forceActiveWord`).
- `editor-core.js`: **kept** the `scrollToParagraph` top-gap override (24px) so the active paragraph clears the navbar — a stopgap until the library adds a configurable `scrollOffset` (upstream #230).
- Keeps `scrollContainer = .transcript-holder`; bumps `index.html` to 0.6.13.

### Verification
Headless: play-follow, scrub-follow, top-gap (24px), rewind (0 stale `active unread`), and typing-pause all pass, no console errors.
