### PR TITLE
Add find & replace for the transcript (#25, 0.6.29)

### DIFF
--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -592,3 +592,48 @@ mark.search-mark {
    to the top so it only grows downward. (#349 follow-up) */
 #transcribe-modal + .modal { align-items: start; }
 #transcribe-modal + .modal .modal-box { margin-top: 3rem; }
+
+/* Find & replace (#25). The replace panel drops below the search box; the
+   currently-focused match is highlighted in a distinct colour from the other
+   (purple) search hits. */
+#find-row { display: flex; align-items: center; gap: 2px; }
+/* the search box + its dropdown panel; the panel is anchored to this wrapper so
+   it lines up with the search box (left edge and width) rather than the wider
+   centred form-control */
+#search-wrap { position: relative; flex: 1 1 auto; min-width: 0; max-width: 230px; }
+#search-wrap #search-box { width: 100%; max-width: none; margin-right: 0; }
+#replace-panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  min-width: 240px;   /* keep the action buttons visible when the search box is narrow */
+  max-width: 90vw;
+  z-index: 70;
+  background: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 0;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+  text-align: left;
+  overflow: hidden;
+}
+#replace-panel[hidden] { display: none; }
+/* the replace box fills the panel so it aligns edge-to-edge with the search box */
+#replace-panel #replace-box { width: 100%; border: 0; border-radius: 0; box-shadow: none; }
+#replace-panel input, #replace-panel button { margin-bottom: 0; }
+#replace-actions { display: flex; align-items: center; gap: 3px; padding: 6px; border-top: 1px solid #eee; }
+#replace-actions .btn-xs { padding-left: 6px; padding-right: 6px; }
+#find-match-count {
+  font-size: 78%;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.replace-spacer { flex: 1; }
+mark.search-mark.active { background-color: #f6c344; color: inherit; border-radius: 2px; }
+
+/* When the replace panel is open, drop the transcript start so the panel doesn't
+   cover the first line. */
+.hyperaudio-transcript { transition: padding-top 0.2s ease; }
+body.find-replace-open .hyperaudio-transcript { padding-top: 108px; }

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.28 (last changed in release 0.6.28) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.29 (last changed in release 0.6.29) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.28">
+  <meta name="version" content="0.6.29">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -90,7 +90,7 @@ If you are creating an open source application under a license compatible with t
     }
     
   </style>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.6.28">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.6.29">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -377,8 +377,26 @@ If you are creating an open source application under a license compatible with t
           </div>
         </div>
         <div class="navbar-center">
-          <div class="form-control">
-            <input id="search-box" type="text" placeholder="Search" class="input input-bordered" />
+          <div id="find-replace" class="form-control">
+            <div id="find-row">
+              <div id="search-wrap">
+                <input id="search-box" type="text" placeholder="Search" class="input input-bordered" />
+                <div id="replace-panel" hidden>
+                  <input id="replace-box" type="text" placeholder="Replace with…" class="input input-bordered input-sm" />
+                  <div id="replace-actions">
+                    <span id="find-match-count" aria-live="polite">0 / 0</span>
+                    <button id="find-prev" type="button" class="btn btn-xs btn-ghost" aria-label="Previous match" title="Previous match">‹</button>
+                    <button id="find-next" type="button" class="btn btn-xs btn-ghost" aria-label="Next match" title="Next match">›</button>
+                    <span class="replace-spacer"></span>
+                    <button id="replace-one" type="button" class="btn btn-xs">Replace</button>
+                    <button id="replace-all" type="button" class="btn btn-xs btn-primary">All</button>
+                  </div>
+                </div>
+              </div>
+              <button id="find-replace-toggle" type="button" class="btn btn-square btn-ghost btn-sm tooltip" data-tip="Find & replace" aria-label="Find and replace" aria-expanded="false">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m16 3 4 4-4 4"/><path d="M20 7H4"/><path d="m8 21-4-4 4-4"/><path d="M4 17h16"/></svg>
+              </button>
+            </div>
           </div>
         </div>
         <div class="navbar-end" style="padding-right: 8px;">
@@ -835,6 +853,7 @@ If you are creating an open source application under a license compatible with t
 
   </style>
   <script src="js/editor-main.js?v=0.6.14"></script>
+  <script src="js/find-replace.js?v=0.6.29"></script>
   <!-- end of caption editor additions -->
 
   <!-- responsive small-screen UI toggles (#349) -->

--- a/js/find-replace.js
+++ b/js/find-replace.js
@@ -1,0 +1,153 @@
+/**
+ * find-replace.js
+ * (C) The Hyperaudio Project
+ * @version 0.6.29 — last changed in release 0.6.29
+ * @license MIT
+ *
+ * Find & replace for the transcript (#25). "Find" reuses the vendored
+ * searchPhrase() (js/hyperaudio-lite-extension.js), which highlights matches by
+ * wrapping the matched substring in <mark class="search-mark">. This module adds
+ * the replace UI on top — without touching the vendored extension:
+ *
+ *  - a toggle that reveals a replace box below the search box;
+ *  - Replace (the active match) and Replace All;
+ *  - prev/next stepping through matches, with the active match highlighted in a
+ *    distinct colour (mark.search-mark.active) and scrolled into view.
+ *
+ * Each match is a <mark> inside a word span; replacing swaps only the mark's text
+ * and leaves the span's data-m / data-d timing intact. Works best on single
+ * terms — a multi-word phrase is highlighted per word, so stepping is per word.
+ */
+
+(function () {
+  const searchBox = document.getElementById('search-box');
+  const toggle = document.getElementById('find-replace-toggle');
+  const panel = document.getElementById('replace-panel');
+  const replaceBox = document.getElementById('replace-box');
+  const countEl = document.getElementById('find-match-count');
+  const prevBtn = document.getElementById('find-prev');
+  const nextBtn = document.getElementById('find-next');
+  const replaceOneBtn = document.getElementById('replace-one');
+  const replaceAllBtn = document.getElementById('replace-all');
+
+  if (searchBox === null || toggle === null || panel === null) return;
+
+  let matches = [];       // ordered mark.search-mark elements in the transcript
+  let activeIndex = -1;
+
+  const isOpen = () => !panel.hasAttribute('hidden');
+
+  const clearActive = () => {
+    document.querySelectorAll('#hypertranscript mark.search-mark.active')
+      .forEach((m) => m.classList.remove('active'));
+  };
+
+  const renderActive = () => {
+    matches.forEach((m, i) => m.classList.toggle('active', i === activeIndex));
+    const active = activeIndex >= 0 ? matches[activeIndex] : null;
+    if (active) {
+      active.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+    countEl.textContent = matches.length ? `${activeIndex + 1} / ${matches.length}` : '0 / 0';
+    const has = matches.length > 0;
+    [prevBtn, nextBtn, replaceOneBtn, replaceAllBtn].forEach((b) => {
+      if (b !== null) b.disabled = !has;
+    });
+  };
+
+  // Re-read the highlighted matches after a search run (or a replace).
+  const collectMatches = (keepIndex) => {
+    matches = Array.from(document.querySelectorAll('#hypertranscript mark.search-mark'));
+    if (matches.length === 0) {
+      activeIndex = -1;
+    } else if (!keepIndex || activeIndex < 0) {
+      activeIndex = 0;
+    } else if (activeIndex >= matches.length) {
+      activeIndex = matches.length - 1;
+    }
+    renderActive();
+  };
+
+  // Run the existing search, then pick up its marks.
+  const runSearch = (keepIndex) => {
+    if (typeof searchPhrase === 'function') {
+      searchPhrase(searchBox.value);
+    }
+    collectMatches(keepIndex);
+  };
+
+  const step = (delta) => {
+    if (matches.length === 0) return;
+    activeIndex = (activeIndex + delta + matches.length) % matches.length;
+    renderActive();
+  };
+
+  // Signal the editor that the transcript changed (programmatic DOM edits don't
+  // fire input on their own), so it can mark the document dirty / re-caption.
+  const markDirty = () => {
+    const ht = document.getElementById('hypertranscript');
+    if (ht !== null) ht.dispatchEvent(new Event('input', { bubbles: true }));
+  };
+
+  const replaceMark = (mark) => {
+    const span = mark.closest('[data-m]') || mark.parentNode;
+    mark.replaceWith(document.createTextNode(replaceBox.value));
+    if (span && typeof span.normalize === 'function') span.normalize();
+  };
+
+  const replaceOne = () => {
+    if (activeIndex < 0 || !matches[activeIndex]) return;
+    const at = activeIndex;
+    replaceMark(matches[activeIndex]);
+    markDirty();
+    runSearch(true);           // refresh; keep position so we land on the next hit
+    if (matches.length) {
+      activeIndex = Math.min(at, matches.length - 1);
+      renderActive();
+    }
+  };
+
+  const replaceAll = () => {
+    if (matches.length === 0) return;
+    matches.forEach(replaceMark);
+    markDirty();
+    activeIndex = -1;
+    runSearch(false);
+  };
+
+  const openPanel = () => {
+    panel.removeAttribute('hidden');
+    toggle.setAttribute('aria-expanded', 'true');
+    document.body.classList.add('find-replace-open');
+    runSearch(false);
+    replaceBox.focus();
+  };
+
+  const closePanel = () => {
+    panel.setAttribute('hidden', '');
+    toggle.setAttribute('aria-expanded', 'false');
+    document.body.classList.remove('find-replace-open');
+    clearActive();
+  };
+
+  toggle.addEventListener('click', () => { isOpen() ? closePanel() : openPanel(); });
+
+  // Click anywhere outside the find/replace widget closes the panel; Escape too.
+  document.addEventListener('click', (e) => {
+    if (isOpen() && e.target.closest && !e.target.closest('#find-replace')) closePanel();
+  });
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && isOpen()) closePanel(); });
+
+  // The extension already runs searchPhrase on search-box keyup; collect after
+  // it so the match list and active highlight stay in sync while typing.
+  searchBox.addEventListener('keyup', () => { if (isOpen()) collectMatches(false); });
+
+  if (prevBtn) prevBtn.addEventListener('click', () => step(-1));
+  if (nextBtn) nextBtn.addEventListener('click', () => step(1));
+  if (replaceOneBtn) replaceOneBtn.addEventListener('click', replaceOne);
+  if (replaceAllBtn) replaceAllBtn.addEventListener('click', replaceAll);
+
+  replaceBox.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); e.shiftKey ? step(1) : replaceOne(); }
+  });
+})();


