### PR TITLE
Add paragraph-level timecodes (0.6.20)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.19 (last changed in release 0.6.19) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.20 (last changed in release 0.6.20) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.19">
+  <meta name="version" content="0.6.20">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -31,6 +31,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js?v=0.6.18"></script>
   <script src="js/transcript-to-ionosphere.js?v=0.6.18"></script>
+  <script src="js/paragraph-timecodes.js?v=0.6.20"></script>
 
   <!-- Meta Tags required for
     Progressive Web App -->
@@ -258,8 +259,12 @@ If you are creating an open source application under a license compatible with t
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-audio-lines"><path d="M2 10v3"/><path d="M6 6v11"/><path d="M10 3v18"/><path d="M14 8v7"/><path d="M18 5v13"/><path d="M22 10v3"/></svg>
             </button>
             <label for="show-speakers" style="display:flex; align-items:center; gap:6px; margin-left:4px; cursor:pointer; white-space:nowrap;">
-              Display speakers
+              Speakers
               <input type="checkbox" id="show-speakers" name="show-speakers" checked="checked" class="checkbox checkbox-primary checkbox-sm"/>
+            </label>
+            <label for="show-timecodes" style="display:flex; align-items:center; gap:6px; margin-left:4px; cursor:pointer; white-space:nowrap;">
+              Timecodes
+              <input type="checkbox" id="show-timecodes" name="show-timecodes" class="checkbox checkbox-primary checkbox-sm"/>
             </label>
             <label id="info-btn" for="info-modal" class="btn btn-square btn-ghost btn-sm tooltip" data-tip="Transcription info" aria-label="Transcription info" style="margin-left:auto;">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-info"><circle cx="12" cy="12" r="10"></circle><line x1="12" x2="12" y1="16" y2="12"></line><line x1="12" x2="12.01" y1="8" y2="8"></line></svg>

