### PR TITLE
Estimate split-word timing by syllable count (0.6.16)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.15 (last changed in release 0.6.15) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.16 (last changed in release 0.6.16) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.15">
+  <meta name="version" content="0.6.16">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -734,7 +734,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite.js?v=2.4.8"></script>
   <script src="js/hyperaudio-lite-extension.js"></script>
   <script src="js/caption-modified.js"></script>
-  <script src="js/editor-core.js?v=0.6.15"></script>
+  <script src="js/editor-core.js?v=0.6.16"></script>
 
 
   <import-deepgram-json></import-deepgram-json>

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -198,19 +198,77 @@
         }, 1500);
       });
 
-      // Strip non-breaking spaces (U+00A0) that contenteditable injects on edit,
-      // back to regular spaces (#339). On blur only — never during typing — so it
-      // has zero impact on editing smoothness and can't disturb the caret; the
-      // textContent check makes the common (no-nbsp) case a cheap early-out.
-      transcriptEl.addEventListener('blur', () => {
-        if (transcriptEl.textContent.indexOf('\u00A0') === -1) {
+      // --- Word-split timing (modular; set WORD_SPLIT_TIMING = false to remove) ---
+      // When the user types a space inside a word, contenteditable leaves two (or
+      // more) words inside one timed <span>. On blur we split that span into one
+      // span per word and estimate each word's timing by dividing the original
+      // span's [data-m, data-d] window pro-rata across the parts. Weighting is by
+      // estimated syllable count (vowel groups) rather than letters — a reasonable
+      // proxy for spoken duration in Latin-script languages.
+      const WORD_SPLIT_TIMING = true;
+
+      // Estimate syllables from contiguous vowel groups (Latin-script heuristic).
+      // Includes common Romance/Germanic accented vowels and y; floored at 1 so
+      // every part carries weight (no zero-duration or divide-by-zero parts).
+      const estimateSyllables = function (token) {
+        const groups = token.toLowerCase().match(/[aeiouyàáâäãèéêëìíîïòóôöõùúûüýÿ]+/g);
+        return Math.max(1, groups ? groups.length : 1);
+      };
+
+      // Split one multi-word span into per-word spans, distributing the original
+      // duration by syllable weight; parts stay contiguous and their durations sum
+      // exactly to the original (last part absorbs any rounding remainder).
+      const splitWordSpan = function (span) {
+        const tokens = span.textContent.split(/\s+/).filter(t => t.length > 0);
+        if (tokens.length < 2) {
           return;
         }
-        const walker = document.createTreeWalker(transcriptEl, NodeFilter.SHOW_TEXT);
-        let node;
-        while ((node = walker.nextNode())) {
-          if (node.nodeValue.indexOf('\u00A0') !== -1) {
-            node.nodeValue = node.nodeValue.replace(/\u00A0/g, ' ');
+        const m = parseInt(span.getAttribute('data-m'), 10) || 0;
+        const d = parseInt(span.getAttribute('data-d'), 10) || 0;
+        const weights = tokens.map(estimateSyllables);
+        const totalWeight = weights.reduce((a, b) => a + b, 0);
+
+        const frag = document.createDocumentFragment();
+        let start = m;
+        let allocated = 0;
+        for (let i = 0; i < tokens.length; i++) {
+          const dur = i === tokens.length - 1
+            ? Math.max(0, d - allocated)
+            : Math.round((d * weights[i]) / totalWeight);
+          allocated += dur;
+          const part = span.cloneNode(false); // preserve class and any data-* attrs
+          part.setAttribute('data-m', String(start));
+          part.setAttribute('data-d', String(dur));
+          part.textContent = tokens[i] + ' '; // keep the word separator
+          frag.appendChild(part);
+          start += dur;
+        }
+        span.replaceWith(frag);
+      };
+
+      transcriptEl.addEventListener('blur', () => {
+        // Strip non-breaking spaces (U+00A0) that contenteditable injects on edit,
+        // back to regular spaces (#339). The textContent check keeps the common
+        // (no-nbsp) case a cheap early-out.
+        if (transcriptEl.textContent.indexOf('\u00A0') !== -1) {
+          const walker = document.createTreeWalker(transcriptEl, NodeFilter.SHOW_TEXT);
+          let node;
+          while ((node = walker.nextNode())) {
+            if (node.nodeValue.indexOf('\u00A0') !== -1) {
+              node.nodeValue = node.nodeValue.replace(/\u00A0/g, ' ');
+            }
+          }
+        }
+
+        // Split any span that now holds more than one word (internal whitespace
+        // between non-space characters). Touches only affected spans, so the
+        // common single-word case costs one regex test per span.
+        if (WORD_SPLIT_TIMING) {
+          const spans = transcriptEl.querySelectorAll('span[data-m]');
+          for (let i = 0; i < spans.length; i++) {
+            if (/\S\s+\S/.test(spans[i].textContent)) {
+              splitWordSpan(spans[i]);
+            }
           }
         }
       });


### PR DESCRIPTION
## Summary

Follow-up to #340. When a space is typed inside a word, `contenteditable` leaves multiple words inside one timed `<span>`. On blur, this splits that span into one span per word and estimates each word's timing by dividing the original `[data-m, data-d]` window pro-rata across the parts.

Weighting is by **estimated syllable count** — contiguous vowel groups (including common accented Latin vowels and `y`), floored at 1 — rather than letter count. A reasonable proxy for spoken duration in Latin-script languages.

## Behaviour

- Parts stay **contiguous** (`mₙ₊₁ = mₙ + dₙ`) and their durations **sum exactly** to the original (the last part absorbs any rounding remainder).
- Spans are cloned (`cloneNode(false)`), so `class` and any `data-*` attributes carry to each part.
- Runs **on blur only**, one regex test per span, so editing stays smooth.
- Behind a `WORD_SPLIT_TIMING` flag and isolated in two helpers (`estimateSyllables`, `splitWordSpan`) so it can be disabled or removed cleanly.

## Verification

Headless (Playwright):
- `inter national` (2 vs 3 syllables) over a 500ms window → `inter`=200ms, `national`=300ms; contiguous; sums to 500.
- `mod`+NBSP+`el` → NBSP normalized first, then split into `mod `/`el ` (1 vs 1 syllable → 100/100); contiguous; sums to 200.
- No NBSP left in the DOM; zero console errors.

## Known limitation

Newly-split spans aren't in the library's `wordArr`, so a just-split word highlights as its parent until the next `hyperaudioInit`. Export and caption generation read the DOM, so those are correct.

## Versioning

Bumped to 0.6.16: line-3 comment, `<meta name="version">` (also corrects a stale 0.6.14), and `editor-core.js?v` cache-bust.

## Note

Stacked on #340 — merge that first. Base will need retargeting to `main` once #340 lands.
