### PR TITLE
Pin the app shell so the top bar can't scroll off-screen (0.6.22)

### DIFF
--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -13,6 +13,16 @@ body {
   font-family: system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Fira Sans','Droid Sans','Helvetica Neue',sans-serif;
   line-height: 1.8;
   background-color: #f5f5f5;
+  /* #354: pin the app shell to the viewport. The layout is fully absolute-
+     positioned, but the absolute #hypertranscript bled ~18px of overflow into
+     the document, letting the whole page (and the fixed top bar) scroll — and
+     a restored scroll position could stick it off-screen. A fixed body of the
+     exact viewport size removes any document scroll while keeping every
+     absolute panel in place (a fixed body is still their containing block). */
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  overscroll-behavior: none;
 }
 
 input, output, select, button, textarea {

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.21 (last changed in release 0.6.21) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.22 (last changed in release 0.6.22) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.21">
+  <meta name="version" content="0.6.22">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -88,7 +88,7 @@ If you are creating an open source application under a license compatible with t
     }
     
   </style>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.6.21">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.6.22">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>


### PR DESCRIPTION
Closes #354.

The editor is a fully absolute-positioned app shell, but the absolute `#hypertranscript` (top:10/bottom:0 with overflowing content) bled **~18px** into the document scroll height, so the whole page — including the fixed top bar — could be scrolled.

A first attempt (`html { overflow: hidden }`) made it worse: it froze a **restored** scroll position, sticking the bar permanently off-screen.

## Fix
Pin `<body>` to the viewport so the document has **no scroll height at all** — nothing to scroll, nothing to restore — while the absolutely-positioned panels stay exactly where they were (a fixed body is still their containing block):
```css
body {
  position: fixed;
  inset: 0;
  overflow: hidden;
  overscroll-behavior: none;
}
```

## Verification (headless, 1280×900)
- Navbar pinned at top `0`; side panel fills the viewport (`0..900`).
- **Document overflow is now `0px`** (was 18px).
- A forced/restored `scrollTop = 30` leaves `scrollY = 0` and the navbar at `0` — the off-screen regression is gone.
- Wheel over the page doesn't move it; the transcript still scrolls internally.

App → 0.6.22; editor CSS cache-bust bumped.