--- a/js/paragraph-timecodes.js
+++ b/js/paragraph-timecodes.js
@@ -1,0 +1,265 @@
+/*! (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html */
+/*! Hyperaudio Lite Editor - paragraph-level timecodes. @version 0.6.20 */
+
+// Self-contained, modular display feature. To remove it entirely: delete this
+// file, its <script> tag in index.html, and the #show-timecodes checkbox.
+//
+// Shows a small timecode at the start of each transcript paragraph, derived
+// from that paragraph's first word (data-m). Clicking it seeks the player.
+// Toggled by the #show-timecodes checkbox (off by default).
+//
+// IMPORTANT: the timecodes are rendered OUTSIDE the contenteditable, as
+// absolutely-positioned elements inside .transcript-holder (the scroll
+// container that wraps #hypertranscript). Because they are absolute children
+// of the scroll container, they scroll with the content natively. Being
+// outside #hypertranscript means they can't be deleted or selected while
+// editing, are never part of a strikeout/skip selection, and never appear in
+// any export (captions, JSON, ionosphere, interactive HTML). Positions are
+// recomputed only when the transcript layout changes (edits, reflow, resize,
+// sidebar toggle) via a ResizeObserver - never on scroll.
+
+(function () {
+  'use strict';
+
+  let enabled = false;
+  let rafPending = false;
+  let busyObs = null;
+  let observedTranscript = null;
+
+  function formatTimecode(ms) {
+    const totalSeconds = Math.floor(ms / 1000);
+    const seconds = totalSeconds % 60;
+    const minutes = Math.floor(totalSeconds / 60) % 60;
+    const hours = Math.floor(totalSeconds / 3600);
+    const ss = String(seconds).padStart(2, '0');
+    const mm = String(minutes).padStart(2, '0');
+    return hours > 0 ? `${hours}:${mm}:${ss}` : `${mm}:${ss}`;
+  }
+
+  function holderEl() {
+    return document.querySelector('.transcript-holder');
+  }
+  function transcriptEl() {
+    return document.getElementById('hypertranscript');
+  }
+  function firstWordOf(paragraph) {
+    return paragraph.querySelector('span[data-m]:not(.speaker)');
+  }
+
+  function clearTimecodes(holder) {
+    holder.querySelectorAll(':scope > .para-timecode').forEach((el) => el.remove());
+  }
+
+  function reposition() {
+    const holder = holderEl();
+    const transcript = transcriptEl();
+    if (!holder || !transcript) {
+      return;
+    }
+    // While transcribing/processing, setTranscriptBusy() marks the transcript
+    // aria-busy="true" (the old timed transcript may still be in the DOM) - hide
+    // timecodes in that state, and whenever the container holds no timed words.
+    const busy = transcript.getAttribute('aria-busy') === 'true';
+    const paragraphs = [];
+    if (enabled && !busy) {
+      transcript.querySelectorAll('p').forEach((paragraph) => {
+        const firstWord = firstWordOf(paragraph);
+        if (!firstWord) {
+          return;
+        }
+        const ms = parseInt(firstWord.getAttribute('data-m'), 10);
+        if (!isNaN(ms)) {
+          paragraphs.push({ paragraph, ms });
+        }
+      });
+    }
+
+    // Off, or nothing to label yet (e.g. transcribing) -> no labels.
+    if (paragraphs.length === 0) {
+      clearTimecodes(holder);
+      return;
+    }
+
+    // Reuse existing timecode elements where possible (cheap reflow updates);
+    // only rebuild when the paragraph count changes.
+    let tcs = Array.prototype.slice.call(
+      holder.querySelectorAll(':scope > .para-timecode'),
+    );
+    if (tcs.length !== paragraphs.length) {
+      clearTimecodes(holder);
+      tcs = paragraphs.map(() => {
+        const tc = document.createElement('div');
+        tc.className = 'para-timecode';
+        holder.appendChild(tc);
+        return tc;
+      });
+    }
+
+    // Place each label in the left margin, OUTSIDE the fixed-width transcript, so
+    // the reading column never shifts. The transcript is centred in the wider
+    // holder; right-anchor the label to end just before the transcript's left
+    // edge, and top-align it to the paragraph's first line.
+    const holderRect = holder.getBoundingClientRect();
+    const transcriptRect = transcript.getBoundingClientRect();
+    const scrollTop = holder.scrollTop;
+    const GAP = 12;
+    const rightOffset = holderRect.width - (transcriptRect.left - holderRect.left) + GAP;
+    // Match the paragraph's line-height so the small label aligns with its first line.
+    const lineHeight = getComputedStyle(paragraphs[0].paragraph).lineHeight;
+    paragraphs.forEach((item, i) => {
+      const tc = tcs[i];
+      const label = formatTimecode(item.ms);
+      if (tc.textContent !== label) {
+        tc.textContent = label;
+        tc.title = `Jump to ${label}`;
+      }
+      tc.dataset.ms = String(item.ms);
+      tc.style.right = `${rightOffset}px`;
+      tc.style.lineHeight = lineHeight;
+      const top = item.paragraph.getBoundingClientRect().top - holderRect.top + scrollTop;
+      tc.style.top = `${top}px`;
+    });
+  }
+
+  function scheduleReposition() {
+    if (rafPending) {
+      return;
+    }
+    rafPending = true;
+    requestAnimationFrame(() => {
+      rafPending = false;
+      reposition();
+    });
+  }
+
+  function trigger() {
+    if (enabled) {
+      scheduleReposition();
+    }
+  }
+
+  // The transcript element is replaced wholesale when a file loads (Recents wipes
+  // .transcript-holder). Re-bind the per-transcript observers to the current one.
+  function attachToTranscript() {
+    const transcript = transcriptEl();
+    if (transcript === observedTranscript) {
+      return;
+    }
+    if (observedTranscript) {
+      observedTranscript.removeEventListener('blur', trigger, true);
+    }
+    if (busyObs) {
+      busyObs.disconnect();
+      busyObs = null;
+    }
+    observedTranscript = transcript;
+    if (!transcript) {
+      return;
+    }
+    // Edits don't resize the fixed-size transcript box, so refresh on blur.
+    transcript.addEventListener('blur', trigger, true);
+    // Transcribe toggles aria-busy without a size change.
+    if (typeof MutationObserver !== 'undefined') {
+      busyObs = new MutationObserver(trigger);
+      busyObs.observe(transcript, { attributes: true, attributeFilter: ['aria-busy'] });
+    }
+  }
+
+  function injectStyles() {
+    const style = document.createElement('style');
+    style.textContent = [
+      // .transcript-holder is already position:absolute, so it is the containing
+      // block for these absolute children, which sit in its left margin (outside
+      // the fixed-width transcript) - no padding on the transcript, no text shift.
+      '.transcript-holder .para-timecode {',
+      '  position: absolute;',
+      '  font-size: 0.85rem;',
+      '  font-variant-numeric: tabular-nums;',
+      '  color: #8a8a8a;',
+      '  cursor: pointer;',
+      '  white-space: nowrap;',
+      '  -webkit-user-select: none;',
+      '  user-select: none;',
+      '  z-index: 1;',
+      '}',
+      '.transcript-holder .para-timecode:hover {',
+      '  color: var(--p, #1f6feb);',
+      '  text-decoration: underline;',
+      '}',
+    ].join('\n');
+    document.head.appendChild(style);
+  }
+
+  function init() {
+    injectStyles();
+
+    const checkbox = document.getElementById('show-timecodes');
+    if (checkbox) {
+      enabled = checkbox.checked;
+      checkbox.addEventListener('change', () => {
+        enabled = checkbox.checked;
+        reposition();
+      });
+    }
+
+    const holder = holderEl();
+    if (holder) {
+      // Delegated seek (elements are reused across repositions).
+      holder.addEventListener('click', (e) => {
+        const tc = e.target.closest && e.target.closest('.para-timecode');
+        if (!tc) {
+          return;
+        }
+        const ms = parseInt(tc.dataset.ms, 10);
+        const player = document.getElementById('hyperplayer');
+        if (player && !isNaN(ms)) {
+          // Nudge just past the first word's start so the library activates and
+          // scrolls to this paragraph, not the previous one (boundary off-by-one).
+          player.currentTime = ms / 1000 + 0.01;
+        }
+      });
+    }
+
+    if (holder && typeof ResizeObserver !== 'undefined') {
+      // The transcript box is fixed-size, but the holder resizes on window
+      // resize and sidebar collapse, which shifts the centred transcript and
+      // its margin labels - so observe the holder, not the transcript.
+      new ResizeObserver(trigger).observe(holder);
+    }
+    if (holder && typeof MutationObserver !== 'undefined') {
+      // The transcript content is replaced by Recents (.transcript-holder wiped),
+      // by transcription, and by imports (#hypertranscript.innerHTML = ...). Watch
+      // the subtree for element add/remove and rebuild. The nodeType===1 guard
+      // skips plain typing (text-node mutations); the .para-timecode guard skips
+      // our own label churn (so this can't loop).
+      new MutationObserver((mutations) => {
+        const structural = mutations.some((m) =>
+          [].concat(
+            Array.prototype.slice.call(m.addedNodes),
+            Array.prototype.slice.call(m.removedNodes),
+          ).some((n) => n.nodeType === 1 && !n.classList.contains('para-timecode')),
+        );
+        if (!structural) {
+          return;
+        }
+        attachToTranscript();
+        trigger();
+      }).observe(holder, { childList: true, subtree: true });
+    }
+
+    window.addEventListener('resize', trigger);
+    document.addEventListener('hyperaudioInit', trigger, false);
+
+    attachToTranscript();
+
+    if (enabled) {
+      reposition();
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
Adds a **Timecodes** toggle (next to **Speakers**) that shows a small `mm:ss` label at the start of each transcript paragraph, derived from its first word's `data-m`. Clicking a label seeks the player. Off by default. Closes #348.

## Design — rendered outside the contenteditable
The labels are **not** DOM nodes inside `#hypertranscript`. They're absolutely-positioned elements appended to `.transcript-holder` (the scroll container), sitting in its **left margin**, outside the fixed-width reading column. Consequences:
- **Not deletable / not selectable** while editing, and never copied.
- **Never in the `[data-m]` word stream** → captions, JSON, ionosphere and the interactive-HTML export are all untouched.
- **No text shift** — they live in the margin, so the 520px reading column doesn't move when toggled on.
- **Scroll with the content natively** (absolute children of the scroll container) — no scroll listener.

## Refresh triggers
Positions/labels rebuild on edit, window-resize and sidebar-collapse, and on every content swap — **Recents load, transcription, and Hyperaudio JSON / SRT / VTT / Deepgram import** — via a `ResizeObserver` + a subtree `MutationObserver` on `.transcript-holder` (guarded by `nodeType===1` so plain typing and our own label churn don't trigger it). Hidden while the transcript is `aria-busy` (transcribing).

## Notes
- Self-contained in `js/paragraph-timecodes.js` — to remove: delete the file, its `<script>` tag, and the `#show-timecodes` checkbox.
- The timecode click nudges the seek **+10 ms** past the word start to dodge a word-boundary off-by-one in the vendored **hyperaudio-lite 2.4.8** (fixed upstream; tracked in #350 — once that bump lands the nudge can go).
- Also shortens the existing "Display speakers" label to "Speakers" to fit the controls row.

## Verification
Headless (Playwright) — all pass: default-off; renders + `mm:ss` format; labels are outside `#hypertranscript`; toggling doesn't shift the text; `#hypertranscript` export byte-identical on vs off; aligned to paragraph tops (0px) and stays aligned after scroll (0px); hidden while `aria-busy`; labels update on content swap (import); click seeks to paragraph start (+nudge).
