### PR TITLE
Responsive layout for tablet and phone (#349, 0.6.27)

### DIFF
--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -262,49 +262,233 @@ dialog::backdrop {
 
 }
 
-@media screen and (max-width: 480px) {
-  
-  .hyperaudio-transcript {
-    top: 40px; 
-    bottom: 0px; 
-    background-color: #ffffff; 
-    padding-top: 48px; 
-    width: 100%; 
-    outline: none;
+/* The Recents drawer backdrop and the player-collapse toggle only exist on the
+   small-screen layout; hide them by default (desktop). */
+#drawer-backdrop { display: none; }
+#player-collapse-toggle { display: none; }
+
+/* =========================================================================
+   Small-screen layout (#349) — phones and tablet portrait.
+   A single column: fixed navbar at the very top, the video pinned just below
+   it (collapsible), the transcript scrolling full-width beneath, and the play
+   bar docked at the bottom. Recents becomes an off-canvas drawer. This replaces
+   the desktop absolute two-pane; !important is needed on a few rules to beat
+   the inline .style.left the sidebar-toggle JS writes.
+   ========================================================================= */
+@media screen and (max-width: 948px) {
+  body {
+    --nav-h: 70px;       /* matches the navbar's inline min-height */
+    --player-h: 210px;   /* video area + a 44px controls row */
+  }
+  body.player-collapsed {
+    --player-h: 44px;    /* controls row only; video hidden */
   }
 
+  /* the side panel no longer lays anything out — its children (player + recents)
+     are individually fixed below */
+  .side-panel {
+    position: static !important;
+    width: auto !important;
+    height: auto;
+    padding: 0;
+    background: none;
+    overflow: visible;
+  }
+
+  /* navbar (the .main-panel) pinned to the very top */
+  .main-panel {
+    position: fixed !important;
+    top: 0;
+    left: 0 !important;
+    right: 0;
+    width: auto;
+  }
+  .main-panel .navbar {
+    min-height: var(--nav-h);
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+
+  /* pinned, collapsible player just below the navbar */
+  #player-pane {
+    position: fixed;
+    top: var(--nav-h);
+    left: 0;
+    right: 0;
+    height: var(--player-h);
+    z-index: 15;
+    background: #f5f5f5;
+    padding: 4px 8px 0;
+    box-sizing: border-box;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+    transition: height 0.25s ease;
+    overflow: visible;   /* let control tooltips show; the video is clipped by #player-frame */
+  }
+  #player-pane #player-frame {
+    height: calc(var(--player-h) - 44px);   /* 0 when collapsed → video hidden */
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;   /* centre the video; grey shows either side */
+    transition: height 0.25s ease;
+  }
+  #player-pane #hyperplayer {
+    height: 100%;
+    width: auto !important;    /* size to the video's aspect, not the full frame */
+    max-width: 100%;
+    object-fit: contain;
+    background: transparent;   /* let the grey player background show, not black */
+    border-radius: 0.5rem;     /* rounded corners hug the video itself */
+  }
+  #player-pane #player-controls {
+    height: 40px;
+    margin-top: 4px;
+    overflow-x: auto;
+  }
+  /* Paragraph timecodes live in the transcript's left margin, which the
+     full-width mobile layout has no room for — hide the toggle and any nodes. */
+  #player-controls label[for="show-timecodes"] { display: none !important; }
+  .para-timecode { display: none; }
+  /* flip the collapse chevron when collapsed */
+  #player-collapse-toggle { display: inline-flex; }
+  body.player-collapsed #player-collapse-icon { transform: rotate(180deg); }
+
+  /* transcript fills the space between the pinned player and the play bar */
   .transcript-holder {
-    left: 0px;
+    position: fixed !important;
+    top: calc(var(--nav-h) + var(--player-h)) !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: 52px !important;
+    transition: top 0.25s ease;
+  }
+  .hyperaudio-transcript {
+    position: relative;
+    top: auto;
+    bottom: auto;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    padding: 8px 12px 48px;
   }
 
   #playbar {
-    left: 0px;
+    left: 0 !important;
+    right: 0;
+    gap: 8px;
+    padding: 0 8px;
   }
+  #playbar-seek { min-width: 0; }
 
-  .side-panel, #transcribe-label {
-    display: none;
-  }
+  html { overflow-x: hidden; }
+  /* let button tooltips drop below the bar over the video */
+  .main-panel .navbar { overflow: visible; }
 
