### PR TITLE
Grey out the strikethrough button when no text is selected (#274, 0.6.30)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.29 (last changed in release 0.6.29) -->
+<!--  Hyperaudio Lite Editor - Version 0.6.30 (last changed in release 0.6.30) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.29">
+  <meta name="version" content="0.6.30">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -861,7 +861,7 @@ If you are creating an open source application under a license compatible with t
 
   <!-- service worker script for PWA -->
   <script src="js/editor-service-worker.js?v=0.6.12"></script>
-  <script type="module" src="js/editor-audio-cut.js?v=0.6.12"></script>
+  <script type="module" src="js/editor-audio-cut.js?v=0.6.30"></script>
 
 
   <script src="js/editor-svg.js?v=0.6.12"></script>

--- a/js/editor-audio-cut.js
+++ b/js/editor-audio-cut.js
@@ -8,11 +8,31 @@
   let gapThreshold = 0.5;
   let gapBuffer = 0.1;
 
-  document.querySelector('#strikethrough').addEventListener('click', () => {
+  const strikethroughBtn = document.querySelector('#strikethrough');
+
+  strikethroughBtn.addEventListener('click', () => {
+    if (strikethroughBtn.classList.contains('btn-disabled')) return;
     applyStrikeThroughToSelection();
     rebuildAudioDataArray();
     ensureSkipListeners();
   });
+
+  // #274: grey out the strikethrough button unless text is selected in the
+  // transcript. The selection survives clicking the button (which is what the
+  // click handler above relies on), so disabling via selectionchange can't
+  // race a legitimate click.
+  function updateStrikethroughState() {
+    const transcript = document.getElementById('hypertranscript');
+    const selection = window.getSelection();
+    let enabled = false;
+    if (transcript && selection && selection.rangeCount > 0 && !selection.isCollapsed) {
+      enabled = selection.getRangeAt(0).intersectsNode(transcript);
+    }
+    strikethroughBtn.classList.toggle('btn-disabled', !enabled);
+    strikethroughBtn.setAttribute('aria-disabled', String(!enabled));
+  }
+  document.addEventListener('selectionchange', updateStrikethroughState);
+  updateStrikethroughState();
 
   function applyGapSettings() {
     const enabledEl = document.querySelector('#remove-gaps-enabled');


### PR DESCRIPTION
Closes #274.

The strikethrough button did nothing without a selection (the handler silently no-ops), but gave no visual cue. It is now **greyed out** (`btn-disabled` + `aria-disabled`) unless there is a non-collapsed selection intersecting the transcript.

- Updated live via `selectionchange`: enabled the moment transcript text is selected, disabled when the selection collapses (including right after a strike, which clears the selection).
- A selection **outside** the transcript (e.g. the search box) keeps it disabled.
- The disabled state can't race a legitimate click — the selection survives clicking the button, which the existing click handler already relies on. A guard was added to the handler for the pointer-events edge.

### Verification
Headless Chromium: disabled at load → enabled on selecting a transcript word → clicking strikes the word (feature intact) → disabled again after the strike → stays disabled for non-transcript selections. No console errors.

Bumps app version to 0.6.30.
