### PR TITLE
Add AT Protocol / ionosphere transcript export (0.6.18)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.17 (last changed in release 0.6.17) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.18 (last changed in release 0.6.18) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.17">
+  <meta name="version" content="0.6.18">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -29,7 +29,8 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.9"></script>
   <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.6.9"></script>
   <script src="js/word-alignment.js"></script>
-  <script src="js/html-json-converter.js"></script>
+  <script src="js/html-json-converter.js?v=0.6.18"></script>
+  <script src="js/transcript-to-ionosphere.js?v=0.6.18"></script>
 
   <!-- Meta Tags required for
     Progressive Web App -->
@@ -334,6 +335,7 @@ If you are creating an open source application under a license compatible with t
                 </span>
               </li>
               <li><export-json></export-json></li>
+              <li><export-ionosphere></export-ionosphere></li>
               <li><import-json></import-json></li>
               <li><label for="file-import-deepgram-json-dialog">Import Deepgram JSON</label></li>
               <li><label for="file-import-srt-dialog">Import SRT</label></li>

--- a/js/html-json-converter.js
+++ b/js/html-json-converter.js
@@ -103,16 +103,22 @@ function jsonToHTML(jsonData) {
         word.start >= paragraphStart && word.start < paragraphEnd
       );
       
-      // Generate span for each word
-      paragraphWords.forEach(word => {
-        // Convert times from seconds to milliseconds
+      // One span per line (indented) for readability. A word flagged
+      // space:false has no trailing space and is kept adjacent to the next
+      // span — no newline between them — so split tokens stay glued (e.g.
+      // "speech" + "-to" + "-text" -> "speech-to-text"). Normal words carry a
+      // trailing space inside the span, so the newline between them collapses
+      // to a single rendered space as before.
+      paragraphWords.forEach((word, wordIndex) => {
         const startMs = Math.round(word.start * 1000);
         const endMs = Math.round(word.end * 1000);
         const durationMs = endMs - startMs;
-        
-        // Create span with timing attributes
-        html += `    <span data-m="${startMs}" data-d="${durationMs}">${word.text} </span>\n`;
+        const trail = word.space === false ? '' : ' ';
+        const gluedToPrev = wordIndex > 0 && paragraphWords[wordIndex - 1].space === false;
+        const lead = wordIndex === 0 ? '    ' : gluedToPrev ? '' : '\n    ';
+        html += `${lead}<span data-m="${startMs}" data-d="${durationMs}">${word.text}${trail}</span>`;
       });
+      html += '\n';
       
       html += '  </p>\n';
     });
