### PR TITLE
Bump hyperaudio-lite to 2.5.1 + adopt options API + fragment search (0.6.21)

### DIFF
--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -365,3 +365,16 @@ dialog::backdrop {
   right: 0;
   transform: none;
 }
+
+/* Search: highlight only the matched substring. searchPhrase wraps the match in
+   <mark class="search-mark"> and also tags the word .search-match — neutralise
+   the vendored whole-word background so just the mark shows, tinted with a much
+   lighter version of the signature purple (the DaisyUI primary at low opacity). */
+.hyperaudio-transcript .search-match {
+  background-color: transparent;
+}
+mark.search-mark {
+  background-color: oklch(var(--p) / 0.3);
+  color: inherit;
+  border-radius: 2px;
+}

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -374,7 +374,7 @@ dialog::backdrop {
   background-color: transparent;
 }
 mark.search-mark {
-  background-color: oklch(var(--p) / 0.3);
+  background-color: oklch(var(--p) / 0.22);
   color: inherit;
   border-radius: 2px;
 }

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.20 (last changed in release 0.6.20) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.21 (last changed in release 0.6.21) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.20">
+  <meta name="version" content="0.6.21">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -88,7 +88,7 @@ If you are creating an open source application under a license compatible with t
     }
     
   </style>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.6.14">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.6.21">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -738,10 +738,10 @@ If you are creating an open source application under a license compatible with t
 
 
   <script src="js/hyperaudio-push-notification.js"></script>
-  <script src="js/hyperaudio-lite.js?v=2.4.8"></script>
-  <script src="js/hyperaudio-lite-extension.js"></script>
+  <script src="js/hyperaudio-lite.js?v=2.5.1"></script>
+  <script src="js/hyperaudio-lite-extension.js?v=0.6.21"></script>
   <script src="js/caption.js?v=0.6.19"></script>
-  <script src="js/editor-core.js?v=0.6.16"></script>
+  <script src="js/editor-core.js?v=0.6.21"></script>
 
 
   <import-deepgram-json></import-deepgram-json>

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -119,19 +119,28 @@
   /* ----------------------------------------------------------- */
 
   function hyperaudio() {
-    const minimizedMode = false;
-    const autoScroll = true;
-    const doubleClick = true;
-    const webMonetization = false;
-    const playOnClick = false;
+    // Leave a small gap below the navbar when autoscrolling the active paragraph
+    // (passed natively as scrollOffset to the 2.5.x options-object constructor).
+    const SCROLL_TOP_GAP = 24;
 
-    const hyperaudioInstance = new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick);
+    const hyperaudioInstance = new HyperaudioLite({
+      transcript: "hypertranscript",
+      player: "hyperplayer",
+      minimizedMode: false,
+      autoScroll: true,
+      doubleClick: true,
+      webMonetization: false,
+      playOnClick: false,
+      scrollOffset: SCROLL_TOP_GAP,
+    });
 
     // Patch for #294: if the library's polling chain runs while wordArr
     // still references a span deleted by an in-progress edit, the original
     // throws on word.n.parentNode.classList and the chain dies silently.
     // Strip detached entries before delegating — the next debounced
     // refreshHyperaudioInstance will rebuild wordArr from the live DOM.
+    // (Still required in 2.5.1: updateTranscriptVisualState dereferences
+    // word.n.parentNode.classList unguarded.)
     const originalUpdateVisualState = hyperaudioInstance.updateTranscriptVisualState.bind(hyperaudioInstance);
     hyperaudioInstance.updateTranscriptVisualState = function (...args) {
       if (hyperaudioInstance.wordArr) {
@@ -154,28 +163,8 @@
       hyperaudioInstance.scrollContainer = scrollHolder;
     }
 
-    // The library scrolls the active paragraph flush to the top of the scroll
-    // container, which tucks it under the navbar. Override scrollToParagraph to
-    // leave a small gap at the top. (Stopgap until hyperaudio-lite supports a
-    // configurable scroll offset.)
-    const SCROLL_TOP_GAP = 24;
-    hyperaudioInstance.scrollToParagraph = function (currentParentElementIndex, index) {
-      if (currentParentElementIndex === this.parentElementIndex) {
-        return;
-      }
-      this.parentElementIndex = currentParentElementIndex;
-      if (!this.autoscroll) {
-        return;
-      }
-      const paragraph = this.parentElements[currentParentElementIndex];
-      if (!paragraph) {
-        return;
-      }
-      const containerRect = this.scrollContainer.getBoundingClientRect();
-      const paragraphRect = paragraph.getBoundingClientRect();
-      const target = this.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top) - SCROLL_TOP_GAP;
-      this.smoothScrollTo(this.scrollContainer, Math.max(0, target), 800);
-    };
+    // (The top-gap scrollToParagraph override is gone — 2.5.x applies it natively
+    // via the scrollOffset option passed to the constructor above.)
 
     // Pause autoscroll while the user is actively typing so it doesn't yank the
     // view mid-edit; resume shortly after. Uses 'input' (content changes) so