-  .main-panel {
+  /* Lift the navbar above the pinned player and transcript so its tooltips (which
+     drop below the buttons, over the video) are not covered. Beats the inline
+     z-index:2 on .main-panel. */
+  .main-panel { z-index: 60 !important; }
+
+  /* Recents: off-canvas drawer, toggled by #sidebar-toggle (see responsive.js) */
+  #recents-pane {
+    position: fixed;
+    top: var(--nav-h);
+    bottom: 52px;
     left: 0;
+    width: min(85vw, 320px);
+    z-index: 45;
+    background: #f5f5f5;
+    padding: 8px;
+    box-sizing: border-box;
+    overflow-y: auto;
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    box-shadow: 2px 0 10px rgba(0,0,0,0.25);
   }
+  body.drawer-open #recents-pane { transform: none; }
 
-  .holder {
-    left: 0;
+  #drawer-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 44;
+    background: rgba(0,0,0,0.4);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.25s ease;
   }
+  body.drawer-open #drawer-backdrop { opacity: 1; visibility: visible; }
 
-  #search-box, #sidebar-toggle, #regenerate-icon{
-    display: none;
+  /* keep the sidebar toggle available (it opens the drawer); it was hidden at
+     ≤480 before */
+  #sidebar-toggle { display: inline-flex; }
+
+  /* fluid modals / overlays so they fit ~375px screens */
+  .modal-box { max-width: calc(100vw - 24px); }
+  #captionsource-alert {
+    width: calc(100vw - 24px) !important;
+    max-width: 480px;
+    left: 12px !important;
+    right: 12px;
+    margin: -70px auto 0 !important;
   }
+  #captions-display { width: 100%; }
+  /* the three transcribe tabs must wrap/shrink instead of overflowing */
+  .modal-box [name="my_tabs_2"] { width: auto !important; flex: 1 1 auto; min-width: 0; }
 
-  /*.navbar-start {
-    width: 36%;
-  }*/
+  /* Hide the scrollbars on the mobile scroll surfaces (touch scrolling still
+     works) — otherwise the transcript's always-on scrollbar shows as a grey
+     sliver at the right edge. */
+  .transcript-holder,
+  #player-controls,
+  #recents-pane { scrollbar-width: none; }
+  .transcript-holder::-webkit-scrollbar,
+  #player-controls::-webkit-scrollbar,
+  #recents-pane::-webkit-scrollbar { width: 0; height: 0; display: none; }
+}
 