@@ -122,14 +128,16 @@ function jsonToHTML(jsonData) {
     // No paragraph data, put all words in one <p>
     html += '  <p>\n';
     
-    words.forEach(word => {
-      // Convert times from seconds to milliseconds
+    words.forEach((word, wordIndex) => {
       const startMs = Math.round(word.start * 1000);
       const endMs = Math.round(word.end * 1000);
       const durationMs = endMs - startMs;
-      
-      html += `    <span data-m="${startMs}" data-d="${durationMs}">${word.text} </span>\n`;
+      const trail = word.space === false ? '' : ' ';
+      const gluedToPrev = wordIndex > 0 && words[wordIndex - 1].space === false;
+      const lead = wordIndex === 0 ? '    ' : gluedToPrev ? '' : '\n    ';
+      html += `${lead}<span data-m="${startMs}" data-d="${durationMs}">${word.text}${trail}</span>`;
     });
+    html += '\n';
     
     html += '  </p>\n';
   }
@@ -191,19 +199,30 @@ function htmlToJSON(html) {
   const wordSpans = doc.querySelectorAll('span[data-m][data-d]:not(.speaker)');
   
   wordSpans.forEach(span => {
-    const text = span.textContent.trim();
+    const raw = span.textContent;
+    const text = raw.trim();
     if (text) {
       // Parse timing attributes
       const startMs = parseInt(span.getAttribute('data-m'));
       const durationMs = parseInt(span.getAttribute('data-d'));
       const endMs = startMs + durationMs;
-      
+
       // Convert from milliseconds to seconds
-      words.push({
+      const word = {
         start: startMs / 1000,
         end: endMs / 1000,
         text: text
-      });
+      };
+
+      // Preserve whether a space follows this word. The editor encodes a word
+      // split across spans (e.g. "speech" "-to" "-text") as adjacent spans with
+      // no trailing space; flag those so they don't gain spaces on round-trip.
+      // Omitted (the common case) means a space follows.
+      if (!/\s$/.test(raw)) {
+        word.space = false;
+      }
+
+      words.push(word);
     }
   });
   

--- a/js/transcript-to-ionosphere.js
+++ b/js/transcript-to-ionosphere.js
@@ -1,0 +1,257 @@
+/*! (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html */
+/*! Hyperaudio Lite Editor - ionosphere (AT Protocol) transcript export. @version 0.6.18 */
+
+// Self-contained, modular export feature. To remove it entirely: delete this
+// file, its <script> tag in index.html, and the <export-ionosphere> menu item.
+//
+// Serializes the canonical transcript JSON ({ words, paragraphs }, as produced
+// by htmlToJSON in html-json-converter.js) into the tv.ionosphere / pub.layers
+// record set that ATmosphereConf's transcript pipeline reads. This is the
+// inverse of transcript-from-ionosphere.ts in the atproto-conf repo.
+//
+// v1 emits the record set as a downloadable JSON file (no PDS write). The repo
+// `did` is a placeholder and the talk rkey is a freshly generated TID — replace
+// the did before publishing the records to a PDS with com.atproto.repo.putRecord.
+//
+// Note: byte ranges are UTF-8 offsets (TextEncoder), never string indices —
+// otherwise any non-ASCII word desyncs every later span.
+
+(function () {
+  'use strict';
+
+  const PLACEHOLDER_DID = 'did:plc:REPLACE_ME';
+  const MAX_TOKEN_BYTES = 900000; // atproto record values cap ~1 MB; leave headroom
+
+  const utf8 = new TextEncoder();
+  const byteLength = (s) => utf8.encode(s).length;
+
+  // atproto's conventional record key: a 13-char base32-sortable TID.
+  const TID_ALPHABET = '234567abcdefghijklmnopqrstuvwxyz';
+  function generateTid() {
+    let n =
+      ((BigInt(Date.now()) * 1000n) << 10n) |
+      BigInt(Math.floor(Math.random() * 1024));
+    let s = '';
+    for (let i = 0; i < 13; i++) {
+      s = TID_ALPHABET[Number(n & 31n)] + s;
+      n >>= 5n;
+    }
+    return s;
+  }
+
+  function slugify(name) {
+    const slug = String(name)
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    return slug || 'speaker';
+  }
+
+  // Assign each word to a paragraph index (-1 if outside all). Latest paragraph
+  // whose [start, end] contains word.start — matches the render-path bucketing.
+  function bucketWords(words, paragraphs) {
+    const assign = new Array(words.length).fill(-1);
+    let pIdx = 0;
+    for (let wi = 0; wi < words.length; wi++) {
+      const w = words[wi];
+      while (pIdx < paragraphs.length && w.start > paragraphs[pIdx].end) pIdx++;
+      if (pIdx >= paragraphs.length) break;
+      while (
+        pIdx + 1 < paragraphs.length &&
+        paragraphs[pIdx + 1].start <= w.start
+      ) {
+        pIdx++;
+      }
+      if (w.start < paragraphs[pIdx].start) continue;
+      assign[wi] = pIdx;
+    }
+    return assign;
+  }
+
+  // Greedily pack tokens into shards so each shard's serialised tokens array
+  // stays under maxTokenBytes (a single oversized token still gets its own shard).
+  function shardTokens(tokens, maxTokenBytes) {
+    const shards = [];
+    let current = [];
+    let currentBytes = 2; // "[]"
+    for (const token of tokens) {
+      const tokenBytes = byteLength(JSON.stringify(token)) + 1; // + comma
+      if (current.length > 0 && currentBytes + tokenBytes > maxTokenBytes) {
+        shards.push(current);
+        current = [];
+        currentBytes = 2;
+      }
+      current.push(token);
+      currentBytes += tokenBytes;
+    }
+    if (current.length > 0) shards.push(current);
+    return shards.length > 0 ? shards : [[]];
+  }
+
+  // { words:[{start,end,text}], paragraphs:[{start,end,speaker?}] } -> record set.
+  function transcriptJsonToIonosphere(data, opts) {
+    const words = (data && data.words) || [];
+    const paragraphs = (data && data.paragraphs) || [];
+    const did = opts.did;
+    const rkey = opts.rkey;
+    const createdAt = opts.createdAt || new Date().toISOString();
+    const maxTokenBytes = opts.maxTokenBytes || MAX_TOKEN_BYTES;
+    const records = [];
+
+    // 1. Expression text + per-word UTF-8 byte ranges (ranges cover the word only).
+    const wordSpans = [];
+    let text = '';
+    let byteCursor = 0;
+    for (let i = 0; i < words.length; i++) {
+      // Separate from the previous word with a space, unless that word was
+      // flagged space:false (a glued split token like "speech"/"-to"/"-text").
+      if (i > 0 && words[i - 1].space !== false) {
+        text += ' ';
+        byteCursor += 1; // a space is one UTF-8 byte
+      }
+      const byteStart = byteCursor;
+      text += words[i].text;
+      byteCursor += byteLength(words[i].text);
+      wordSpans.push({ byteStart: byteStart, byteEnd: byteCursor });
+    }
+    records.push({
+      collection: 'pub.layers.expression.expression',
+      rkey: rkey + '-expression',
+      value: { $type: 'pub.layers.expression.expression', text: text, createdAt: createdAt },
+    });
+
+    // 2. Word byte-range tokens (kind "word"), sharded.
+    const wordTokens = wordSpans.map((span, i) => ({ tokenIndex: i, textSpan: span }));
+    shardTokens(wordTokens, maxTokenBytes).forEach((tokens, n) => {
+      records.push({
+        collection: 'pub.layers.segmentation.segmentation',
+        rkey: rkey + '-segmentation-' + (n + 1),
+        value: {
+          $type: 'pub.layers.segmentation.segmentation',
+          tokenizations: [{ kind: 'word', tokens: tokens }],
+          createdAt: createdAt,
+        },
+      });
+    });
+
+    // 3. Word temporal-span tokens (kind "word-temporal"), sharded. ms resolution.
+    const temporalTokens = words.map((w, i) => ({
+      tokenIndex: i,
+      temporalSpan: { start: Math.round(w.start * 1000), ending: Math.round(w.end * 1000) },
+    }));
+    shardTokens(temporalTokens, maxTokenBytes).forEach((tokens, n) => {
+      records.push({
+        collection: 'pub.layers.segmentation.segmentation',
+        rkey: rkey + '-temporal-' + (n + 1),
+        value: {
+          $type: 'pub.layers.segmentation.segmentation',
+          tokenizations: [{ kind: 'word-temporal', tokens: tokens }],
+          createdAt: createdAt,
+        },
+      });
+    });
+
+    // 4. Paragraph annotations: byte range spans each paragraph's member words.
+    const assign = bucketWords(words, paragraphs);
+    const annotations = [];
+    for (let p = 0; p < paragraphs.length; p++) {
+      let first = -1;
+      let last = -1;
+      for (let wi = 0; wi < assign.length; wi++) {
+        if (assign[wi] !== p) continue;
+        if (first === -1) first = wi;
+        last = wi;
+      }
+      if (first === -1) continue; // empty paragraph
+      annotations.push({
+        label: 'paragraph',
+        anchor: {
+          textSpan: {
+            byteStart: wordSpans[first].byteStart,
+            byteEnd: wordSpans[last].byteEnd,
+          },
+        },
+      });
+    }
+    records.push({
+      collection: 'pub.layers.annotation.annotationLayer',
+      rkey: rkey + '-paragraphs',
+      value: { $type: 'pub.layers.annotation.annotationLayer', annotations: annotations, createdAt: createdAt },
+    });
+
+    // 5. Speaker records — one per distinct speaker, first-appearance order.
+    const speakerOrder = [];
+    paragraphs.forEach((p) => {
+      if (p.speaker && speakerOrder.indexOf(p.speaker) === -1) speakerOrder.push(p.speaker);
+    });
+    const speakerUris = [];
+    speakerOrder.forEach((name) => {
+      const meta = (opts.speakers && opts.speakers[name]) || {};
+      const speakerRkey = meta.rkey || rkey + '-speaker-' + slugify(name);
+      const value = { $type: 'tv.ionosphere.speaker', name: name, createdAt: createdAt };
+      if (meta.handle) value.handle = meta.handle;
+      records.push({ collection: 'tv.ionosphere.speaker', rkey: speakerRkey, value: value });
+      speakerUris.push('at://' + did + '/tv.ionosphere.speaker/' + speakerRkey);
+    });
+
+    // 6. The talk record.
+    const talkValue = { $type: 'tv.ionosphere.talk', speakerUris: speakerUris, createdAt: createdAt };
+    if (opts.title) talkValue.title = opts.title;
+    if (opts.startsAt) talkValue.startsAt = opts.startsAt;
+    if (opts.endsAt) talkValue.endsAt = opts.endsAt;
+    records.push({ collection: 'tv.ionosphere.talk', rkey: rkey, value: talkValue });
+
+    return {
+      talkUri: 'at://' + did + '/tv.ionosphere.talk/' + rkey,
+      did: did,
+      rkey: rkey,
+      records: records,
+    };
+  }
+
+  function downloadJsonFile(obj, filename) {
+    const dataStr =
+      'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(obj, null, 2));
+    const a = document.createElement('a');
+    a.setAttribute('href', dataStr);
+    a.setAttribute('download', filename);
+    document.body.appendChild(a); // required for Firefox
+    a.click();
+    a.remove();
+  }
+
+  class ExportIonosphere extends HTMLElement {
+    exportIonosphere() {
+      const hypertranscript = document.getElementById('hypertranscript');
+      if (hypertranscript === null) {
+        alert('Currently you can only export from the transcript view.');
+        return;
+      }
+      if (typeof htmlToJSON !== 'function') {
+        alert('Transcript JSON converter is unavailable.');
+        return;
+      }
+      const data = htmlToJSON(hypertranscript.innerHTML);
+      if (!data.words || data.words.length === 0) {
+        alert('No transcript words to export.');
+        return;
+      }
+      const out = transcriptJsonToIonosphere(data, {
+        did: PLACEHOLDER_DID,
+        rkey: generateTid(),
+        createdAt: new Date().toISOString(),
+      });
+      downloadJsonFile(out, 'ionosphere-records.json');
+    }
+
+    connectedCallback() {
+      this.innerHTML = '<a>Export ionosphere (AT Protocol) JSON</a>';
+      this.addEventListener('click', this.exportIonosphere);
+    }
+  }
+
+  customElements.define('export-ionosphere', ExportIonosphere);
+
+  // Expose the pure serializer for reuse/testing without the DOM/menu.
+  window.transcriptJsonToIonosphere = transcriptJsonToIonosphere;
+})();


### PR DESCRIPTION
Adds an **Export ionosphere (AT Protocol) JSON** option that serializes the current transcript into the `tv.ionosphere` / `pub.layers` record set read by ATmosphereConf's transcript pipeline — the inverse of its `transcript-from-ionosphere` reader. Implements the core of #346.

## What it does
- New menu item under Export / Import (next to "Export Hyperaudio JSON").
- Reads the transcript via the canonical `htmlToJSON()`, serializes it, and downloads `ionosphere-records.json` containing: `tv.ionosphere.talk`, `pub.layers.expression.expression`, sharded `pub.layers.segmentation.segmentation` (word byte ranges + temporal ranges), `pub.layers.annotation.annotationLayer` (paragraphs), and `tv.ionosphere.speaker`.
- **v1 = downloadable JSON only** (no PDS write): the `did` is a placeholder (`did:plc:REPLACE_ME`) and the talk rkey is a generated TID. Publishing later means swapping in the real DID and `applyWrites`-ing the records.

## Modular
Self-contained in `js/transcript-to-ionosphere.js`. To remove the feature: delete that file, its `<script>` tag, and the `<export-ionosphere>` `<li>`.

## Glue-flag fix (split words)
Words the editor splits across spans (e.g. `speech` / `-to` / `-text`) previously gained spaces in the serialized text (`speech -to -text`). Fixed by carrying a per-word "space follows" flag through the canonical converter:
- `htmlToJSON` marks a word `space: false` when its span has no trailing space (field omitted otherwise — JSON shape unchanged for normal words).
- `jsonToHTML` keeps one span per indented line as before, but places a `space:false` word adjacent to the next span (no whitespace between) so split tokens stay glued. **Output for normal transcripts is unchanged.**
- the serializer omits the separator space/byte after a `space:false` word.

## Verification
- Ran against the default transcript's real export: 162 words ↔ 162 word/temporal tokens, **0 byte-decode mismatches** (every word decodes back out of its UTF-8 byte range), **0 timing mismatches** (`temporalSpan` vs `data-m`/`data-d`), 9 paragraphs ↔ 9 `<p>`, speaker correctly extracted.
- With the glue fix, `speech-to-text` and `built-in.` come out intact; no `speech -to`.
- `jsonToHTML` formatting verified: normal spans one-per-line, glued group adjacent.

## Risk
Low. The new file is purely additive. The only existing consumer of the converter is `editor-audio-cut.js` (alignment), which sets the result as `innerHTML` and re-inits — insensitive to the formatting, and rendering is identical for normal words.

## Note
`@version`/cache-bust set to `0.6.18`. PR #345 (caption-guard sync) is also tagged `0.6.18`; whichever merges second will need its version line rebased.
