### PR TITLE
Re-vendor caption.js 2.1.6 — fixes captions persisting on media change (0.6.23)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.22 (last changed in release 0.6.22) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.23 (last changed in release 0.6.23) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.22">
+  <meta name="version" content="0.6.23">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -740,7 +740,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-push-notification.js"></script>
   <script src="js/hyperaudio-lite.js?v=2.5.1"></script>
   <script src="js/hyperaudio-lite-extension.js?v=0.6.21"></script>
-  <script src="js/caption.js?v=0.6.19"></script>
+  <script src="js/caption.js?v=0.6.23"></script>
   <script src="js/editor-core.js?v=0.6.21"></script>
 
 

--- a/js/caption.js
+++ b/js/caption.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.1.5 */
+/*! Version 2.1.6 */
 'use strict';
 
 const caption = function () {
@@ -412,27 +412,39 @@ const caption = function () {
     const video = document.getElementById(playerId);
 
     if (video !== null) {
-      video.addEventListener('loadedmetadata', function listener() {
+      const applyCaptions = function () {
         const track = document.getElementById(`${playerId}-vtt`);
 
         if (track !== null) {
           track.kind = 'captions';
 
           if (label !== undefined) {
-            //console.log("setting label as "+label);
             track.label = label;
           }
 
           if (srclang !== undefined) {
-            //console.log("setting srclang as "+srclang);
             track.srclang = srclang;
           }
 
           track.src = `data:text/vtt,${encodeURIComponent(captionsVtt)}`;
-          video.textTracks[0].mode = 'showing';
-          video.removeEventListener('loadedmetadata', listener, true);
+          if (video.textTracks[0] !== undefined) {
+            video.textTracks[0].mode = 'showing';
+          }
         }
-      }, true);
+      };
+
+      // If the media's metadata has already loaded, 'loadedmetadata' will not
+      // fire again, so apply the captions now; otherwise apply on a single-use
+      // listener. This prevents a listener persisting with a stale captionsVtt
+      // closure and re-applying it when a different media subsequently loads.
+      if (video.readyState >= 1 /* HAVE_METADATA */) {
+        applyCaptions();
+      } else {
+        video.addEventListener('loadedmetadata', function listener() {
+          applyCaptions();
+          video.removeEventListener('loadedmetadata', listener, true);
+        }, true);
+      }
 
       if (video.textTracks !== undefined && video.textTracks[0] !== undefined) {
         video.textTracks[0].mode = 'showing';


### PR DESCRIPTION
Closes #356.

Re-vendors the verbatim upstream **v2.1.6** build of `caption.js` (hyperaudio/hyperaudio-lite#244), which fixes the listener bug behind #356: `cap.init`'s `loadedmetadata` listener could persist holding a stale caption set and, when a new media source loaded, re-apply the previous media's captions in place of the current ones (the stacked caption sets seen when loading a file from Recents).

The upstream fix applies the captions immediately when the metadata is already loaded, and otherwise uses a single-use listener — so no listener persists.

## Notes
- `js/caption.js` is **byte-identical to upstream `origin/main`** (v2.1.6) — pulled the build, not hand-edited.
- No editor code changed; the editor keeps calling `caption.js` as before.

## Verification (headless, editor with the re-vendored 2.1.6)
- Captions apply (cues present) when metadata is already loaded.
- A subsequent `loadedmetadata` event no longer overwrites the current captions.

App → 0.6.23; `caption.js` cache-bust bumped.