-  .modal-box {
-    width:300px;
+/* =========================================================================
+   Compact toolbar for the narrowest screens (#349). Between 948px and 580px the
+   pinned/drawer layout is active but the navbar still shows the search box and
+   the full toolbar. Below 580px there is no longer room, so drop the search box
+   and FILE menu, shrink and right-align the buttons, and trim the play bar.
+   ========================================================================= */
+@media screen and (max-width: 580px) {
+  /* navbar: drop search + FILE menu, compact and right-align the rest */
+  .navbar-center { display: none; }
+  .navbar-start .dropdown { display: none; }
+  .main-panel .navbar {
+    flex-wrap: nowrap;
+    gap: 2px;
+    padding-left: 4px;
+    padding-right: 4px;
   }
+  .navbar .navbar-start,
+  .navbar .navbar-end { gap: 2px; }
+  .navbar .btn {
+    margin-right: 0 !important;
+    height: 40px;
+    min-height: 40px;
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+  .navbar .btn-square { width: 40px; padding-left: 0; padding-right: 0; }
+  /* the Recents/drawer toggle stays hard left; everything else is pushed right */
+  .navbar .navbar-start { flex: 1 1 auto; min-width: 0; }
+  .navbar-start #sidebar-toggle { margin-right: auto !important; }
 
+  /* play bar: hardware volume/mute, slimmer rate select */
+  #playbar-volume,
+  #playbar-mute { display: none; }
+  #playbar-rate {
+    padding-inline-start: 8px;
+    padding-inline-end: 20px;
+    min-width: 0;
+    font-size: 85%;
+  }
+}
+
+@media screen and (max-width: 480px) {
   .caption-row input.line1, .caption-row input.line2 {
     width: 24ch;
   }
@@ -312,8 +496,6 @@ dialog::backdrop {
   .caption-row input.start, .caption-row input.end {
     width: 12ch;
   }
-
-
 }
 
 /* Minimal tooltip styling — mirrors DaisyUI .tooltip + data-tip so a future

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.26 (last changed in release 0.6.26) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.27 (last changed in release 0.6.27) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.26">
+  <meta name="version" content="0.6.27">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -90,7 +90,7 @@ If you are creating an open source application under a license compatible with t
     }
     
   </style>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.6.22">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.6.27">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -241,10 +241,12 @@ If you are creating an open source application under a license compatible with t
 
   <!-- end of templates -->
 
+  <!-- Dimmed backdrop behind the Recents drawer on small screens (#349) -->
+  <div id="drawer-backdrop"></div>
   <div class="holder grid grid-flow-col auto-cols-max">
     <div class="side-panel">
       <div style="display:flex; flex-direction:column; height:100%;">
-        <div class="top-bar-item" style="flex-shrink:0;">
+        <div id="player-pane" class="top-bar-item" style="flex-shrink:0;">
           <!-- example src -->
           <div id="player-frame" style="position:relative;">
             <video id="hyperplayer" class="hyperaudio-player" src="https://lab.hyperaud.io/audio/HLE_Intro.mp3" type="audio/mpeg" poster="images/poster.png" style="width:100%; border-radius:0.5rem; display:block;">
@@ -275,16 +277,22 @@ If you are creating an open source application under a license compatible with t
             <label id="info-btn" for="info-modal" class="btn btn-square btn-ghost btn-sm tooltip" data-tip="Transcription info" aria-label="Transcription info" style="margin-left:auto;">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-info"><circle cx="12" cy="12" r="10"></circle><line x1="12" x2="12" y1="16" y2="12"></line><line x1="12" x2="12.01" y1="8" y2="8"></line></svg>
             </label>
+            <!-- Collapse the pinned player to reclaim editing space (phone layout only, #349) -->
+            <button id="player-collapse-toggle" type="button" class="btn btn-square btn-ghost btn-sm" aria-label="Collapse player" aria-expanded="true">
+              <svg id="player-collapse-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m18 15-6-6-6 6"/></svg>
+            </button>
           </div>
         </div>
 
-        <div class="tabs" style="justify-content:flex-start; margin-top:12px; flex-shrink:0;">
-          <a class="tab tab-lifted tab-active"><strong style="font-size:1.1rem">Recents</strong></a>
-        </div>
-        <div style="display: flex; overflow-y:scroll; flex:1 1 auto; min-height:0;">
-          <div style="width:100%; height:100%;">
-            <ul id="file-picker" class="menu menu-compact bg-base-100 w-full" style="height:100%; border-radius:0.5rem;">
-            </ul>
+        <div id="recents-pane" style="display:flex; flex-direction:column; flex:1 1 auto; min-height:0;">
+          <div class="tabs" style="justify-content:flex-start; margin-top:12px; flex-shrink:0;">
+            <a class="tab tab-lifted tab-active"><strong style="font-size:1.1rem">Recents</strong></a>
+          </div>
+          <div style="display: flex; overflow-y:scroll; flex:1 1 auto; min-height:0;">
+            <div style="width:100%; height:100%;">
+              <ul id="file-picker" class="menu menu-compact bg-base-100 w-full" style="height:100%; border-radius:0.5rem;">
+              </ul>
+            </div>
           </div>
         </div>
         <div style="position: absolute; bottom: 16px; ">
@@ -747,7 +755,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite.js?v=2.5.1"></script>
   <script src="js/hyperaudio-lite-extension.js?v=0.6.21"></script>
   <script src="js/caption.js?v=0.6.23"></script>
-  <script src="js/editor-core.js?v=0.6.21"></script>
+  <script src="js/editor-core.js?v=0.6.27"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -828,6 +836,9 @@ If you are creating an open source application under a license compatible with t
   </style>
   <script src="js/editor-main.js?v=0.6.14"></script>
   <!-- end of caption editor additions -->
+
+  <!-- responsive small-screen UI toggles (#349) -->
+  <script src="js/responsive.js?v=0.6.27"></script>
 
   <!-- service worker script for PWA -->
   <script src="js/editor-service-worker.js?v=0.6.12"></script>

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -502,20 +502,9 @@
     });
   }
 
-  if (window.matchMedia("(max-width: 480px)").matches === true){
-    let elem = document.querySelector("#hyperplayer");
-
-    // Create a copy of it
-    let clone = elem.cloneNode(true);
-    
-    clone.style.width = "100%";
-    clone.style.paddingTop = "72px";
-
-    // Inject it into the DOM
-
-    document.querySelector('.transcript-holder').prepend(clone);
-    elem.remove();
-  }
+  // (Removed the old ≤480px hack that cloned #hyperplayer into .transcript-holder
+  // and deleted the original — the responsive layout (#349) now keeps the player
+  // in its pinned pane, so moving it into the transcript broke both.)
 
   hyperaudio();
 

--- a/js/responsive.js
+++ b/js/responsive.js
@@ -1,0 +1,57 @@
+/**
+ * responsive.js
+ * (C) The Hyperaudio Project
+ * @version 0.6.27 — last changed in release 0.6.27
+ * @license MIT
+ *
+ * Small-screen UI toggles for the responsive layout (#349):
+ *  - collapse/expand the pinned player to reclaim editing space;
+ *  - open/close the Recents off-canvas drawer via the existing #sidebar-toggle.
+ *
+ * Layout itself is CSS (css/hyperaudio-lite-editor.css, @media max-width:768px);
+ * this only flips classes on <body>. No editor logic is touched.
+ */
+
+(function () {
+  const body = document.body;
+  const mobile = window.matchMedia('(max-width: 948px)');
+
+  // --- Pinned player collapse ------------------------------------------------
+  const collapseBtn = document.getElementById('player-collapse-toggle');
+  if (collapseBtn !== null) {
+    collapseBtn.addEventListener('click', () => {
+      const collapsed = body.classList.toggle('player-collapsed');
+      collapseBtn.setAttribute('aria-expanded', String(!collapsed));
+      collapseBtn.setAttribute('aria-label', collapsed ? 'Expand player' : 'Collapse player');
+    });
+  }
+
+  // --- Recents drawer --------------------------------------------------------
+  const openDrawer = () => body.classList.add('drawer-open');
+  const closeDrawer = () => body.classList.remove('drawer-open');
+
+  // Intercept #sidebar-toggle at the document capture phase so the desktop
+  // sidebar-collapse handler (in editor-core.js) does not also fire on mobile.
+  document.addEventListener('click', (event) => {
+    const toggle = event.target.closest && event.target.closest('#sidebar-toggle');
+    if (toggle !== null && toggle !== undefined && mobile.matches) {
+      event.stopImmediatePropagation();
+      event.preventDefault();
+      body.classList.toggle('drawer-open');
+    }
+  }, true);
+
+  const backdrop = document.getElementById('drawer-backdrop');
+  if (backdrop !== null) {
+    backdrop.addEventListener('click', closeDrawer);
+  }
+
+  // Choosing a recent file closes the drawer.
+  const filePicker = document.getElementById('file-picker');
+  if (filePicker !== null) {
+    filePicker.addEventListener('click', () => { if (mobile.matches) closeDrawer(); });
+  }
+
+  // Leaving the small-screen layout clears any drawer state.
+  mobile.addEventListener('change', (ev) => { if (!ev.matches) closeDrawer(); });
+})();


### PR DESCRIPTION
Closes #349.

Makes the editor usable on tablet and phone. Below ~948px the fixed desktop two-pane is replaced by a single-column layout; the change is layout/CSS-first, with one small `<body>`-class toggle script and one removal in `editor-core.js`.

### Breakpoints
- **> 948px** — desktop two-pane, unchanged.
- **580–948px** — pinned-player + drawer layout, but the **full navbar** (search, FILE menu, all buttons) and full play bar.
- **≤ 580px** — same layout, compacted: search + FILE menu dropped, toolbar shrunk and right-aligned (the Recents/drawer toggle stays hard left), play bar trimmed to play · seek · time · rate.

### Layout (max-width: 948px)
- **Fixed navbar** at the top; **pinned collapsible video player** just below (a `--player-h` custom property drives both the player height and the transcript's top offset, so collapsing reclaims space cleanly); **full-width transcript**; **docked play bar**.
- **Recents → off-canvas drawer** + dimmed backdrop, toggled by the existing `#sidebar-toggle` (intercepted on mobile so the desktop collapse handler doesn't also fire).
- Video is **aspect-sized and centred** on the grey player background (no black letterbox bars; rounded corners hug the video).
- Navbar raised above the player so its **tooltips aren't covered**; paragraph-timecode toggle hidden (no left margin on mobile); mobile scrollbars hidden.

### Files
- **`css/hyperaudio-lite-editor.css`** — new `@media (max-width:948px)` and `@media (max-width:580px)` blocks; removed the old `≤480px` block that hid the video entirely.
- **`js/responsive.js`** (new, modular) — flips `body.player-collapsed` and `body.drawer-open`; no editor logic touched.
- **`index.html`** — `#player-pane`, `#recents-pane` wrapper, collapse chevron, `#drawer-backdrop`, script tag, version 0.6.27.
- **`js/editor-core.js`** — removed the old `≤480px` hack that cloned `#hyperplayer` into the transcript and deleted the original (it fought the pinned player).

### Verification
- Headless Chromium across widths (375 / 405 / 500 / 700 / 900 / 1000 / 1280): correct stacking, no horizontal clipping, drawer open/close, player collapse growing the transcript, breakpoint switches at 948 and 580, desktop unchanged. All touched JS passes `node --check`.
- **Still to check on a real device (iOS Safari):** tapping into the `contenteditable` raises the software keyboard, which resizes the viewport and can affect the fixed player/nav — the one thing headless can't exercise.
