### PR TITLE
Fix garbled transcribe tabs on narrow modal; drop (Beta) labels (0.6.28)

### DIFF
--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -586,3 +586,9 @@ mark.search-mark {
   color: inherit;
   border-radius: 2px;
 }
+
+/* Top-anchor the Transcribe modal. Its three tabs have different heights, and a
+   grid-centred modal re-centres (and visibly jumps) when you switch tabs. Pin it
+   to the top so it only grows downward. (#349 follow-up) */
+#transcribe-modal + .modal { align-items: start; }
+#transcribe-modal + .modal .modal-box { margin-top: 3rem; }

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -424,7 +424,9 @@ dialog::backdrop {
   #sidebar-toggle { display: inline-flex; }
 
   /* fluid modals / overlays so they fit ~375px screens */
-  .modal-box { max-width: calc(100vw - 24px); }
+  /* !important beats the inline max-width:36rem on the transcribe modal so it
+     fits the viewport (and its tab row can then wrap instead of overflowing). */
+  .modal-box { max-width: calc(100vw - 24px) !important; }
   #captionsource-alert {
     width: calc(100vw - 24px) !important;
     max-width: 480px;
@@ -433,8 +435,22 @@ dialog::backdrop {
     margin: -70px auto 0 !important;
   }
   #captions-display { width: 100%; }
-  /* the three transcribe tabs must wrap/shrink instead of overflowing */
-  .modal-box [name="my_tabs_2"] { width: auto !important; flex: 1 1 auto; min-width: 0; }
+  /* The three transcribe tabs are a fixed 165px each (495px) with nowrap labels,
+     which overflowed the narrowed modal. Let them share the row and shrink
+     evenly, with the label WRAPPING to two lines rather than collapsing into an
+     overlapping garble. */
+  .modal-box [role="tablist"] { flex-wrap: wrap; width: 100%; box-sizing: border-box; }
+  .modal-box [name="my_tabs_2"] {
+    flex: 1 1 0;
+    width: auto !important;
+    min-width: 6rem;
+    white-space: normal !important;
+    height: auto;
+    min-height: 3rem;
+    line-height: 1.15;
+    font-size: 0.8rem;
+    padding: 4px 6px;
+  }
 
   /* Hide the scrollbars on the mobile scroll surfaces (touch scrolling still
      works) — otherwise the transcript's always-on scrollbar shows as a grey

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.27 (last changed in release 0.6.27) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.28 (last changed in release 0.6.28) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.27">
+  <meta name="version" content="0.6.28">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -90,7 +90,7 @@ If you are creating an open source application under a license compatible with t
     }
     
   </style>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.6.27">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.6.28">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -642,12 +642,12 @@ If you are creating an open source application under a license compatible with t
       <h3 class="font-bold text-lg"  style="margin-bottom:16px">Transcribe</h3>
       <div role="tablist" class="tabs tabs-lifted">
 
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:165px; white-space:nowrap" aria-label="Parakeet (Beta)" checked />
+        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:165px; white-space:nowrap" aria-label="Parakeet" checked />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
           <client-parakeet-service templateSelector="#parakeet-local-template"></client-parakeet-service>
         </div>
 
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:165px; white-space:nowrap" aria-label="Whisper (Beta)"  />
+        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:165px; white-space:nowrap" aria-label="Whisper"  />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
           <client-whisper-service templateSelector="#whisper-client-template"></client-whisper-service>
         </div>


### PR DESCRIPTION
Hotfix on top of 0.6.27.

The responsive work (#349) added a mobile rule that shrank the three transcribe tabs with `min-width:0`, which collapsed their `nowrap` labels into an overlapping garble under the "Transcribe" title.

### Fix
- Let the tabs share the row and shrink evenly, with the label **wrapping to two lines** rather than collapsing (no more overlap).
- Cap the transcribe modal to the viewport (`!important` beats its inline `max-width:36rem`) so it fits narrow screens.
- Drop the now-shorter **(Beta)** suffix from the Parakeet and Whisper tab labels (they're single words now: Parakeet / Whisper / Deepgram), which also makes them fit comfortably on one row.

### Verification
- Headless Chromium with the modal open at 375 / 390 / 700 px: the three tabs render on one row, evenly spaced, **no overlap** (screenshotted). Desktop (>948px) is unaffected — tabs keep their 165px width.

Bumps app version to 0.6.28.