--- a/js/hyperaudio-lite-extension.js
+++ b/js/hyperaudio-lite-extension.js
@@ -21,54 +21,68 @@ document.querySelector('#search-box').addEventListener("keyup", (event) => {
 });
 
 
-let searchPhrase = function (phrase) {
-	
-  let htmlWords = document.querySelectorAll('[data-m]');
-  let htmlWordsLen = htmlWords.length;
-	
-  let phraseWords = phrase.split(" ");
-  let phraseWordsLen = phraseWords.length;
-  let matchedTimes = [];
+// searchPhrase + helpers ported verbatim from hyperaudio-lite v2.5.1's
+// extension. Walks consecutive [data-m] spans for multi-word phrases; for each
+// matching span it wraps just the matched substring in a <mark class="search-mark">
+// so only the searched characters are highlighted, not the whole word. Matching
+// is substring-based, so word fragments are found as you type.
+const SEARCH_PUNCT = /[.,\-\/#!$%\^&\*;:{}=_`~()\?\s]/g;
+const normalise = (text) => text.toLowerCase().replace(SEARCH_PUNCT, '');
 
-  // clear matched times
-  let searchMatched = document.querySelectorAll('.search-match');
-
-  searchMatched.forEach((match) => {
-    match.classList.remove('search-match');
+const clearPreviousSearch = () => {
+  document.querySelectorAll('mark.search-mark').forEach((mark) => {
+    mark.replaceWith(document.createTextNode(mark.textContent));
   });
+  document.querySelectorAll('.search-match').forEach((el) => {
+    el.classList.remove('search-match');
+    el.normalize(); // merge adjacent text nodes left behind by the unwrap
+  });
+};
 
-  for (let i = 0; i < htmlWordsLen; i++) {
-    let numWordsMatched = 0;
-    let potentiallyMatched = [];
+// Wrap the first occurrence of `needle` (case-insensitive) inside `span`'s
+// text with <mark class="search-mark">. Punctuation stays outside the mark.
+const highlightSubstring = (span, needle) => {
+  const original = span.textContent;
+  const idx = original.toLowerCase().indexOf(needle);
+  if (idx < 0) return;
+  const before = original.slice(0, idx);
+  const hit = original.slice(idx, idx + needle.length);
+  const after = original.slice(idx + needle.length);
+  span.textContent = '';
+  if (before) span.append(before);
+  const mark = document.createElement('mark');
+  mark.className = 'search-mark';
+  mark.textContent = hit;
+  span.append(mark);
+  if (after) span.append(after);
+};
 
-    for (let j = 0; j < phraseWordsLen; j++) {
-      let wordIndex = i + numWordsMatched;
+const searchPhrase = (phrase) => {
+  const spans = document.querySelectorAll('[data-m]');
+  if (!spans.length) return;
 
-      if (wordIndex >= htmlWordsLen) {
-        break;
-      }
+  clearPreviousSearch();
 
-      // regex removes punctuation - NB for htmlWords case we also remove the space
+  const needles = phrase
+    .toLowerCase()
+    .split(/\s+/)
+    .map((w) => w.replace(SEARCH_PUNCT, ''))
+    .filter(Boolean);
+  if (!needles.length) return;
 
-      if (phraseWords[j].toLowerCase() == htmlWords[wordIndex].innerHTML.toLowerCase().replace(/[\.,-\/#!$%\^&\*;:{}=\-_`~()\? ]/g,"")) {
-        potentiallyMatched.push(htmlWords[wordIndex].getAttribute('data-m'));
-        numWordsMatched++;
-      } else {
-        break;
-      }
-
-      // if the num of words matched equal the search phrase we have a winner!
-      if (numWordsMatched >= phraseWordsLen) {
-        matchedTimes = matchedTimes.concat(potentiallyMatched);
-      }
-    }
+  const lastStart = spans.length - needles.length;
+  for (let i = 0; i <= lastStart; i++) {
+    const hit = needles.every((needle, j) =>
+      normalise(spans[i + j].textContent).includes(needle)
+    );
+    if (!hit) continue;
+    needles.forEach((needle, j) => {
+      const span = spans[i + j];
+      span.classList.add('search-match');
+      highlightSubstring(span, needle);
+    });
   }
-
-  // display
-  matchedTimes.forEach(matchedTime => {
-    document.querySelectorAll("[data-m='"+matchedTime+"']")[0].classList.add("search-match");
-  });
-}
+};
 
 const playbackRateCtrl = document.getElementById('pbr');
 const currentPlaybackRate = document.getElementById('currentPbr');

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.4.8 */
+/*! Version 2.5.1 */
 
 'use strict';
 
@@ -25,26 +25,23 @@ class BasePlayer {
     this.player.addEventListener('seeked', instance.handleSeeked.bind(instance), false);
   }
 
-  // Method to get the current time of the player
+  // Contract methods — subclasses must implement these for their player's API.
+  // BasePlayer is intentionally abstract; previous HTML5 defaults now live in
+  // NativePlayer so non-native subclasses can't silently inherit wrong behaviour.
   getTime() {
-    return Promise.resolve(this.player.currentTime);
+    throw new Error('getTime must be implemented by subclasses');
   }
 
-  // Method to set the current time of the player
   setTime(seconds) {
-    this.player.currentTime = seconds;
+    throw new Error('setTime must be implemented by subclasses');
   }
 
-  // Method to play the media
   play() {
-    this.player.play();
-    this.paused = false;
+    throw new Error('play must be implemented by subclasses');
   }
 
-  // Method to pause the media
   pause() {
-    this.player.pause();
-    this.paused = true;
+    throw new Error('pause must be implemented by subclasses');
   }
 }
 
@@ -53,6 +50,24 @@ class NativePlayer extends BasePlayer {
   // Initialize the native HTML5 player
   initPlayer(instance) {
     return instance.player;
+  }
+
+  getTime() {
+    return Promise.resolve(this.player.currentTime);
+  }
+
+  setTime(seconds) {
+    this.player.currentTime = seconds;
+  }
+
+  play() {
+    this.player.play();
+    this.paused = false;
+  }
+
+  pause() {
+    this.player.pause();
+    this.paused = true;
   }
 }
 
@@ -297,9 +312,37 @@ function hyperaudioPlayer(playerType, instance) {
 
 // Main class for HyperaudioLite functionality
 class HyperaudioLite {
-  constructor(transcriptId, mediaElementId, minimizedMode, autoscroll, doubleClick, webMonetization, playOnClick) {
-    this.transcript = document.getElementById(transcriptId);
-    this.init(mediaElementId, minimizedMode, autoscroll, doubleClick, webMonetization, playOnClick);
+  // Constructor accepts EITHER form:
+  //   new HyperaudioLite({ transcript, player, autoScroll, ... })   -- recommended
+  //   new HyperaudioLite(transcriptId, mediaElementId, ...flags)    -- deprecated, kept for BC
+  // The positional form continues to work indefinitely across the 2.x line.
+  constructor(...args) {
+    let opts;
+    if (typeof args[0] === 'object' && args[0] !== null) {
+      // Options-object form. Apply sensible defaults so common cases stay short.
+      opts = {
+        minimizedMode: false,
+        autoScroll: true,
+        doubleClick: false,
+        webMonetization: false,
+        playOnClick: true,
+        scrollOffset: 0,
+        ...args[0],
+      };
+    } else {
+      // Legacy positional form. Pass values through without applying defaults
+      // so existing callers get identical behaviour (undefined stays undefined).
+      HyperaudioLite._warnPositionalOnce();
+      const [transcript, player, minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick] = args;
+      opts = { transcript, player, minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick };
+    }
+
+    this.transcript = document.getElementById(opts.transcript);
+    this.init(opts.player, opts.minimizedMode, opts.autoScroll, opts.doubleClick, opts.webMonetization, opts.playOnClick);
+    // scrollOffset is read directly by scrollToParagraph; consumers can also
+    // set/change it on the instance after construction (e.g. for layouts that
+    // resize their sticky header).
+    this.scrollOffset = opts.scrollOffset || 0;
 
     // Ensure correct binding for class methods
     this.preparePlayHead = this.preparePlayHead.bind(this);
@@ -308,6 +351,20 @@ class HyperaudioLite {
     this.checkPlayHead = this.checkPlayHead.bind(this);
     this.clearTimer = this.clearTimer.bind(this);
     this.handleSeeked = this.handleSeeked.bind(this);
+  }
+
+  // Throttled deprecation warning — fires at most once per page load
+  // regardless of how many positional-form constructions happen.
+  static _warnPositionalOnce() {
+    if (HyperaudioLite._positionalWarned) return;
+    HyperaudioLite._positionalWarned = true;
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn(
+        'HyperaudioLite: the positional-argument constructor is deprecated. ' +
+        'Pass an options object instead — see the README. The positional form ' +
+        'continues to work across the 2.x line.'
+      );
+    }
   }
 
   // Initialize the HyperaudioLite instance
@@ -649,8 +706,8 @@ class HyperaudioLite {
         if (currentParagraph) {
           const containerRect = this.scrollContainer.getBoundingClientRect();
           const paragraphRect = currentParagraph.getBoundingClientRect();
-          const targetTop = this.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top);
-          this.smoothScrollTo(this.scrollContainer, targetTop, 800);
+          const targetTop = this.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top) - (this.scrollOffset || 0);
+          this.smoothScrollTo(this.scrollContainer, Math.max(0, targetTop), 800);
         }
       }
       this.parentElementIndex = currentParentElementIndex;
@@ -779,7 +836,12 @@ class HyperaudioLite {
       } else if (difference > 0) {
         words = guessIndex - 1;
       } else {
-        index = guessIndex;
+        // Exact match: treat the matched word as having just started, so
+        // wordArr[index - 1] (used downstream as the active word) points to
+        // this word, not the previous one. Without the +1 we'd land an
+        // off-by-one at every word boundary — visible on every click,
+        // since clicks set currentTime to a word's exact start time.
+        index = guessIndex + 1;
         break;
       }
     }


### PR DESCRIPTION
Closes #350, closes #352.

## hyperaudio-lite 2.5.1 (#350)
`js/hyperaudio-lite.js` replaced with the **verbatim upstream v2.5.1** build (`?v=2.5.1`). Fixes the word-boundary off-by-one (clicking a word activated the *previous* word and scrolled to the *previous* paragraph, snapping right on play) — fixed upstream, doesn't reproduce in the 2.5.1 demos.

The editor's customized `hyperaudio-lite-extension.js` was **not** clobbered — it targets the editor's markup (incremental `#search-box` keyup, editable playback-rate input), not the upstream demo's; the off-by-one fix is in the core.

## Adopt the 2.5.x options API (#352)
- `editor-core.js` now uses the **options-object constructor** with `scrollOffset: 24` (silences the positional-constructor deprecation warning).
- **Removed** the custom `scrollToParagraph` override — 2.5.1's native method is byte-for-byte identical and reads `scrollOffset`.
- **Kept** the #294 `updateTranscriptVisualState` wrapper — verified 2.5.1 still dereferences `word.n.parentNode.classList` unguarded, so it's still required.

## Fragment search
`searchPhrase` + helpers **ported verbatim from upstream v2.5.1's extension** (keeping the editor's keyup wiring + playback-rate UI). Search now:
- matches **word fragments** (substring) as you type, and
- wraps **only the matched characters** in `<mark class="search-mark">` instead of flagging the whole word.

Editor CSS neutralises the vendored whole-word `.search-match` pink and tints `mark.search-mark` with a much lighter signature purple (`oklch(var(--p) / 0.3)`).

## Verification (headless, all pass)
- **Library:** loads clean (no errors); 2.5.1 instance with editor wiring (`scrollContainer`, native `scrollOffset === 24`); **no** deprecation warning; double-click word seek correct; paragraph timecodes still render.
- **Search:** `#search-box` present; typing `trans` creates 8 marks; the mark contains only `trans` and sits inside the `transcripts.` word span; clearing removes all marks and the transcript text is byte-identical.

## Notes
- `sanitise` doesn't corrupt marked words (the mark's text node has no siblings, so its walker skips it). An HTML/interactive-transcript export taken *while a search is active* would contain stray `<mark>` tags; captions/JSON/ionosphere are unaffected (they read `data-m` spans). Transient/edge.
- Follow-up: fully reconciling the extension with upstream (adopting upstream's `#searchForm` submit + display-only rate markup) is a separate, larger task.

App → 0.6.21; `editor-core.js`/`hyperaudio-lite-extension.js`/`hyperaudio-lite-editor.css` cache-busts bumped.