### PR DESCRIPTION
Closes #25.

Adds find & replace on top of the existing transcript search. "Find" already worked (`searchPhrase` in the vendored `hyperaudio-lite-extension.js`, which highlights matches); this adds the replace UI **without touching the vendored extension**, in a standalone `js/find-replace.js`.

### UX
- A **swap-arrow toggle** beside the search box reveals a replace panel that **lines up beneath the search box** (same left edge and width, with a min-width so the buttons never disappear when the search box is narrow).
- **Replace** (the active match) and **Replace All**. Each swaps only the matched substring and **preserves the word span's `data-m` / `data-d` timing**, so playback stays in sync.
- **‹ ›** step through matches with a live **n / m** count; the **active match is amber** (vs the purple search hits) and scrolls into view.
- **Enter** = replace current, **Shift+Enter** = next; **click-outside** and **Escape** close the panel; opening it nudges the transcript start down so the first line isn't covered.

### Notes
- Lives in the navbar, so (like search) it's hidden on phones (<580px) — desktop/tablet feature.
- Single-term find/replace is exact; a multi-word phrase highlights per word, so stepping is per word (can refine phrase grouping later).

### Verification
- Headless Chromium: search → open panel → step → Replace (timing preserved: `data-m/data-d` unchanged) → Replace All (all occurrences swapped), no console errors. Panel aligns with the search box and keeps the buttons visible down to ~600px. `node --check` clean.

Bumps app version to 0.6.29.
