### PR TITLE
Normalize injected non-breaking spaces on blur (#339)

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.14">
+  <meta name="version" content="0.6.15">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.14 (last changed in release 0.6.14) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.15 (last changed in release 0.6.15) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -734,7 +734,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite.js?v=2.4.8"></script>
   <script src="js/hyperaudio-lite-extension.js"></script>
   <script src="js/caption-modified.js"></script>
-  <script src="js/editor-core.js?v=0.6.13"></script>
+  <script src="js/editor-core.js?v=0.6.15"></script>
 
 
   <import-deepgram-json></import-deepgram-json>

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -197,6 +197,23 @@
           }
         }, 1500);
       });
+
+      // Strip non-breaking spaces (U+00A0) that contenteditable injects on edit,
+      // back to regular spaces (#339). On blur only — never during typing — so it
+      // has zero impact on editing smoothness and can't disturb the caret; the
+      // textContent check makes the common (no-nbsp) case a cheap early-out.
+      transcriptEl.addEventListener('blur', () => {
+        if (transcriptEl.textContent.indexOf('\u00A0') === -1) {
+          return;
+        }
+        const walker = document.createTreeWalker(transcriptEl, NodeFilter.SHOW_TEXT);
+        let node;
+        while ((node = walker.nextNode())) {
+          if (node.nodeValue.indexOf('\u00A0') !== -1) {
+            node.nodeValue = node.nodeValue.replace(/\u00A0/g, ' ');
+          }
+        }
+      });
     }
 
     const sanitisationCheck = function () {


### PR DESCRIPTION
## Summary

Fixes the `&nbsp;` injection half of #339. `contenteditable` inserts non-breaking spaces (U+00A0) while editing the transcript, which end up baked into the exported HTML as `&nbsp;`. This normalizes them back to regular spaces.

## Approach

A `blur`-only handler on the transcript:
- Runs **only on blur** — never during keystrokes, so editing stays smooth and the caret is never disturbed.
- Cheap early-out (`textContent.indexOf(' ') === -1`) when there's nothing to fix.
- Single text-node walk otherwise, replacing ` ` with a regular space.

## Verification

Headless (Playwright): injected 2 NBSPs into word spans (innerHTML showed `&nbsp;`), dispatched blur → 0 NBSPs remaining, no `&nbsp;` entity in innerHTML, spans normalized to regular spaces, no console errors.

## Scope

This addresses only the NBSP injection. The character-migration-across-spans part of #339 remains open. Multi-word-in-a-single-span (from inserting a space mid-word) is a known, harmless limitation — text and export are intact; only per-word timing granularity is coarser.

## Versioning

Bumped to 0.6.15: line-3 comment, `<meta name="version">`, and `editor-core.js?v` cache-bust.
