### PR TITLE
Clear caption track completely on Recents load (#356/#287, 0.6.25)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.24 (last changed in release 0.6.24) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.25 (last changed in release 0.6.25) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.24">
+  <meta name="version" content="0.6.25">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -790,7 +790,7 @@ If you are creating an open source application under a license compatible with t
   </div>
  
 
-  <script src="./js/hyperaudio-lite-editor-storage.js"></script>
+  <script src="./js/hyperaudio-lite-editor-storage.js?v=0.6.25"></script>
 
   <script src="js/editor-file-menu.js?v=0.6.12"></script>
 

--- a/js/hyperaudio-lite-editor-storage.js
+++ b/js/hyperaudio-lite-editor-storage.js
@@ -23,6 +23,39 @@ const fileExtension = ".hyperaudio";
 let lastFilename = null;
 
 /*
+ * Completely remove the existing caption <track> and insert a fresh, empty one.
+ *
+ * On a Recents (or any media) load the <video> and its <track> are reused. The
+ * track stays in 'showing' mode across the swap, so Chromium can keep the
+ * PREVIOUS media's active cue *painted* even after track.src is reassigned — the
+ * new media starts at currentTime 0, where often no new cue is active yet, so
+ * the caption region never repaints and the old line lingers (the "double
+ * captions" of #356 / #287). Removing the <track> element drops its rendered
+ * output immediately; a fresh element cannot carry stale cues or stale paint.
+ *
+ * @return {HTMLTrackElement|null} the fresh, empty track (or null if no player)
+ */
+function resetCaptionTrack(videoDomId = 'hyperplayer', vttId = 'hyperplayer-vtt') {
+  const video = document.getElementById(videoDomId);
+  if (video === null) {
+    return null;
+  }
+
+  const old = document.getElementById(vttId);
+  if (old !== null) {
+    old.remove();
+  }
+
+  const track = document.createElement('track');
+  track.id = vttId;
+  track.label = 'preview';
+  track.kind = 'subtitles';
+  track.src = '';
+  video.appendChild(track);
+  return track;
+}
+
+/*
  * Render the HyperTranscript in the DOM
  * @return {void}
  */
@@ -34,8 +67,12 @@ function renderTranscript(
   vttId = 'hyperplayer-vtt',
   hypertranscriptHolder = '.transcript-holder',
 ) {
+  // Tear down the previous media's captions completely before loading the new
+  // file, so a stale cue from the old transcript can't stay painted (#356/#287).
+  resetCaptionTrack(videoDomId, vttId);
+
   let hypertranscriptElement = document.getElementById(hypertranscriptDomId);
- 
+
   if (hypertranscriptElement) {
     hypertranscriptElement.innerHTML = hypertranscriptstorage['hypertranscript'];
   } else {
@@ -69,6 +106,13 @@ function renderTranscript(
     // stop caption.js inserting VTT upon insertion of new video
 
     document.getElementById(vttId).src = hypertranscriptstorage['captions'];
+    // the fresh track (resetCaptionTrack) defaults to 'disabled'; restore the
+    // 'showing' mode the stored-caption path previously relied on (the reused
+    // track carried it across loads) so the new captions actually display
+    const video = document.getElementById(videoDomId);
+    if (video !== null && video.textTracks[0] !== undefined) {
+      video.textTracks[0].mode = 'showing';
+    }
     //remove data:text/vtt, and decode
     let plainVtt = decodeURIComponent(hypertranscriptstorage['captions'].split(',')[1]);
 


### PR DESCRIPTION
Closes #356. Also addresses #287 (the same "double captions" symptom).

### Symptom
Loading a file from Recents could leave a caption line from the *previous* media painted under the new transcript's captions.

### Cause
There is only one `<track>` element and nothing ever creates a second, so this isn't two tracks. The `<video>` and its `<track>` are reused across loads, and the track stays in `showing` mode across the swap. After `track.src` is reassigned the cue **data model** updates correctly (verified), but the new media starts at `currentTime` 0 where often no new cue is active yet — so Chromium never repaints the caption region and the old line stays painted.

### Fix
`resetCaptionTrack()` removes the `<track>` element entirely and inserts a fresh empty one **before** the new media and captions are set. Removing the element drops its rendered output immediately, so neither stale cues nor stale paint can survive. The stored-caption branch restores `showing` mode, since a fresh `<track>` defaults to `disabled` (the trap that made an earlier attempt drop captions entirely).

Editor-side only; independent of and complementary to the caption.js 2.1.6 re-vendor in #357.

### Verification
- Headless Chromium against the live page: old cue active/showing → after `resetCaptionTrack` it is completely gone (`cues: []`, `active: []`, one track) → new captions load cleanly on the fresh track. `node --check` clean.
- Manual confirmation that the doubling no longer occurs on a real Recents A→B reload.

### Notes
- `resetCaptionTrack` is reusable: if doubling ever appears on the import path, the same helper can be called there.
