### PR TITLE
Extract shared 16 kHz audio-decode helper (#359, 0.6.24)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.23 (last changed in release 0.6.23) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.24 (last changed in release 0.6.24) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,16 +18,17 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.23">
+  <meta name="version" content="0.6.24">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png">
   <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
  
+  <script src="js/audio-source.js?v=0.6.24"></script>
   <script src="js/hyperaudio-lite-editor-deepgram.js?v=0.6.7"></script>
-  <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.9"></script>
-  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.6.9"></script>
+  <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.24"></script>
+  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.6.24"></script>
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js?v=0.6.18"></script>
   <script src="js/transcript-to-ionosphere.js?v=0.6.18"></script>

--- a/js/audio-source.js
+++ b/js/audio-source.js
@@ -1,0 +1,39 @@
+/**
+ * audio-source.js
+ * (C) The Hyperaudio Project
+ * @version 0.6.24 — last changed in release 0.6.24
+ * @license MIT
+ *
+ * Shared audio-decode helper for the local transcription engines.
+ *
+ * Whisper (Local) and Parakeet (Local) both need their source media decoded to
+ * the single buffer their workers consume: a 16 kHz mono Float32Array. This
+ * used to be a byte-identical `readAudioFrom(file)` copied into each engine
+ * client; it now lives here once (see #359).
+ *
+ * Deepgram is unaffected — it transcribes server-side and never decodes locally.
+ *
+ * Loaded as a plain <script> before the engine clients, exposing
+ * `decodeToMono16k` as a global, matching the rest of the editor's helpers.
+ */
+
+/**
+ * Decode media to a 16 kHz mono Float32Array (channel 0).
+ *
+ * @param {File|Blob|ArrayBuffer} source - an uploaded file/blob, or already-
+ *   fetched bytes (e.g. extracted from a stream).
+ * @returns {Promise<Float32Array>} mono PCM samples at 16 kHz.
+ */
+async function decodeToMono16k(source) {
+  const sampling_rate = 16e3;
+  const audioCTX = new AudioContext({ sampleRate: sampling_rate });
+  try {
+    const arrayBuffer = source instanceof ArrayBuffer
+      ? source
+      : await source.arrayBuffer();
+    const decoded = await audioCTX.decodeAudioData(arrayBuffer);
+    return decoded.getChannelData(0);
+  } finally {
+    audioCTX.close();
+  }
+}

--- a/js/hyperaudio-lite-editor-parakeet-local.js
+++ b/js/hyperaudio-lite-editor-parakeet-local.js
@@ -1,7 +1,7 @@
 /**
  * hyperaudio-lite-editor-parakeet-local.js
  * (C) The Hyperaudio Project
- * @version 0.6.9 — last changed in release 0.6.9
+ * @version 0.6.24 — last changed in release 0.6.24
  * @license MIT
  */
 
@@ -258,7 +258,8 @@ function loadParakeetClient(modal, workerBaseUrl) {
 
     let audio;
     try {
-      audio = await readAudioFrom(file);
+      // shared 16 kHz mono decode helper (js/audio-source.js, #359)
+      audio = await decodeToMono16k(file);
     } catch (e) {
       console.error(e);
       handleError("Could not decode the media file.");
@@ -271,18 +272,6 @@ function loadParakeetClient(modal, workerBaseUrl) {
 
     // transfer the buffer rather than copying it
     webWorker.postMessage({ type: "INFERENCE_REQUEST", audio, forceGpu }, [audio.buffer]);
-  }
-
-  async function readAudioFrom(file) {
-    const sampling_rate = 16e3;
-    const audioCTX = new AudioContext({ sampleRate: sampling_rate });
-    try {
-      const response = await file.arrayBuffer();
-      const decoded = await audioCTX.decodeAudioData(response);
-      return decoded.getChannelData(0);
-    } finally {
-      audioCTX.close();
-    }
   }
 }
 

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -1,7 +1,7 @@
 /**
  * hyperaudio-lite-editor-whisper.js
  * (C) The Hyperaudio Project
- * @version 0.6.9 — last changed in release 0.6.9
+ * @version 0.6.24 — last changed in release 0.6.24
  * @license MIT
  */
 
@@ -286,7 +286,8 @@ function loadWhisperClient(modal, workerBaseUrl) {
 
     let audio;
     try {
-      audio = await readAudioFrom(file);
+      // shared 16 kHz mono decode helper (js/audio-source.js, #359)
+      audio = await decodeToMono16k(file);
     } catch (e) {
       console.error(e);
       handleError("Could not decode the media file.");
@@ -301,17 +302,5 @@ function loadWhisperClient(modal, workerBaseUrl) {
       model_name,
       language
     }, [audio.buffer]);
-  }
-
-  async function readAudioFrom(file) {
-    const sampling_rate = 16e3;
-    const audioCTX = new AudioContext({ sampleRate: sampling_rate });
-    try {
-      const response = await file.arrayBuffer();
-      const decoded = await audioCTX.decodeAudioData(response);
-      return decoded.getChannelData(0);
-    } finally {
-      audioCTX.close();
-    }
   }
 }


### PR DESCRIPTION
Closes #359.

Whisper (Local) and Parakeet (Local) each carried a byte-identical local `readAudioFrom(file)` that decoded media to the 16 kHz mono `Float32Array` their workers consume. This extracts it into a single module.

### Changes
- **New `js/audio-source.js`** — `decodeToMono16k(source)`, the one copy of the decode. Accepts a `File`/`Blob` **or** an `ArrayBuffer`; the `ArrayBuffer` branch is the seam #358 (HLS VOD) will use to resolve stream-extracted bytes into the same engine buffer. Loaded as a plain global, matching the editor's other helpers.
- **Whisper & Parakeet clients** — dropped their local `readAudioFrom`, now call `decodeToMono16k(file)`. Identical error handling and transferable-buffer post.
- **index.html** — `audio-source.js` script tag added before the engine clients; engine `?v=` bumped; version comment + meta → 0.6.24.

Pure refactor — no behavioural change. Deepgram is untouched (transcribes server-side, never decodes locally).

### Verification
- All three touched JS files pass `node --check`; no `readAudioFrom` remains outside an explanatory comment.
- Headless Chromium against `test/test.mp3`: `decodeToMono16k` is global, returns a `Float32Array` of 192,003 samples = 12.0 s at exactly 16 kHz, genuine signal (peak 0.29, finite), no console errors. `ArrayBuffer` and `Blob` inputs produce identical output.
- Manual check of the full transcribe flow through both local engines.
