### PR TITLE
Media export via mediabunny: formats, edited-media cuts, re-timed transcript (0.7.0)

### DIFF
--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -637,3 +637,27 @@ mark.search-mark.active { background-color: #f6c344; color: inherit; border-radi
    cover the first line. */
 .hyperaudio-transcript { transition: padding-top 0.2s ease; }
 body.find-replace-open .hyperaudio-transcript { padding-top: 108px; }
+
+/* Export modal progress bar (#289) — the tailwind build doesn't include
+   DaisyUI's .progress component, so style the native element in the signature
+   purple (the DaisyUI primary), mirroring .progress-primary. */
+#export-progress {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 8px;
+  border: 0;
+  border-radius: 9999px;
+  overflow: hidden;
+  background-color: oklch(var(--p) / 0.2);
+}
+#export-progress::-webkit-progress-bar { background-color: transparent; }
+#export-progress::-webkit-progress-value {
+  background-color: oklch(var(--p));
+  border-radius: 9999px;
+  transition: width 0.2s ease;
+}
+#export-progress::-moz-progress-bar {
+  background-color: oklch(var(--p));
+  border-radius: 9999px;
+}

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hls-source.js?v=0.6.26"></script>
   <script src="js/hyperaudio-lite-editor-deepgram.js?v=0.6.7"></script>
   <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.26"></script>
-  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.6.26"></script>
+  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.7.0"></script>
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js?v=0.6.18"></script>
   <script src="js/transcript-to-ionosphere.js?v=0.6.18"></script>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.6.30 (last changed in release 0.6.30) -->
+<!--  Hyperaudio Lite Editor - Version 0.7.0 (last changed in release 0.7.0) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.6.30">
+  <meta name="version" content="0.7.0">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -345,7 +345,7 @@ If you are creating an open source application under a license compatible with t
               <li><a id="download-srt" href="" download="hyperaudio.srt">SRT (Captions)</a></li>
               <li><a id="download-html" href="" download="hypertranscript.html">HTML</a></li>
               <li><a id="download-hypertranscript" href="" download="hyperaudio.html">Interactive Transcript</a></li>
-              <li><a id="download-wav-cut">WAV</a></li>
+              <li><label for="export-modal">Media (WAV / MP3 / MP4…)</label></li>
               <hr
               class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-25 dark:border-neutral-200" />
               <li class="menu-title">
@@ -653,6 +653,36 @@ If you are creating an open source application under a license compatible with t
     </div>
   </div>
 
+  <!-- Media export modal (#289/#291/#292) — wired by js/media-export.js -->
+  <input type="checkbox" id="export-modal" class="modal-toggle" />
+  <div class="modal">
+    <div class="modal-box" style="max-width:26rem">
+      <label for="export-modal" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+      <h3 class="font-bold text-lg" style="margin-bottom:12px">Export media</h3>
+      <div style="display:flex; flex-direction:column; gap:8px; margin-bottom:14px">
+        <label style="display:flex; gap:10px; align-items:center; cursor:pointer">
+          <input type="radio" name="export-source" id="export-source-entire" class="radio radio-primary radio-sm" checked />
+          <span class="label-text">Entire media</span>
+        </label>
+        <label style="display:flex; gap:10px; align-items:center; cursor:pointer">
+          <input type="radio" name="export-source" id="export-source-edited" class="radio radio-primary radio-sm" />
+          <span class="label-text">Edited media <span id="export-edit-summary" style="opacity:0.6; font-size:85%"></span></span>
+        </label>
+      </div>
+      <label class="label-text" for="export-format">Format</label>
+      <select id="export-format" class="select select-bordered w-full" style="margin-top:4px"></select>
+      <label id="export-retime-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
+        <input type="checkbox" id="export-retime" class="checkbox checkbox-primary checkbox-sm" checked />
+        <span class="label-text">Also download the transcript re-timed to the edited media</span>
+      </label>
+      <progress id="export-progress" class="progress progress-primary w-full" value="0" max="100" style="visibility:hidden; margin-top:14px"></progress>
+      <div id="export-status" aria-live="polite" style="font-size:85%; opacity:0.75; min-height:1.3em; margin-top:2px"></div>
+      <div class="modal-action">
+        <button id="export-start" class="btn btn-primary">EXPORT</button>
+      </div>
+    </div>
+  </div>
+
   <input type="checkbox" id="transcribe-modal" class="modal-toggle" />
   <div class="modal">
     <div class="modal-box" style="max-width:36rem">
@@ -854,6 +884,7 @@ If you are creating an open source application under a license compatible with t
   </style>
   <script src="js/editor-main.js?v=0.6.14"></script>
   <script src="js/find-replace.js?v=0.6.29"></script>
+  <script src="js/media-export.js?v=0.7.0"></script>
   <!-- end of caption editor additions -->
 
   <!-- responsive small-screen UI toggles (#349) -->
@@ -861,7 +892,7 @@ If you are creating an open source application under a license compatible with t
 
   <!-- service worker script for PWA -->
   <script src="js/editor-service-worker.js?v=0.6.12"></script>
-  <script type="module" src="js/editor-audio-cut.js?v=0.6.30"></script>
+  <script type="module" src="js/editor-audio-cut.js?v=0.7.0"></script>
 
 
   <script src="js/editor-svg.js?v=0.6.12"></script>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@ If you are creating an open source application under a license compatible with t
     }
     
   </style>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.6.29">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.7.0">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -671,9 +671,13 @@ If you are creating an open source application under a license compatible with t
       </div>
       <label class="label-text" for="export-format">Format</label>
       <select id="export-format" class="select select-bordered w-full" style="margin-top:4px"></select>
+      <label id="export-rate-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
+        <input type="checkbox" id="export-rate" class="checkbox checkbox-primary checkbox-sm" />
+        <span class="label-text">Apply the playback speed (<span id="export-rate-value">1×</span>) — pitch preserved</span>
+      </label>
       <label id="export-retime-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
         <input type="checkbox" id="export-retime" class="checkbox checkbox-primary checkbox-sm" checked />
-        <span class="label-text">Also download the transcript re-timed to the edited media</span>
+        <span class="label-text">Also download the transcript re-timed to the exported media</span>
       </label>
       <progress id="export-progress" class="progress progress-primary w-full" value="0" max="100" style="visibility:hidden; margin-top:14px"></progress>
       <div id="export-status" aria-live="polite" style="font-size:85%; opacity:0.75; min-height:1.3em; margin-top:2px"></div>

--- a/js/editor-audio-cut.js
+++ b/js/editor-audio-cut.js
@@ -1,5 +1,5 @@
 /* Extracted verbatim from index.html (#334) — loaded as a module in the same document order. */
-  import { AudioData, cutAudioApp } from "./audio-cut.js";
+  import { AudioData } from "./audio-cut.js";
 
   const audioDataArray = [];
   let skipListenersAttached = false;
@@ -366,33 +366,14 @@
     }
   }
 
-  document
-    .getElementById("download-wav-cut")
-    .addEventListener("click", async () => {
-      // grab the filename if saved
-      const element = document.querySelector(".file-item.active");
-
-      let fileName;
-      if (element == null || typeof element === "undefined"){
-        fileName = "default";
-      } else {
-        fileName = element.textContent;
-      }
-
-      if (audioDataArray.length === 0) {
-        audioDataArray.push(
-          new AudioData(
-            document.querySelector("#hyperplayer").src,
-            0,
-            document.getElementById("hyperplayer").duration
-          )
-        );
-      }
-
-      let wavBlob = await cutAudioApp.cutAudio(audioDataArray);
-      cutAudioApp.to_wav(wavBlob, fileName);
-      
-    });
+  // The old direct WAV download (which also mutated audioDataArray as a
+  // fallback, #290) is replaced by the export modal (js/media-export.js,
+  // #289/#291/#292). Expose the kept-sections model so the export can apply
+  // exactly the same strikeout + gap-skip cuts as playback does.
+  window.getPlayableSections = () => {
+    const transcript = getTranscript();
+    return transcript ? computePlayableSections(transcript) : null;
+  };
 
     // Add event listener for the new Upload & Transcribe button
     document.getElementById('upload-transcribe-btn').addEventListener('click', function() {

--- a/js/editor-audio-cut.js
+++ b/js/editor-audio-cut.js
@@ -228,70 +228,86 @@
   }
 
   function computePlayableSections(transcript) {
-    const words = transcript.querySelectorAll('[data-m]');
+    const wordEls = transcript.querySelectorAll('[data-m]');
     const player = document.getElementById("hyperplayer");
     const duration = (player && !isNaN(player.duration) && player.duration > 0) ? player.duration : Infinity;
 
-    if (words.length === 0) {
+    if (wordEls.length === 0) {
       return [{ start: 0, end: duration }];
     }
 
-    const sections = [];
-    let current = { start: 0 };
-    let inStruck = false;
-    let lastStruckEnd = 0;
-    let prevWordEnd = null;
-    let prevWordStruck = false;
+    const words = Array.from(wordEls).map(el => {
+      const start = parseInt(el.getAttribute('data-m')) / 1000;
+      return { start, end: start + (parseInt(el.getAttribute('data-d')) || 0) / 1000, struck: isStruck(el) };
+    });
 
-    words.forEach(word => {
-      const struck = isStruck(word);
-      const wordStart = parseInt(word.getAttribute('data-m')) / 1000;
-      const wordEnd = wordStart + (parseInt(word.getAttribute('data-d')) || 0) / 1000;
+    // Two passes. First, the regions between consecutive KEPT (unstruck) words:
+    // everything in such a region is non-speech once its struck words are cut,
+    // so with gap skipping on we treat the region as one combined pause — if
+    // the pause left after removing the struck words exceeds the threshold,
+    // cut the whole region (keeping a small buffer at each edge so word edges
+    // aren't clipped). Otherwise cut just the struck spans. The old one-pass
+    // version only gap-checked between two unstruck neighbours, so the pauses
+    // AROUND a struck filler word were never skipped.
+    const cuts = [];
+    let prevKeptEnd = null;
+    let pendingStruck = [];
 
-      // Long-gap skipping: when both surrounding words are unstruck and the
-      // gap exceeds the threshold, skip the middle of the gap, keeping a
-      // small buffer on each side so word edges aren't clipped.
-      if (
-        removeGapsEnabled &&
-        !inStruck && !struck &&
-        prevWordEnd !== null &&
-        !prevWordStruck &&
-        current !== null
-      ) {
-        const gap = wordStart - prevWordEnd;
-        if (gap > gapThreshold) {
-          const skipStart = prevWordEnd + gapBuffer;
-          const skipEnd = wordStart - gapBuffer;
-          if (skipEnd > skipStart) {
-            current.end = skipStart;
-            sections.push(current);
-            current = { start: skipEnd };
+    const flushRegion = (regionStart, regionEnd, struckSpans, bufferLeft, bufferRight) => {
+      if (removeGapsEnabled && regionStart !== null) {
+        const struckTotal = struckSpans.reduce((sum, s) => sum + (s.end - s.start), 0);
+        const effectivePause = (regionEnd - regionStart) - struckTotal;
+        if (effectivePause > gapThreshold) {
+          const cutStart = regionStart + (bufferLeft ? gapBuffer : 0);
+          const cutEnd = regionEnd - (bufferRight ? gapBuffer : 0);
+          if (cutEnd > cutStart) {
+            cuts.push({ start: cutStart, end: cutEnd });
+            return;
           }
         }
       }
+      // gaps kept (or gap skipping off): cut only the struck words themselves
+      struckSpans.forEach(s => cuts.push({ start: s.start, end: s.end }));
+    };
 
-      if (struck) {
-        if (!inStruck) {
-          current.end = wordStart;
-          sections.push(current);
-          current = null;
-          inStruck = true;
-        }
-        lastStruckEnd = wordEnd;
-      } else if (inStruck) {
-        current = { start: lastStruckEnd };
-        inStruck = false;
+    words.forEach(word => {
+      if (word.struck) {
+        pendingStruck.push(word);
+        return;
       }
-
-      prevWordEnd = wordEnd;
-      prevWordStruck = struck;
+      if (pendingStruck.length > 0 || prevKeptEnd !== null) {
+        const regionStart = prevKeptEnd !== null ? prevKeptEnd : (pendingStruck.length ? pendingStruck[0].start : null);
+        if (regionStart !== null && word.start > regionStart) {
+          flushRegion(regionStart, word.start, pendingStruck, prevKeptEnd !== null, true);
+        } else {
+          pendingStruck.forEach(s => cuts.push({ start: s.start, end: s.end }));
+        }
+      }
+      pendingStruck = [];
+      prevKeptEnd = word.end;
     });
 
-    if (current === null) {
-      current = { start: lastStruckEnd };
+    // trailing region after the last kept word
+    if (pendingStruck.length > 0) {
+      const regionStart = prevKeptEnd !== null ? prevKeptEnd : pendingStruck[0].start;
+      const regionEnd = pendingStruck[pendingStruck.length - 1].end;
+      if (regionEnd > regionStart) {
+        flushRegion(regionStart, regionEnd, pendingStruck, prevKeptEnd !== null, false);
+      }
     }
-    current.end = duration;
-    sections.push(current);
+
+    // Second pass: subtract the merged cuts from [0, duration].
+    cuts.sort((a, b) => a.start - b.start);
+    const sections = [];
+    let cursor = 0;
+    cuts.forEach(cut => {
+      const start = Math.max(cut.start, cursor);
+      if (start >= cut.end) { cursor = Math.max(cursor, cut.end); return; }
+      if (start > cursor) sections.push({ start: cursor, end: start });
+      cursor = cut.end;
+    });
+    if (cursor < duration) sections.push({ start: cursor, end: duration });
+    if (sections.length === 0) sections.push({ start: duration, end: duration });
 
     return sections;
   }

--- a/js/hyperaudio-lite-editor-parakeet-local.js
+++ b/js/hyperaudio-lite-editor-parakeet-local.js
@@ -1,7 +1,7 @@
 /**
  * hyperaudio-lite-editor-parakeet-local.js
  * (C) The Hyperaudio Project
- * @version 0.6.26 — last changed in release 0.6.26
+ * @version 0.7.0 — last changed in release 0.7.0
  * @license MIT
  */
 
@@ -61,7 +61,7 @@ function loadParakeetClient(modal, workerBaseUrl) {
     workerBaseUrl = "./";
   }
 
-  const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=0.6.9";
+  const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=0.7.0";
 
   // On Chrome (Chromium) Parakeet runs fp16 on the GPU (WebGPU) – fast, and the
   // default. Firefox's WebGPU underperforms here and Safari's can exhaust memory

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -36,8 +36,12 @@
   // copy we encode with. A version-range URL here would load mediabunny twice.
   const MEDIABUNNY_CDN = 'https://cdn.jsdelivr.net/npm/mediabunny@1.50.3/+esm';
   const MP3_ENCODER_CDN = 'https://cdn.jsdelivr.net/npm/@mediabunny/mp3-encoder@1.50.3/+esm';
+  // SoundTouch (WSOLA) for pitch-preserved time-stretch when exporting at the
+  // playback speed. LGPL-2.1, loaded unmodified from CDN.
+  const SOUNDTOUCH_CDN = 'https://cdn.jsdelivr.net/npm/soundtouchjs@0.3.0/+esm';
 
   let mediabunnyPromise = null;
+  let soundtouchPromise = null;
   let mp3Registered = false;
 
   const loadMediabunny = () => {
@@ -45,6 +49,13 @@
       mediabunnyPromise = import(MEDIABUNNY_CDN);
     }
     return mediabunnyPromise;
+  };
+
+  const loadSoundtouch = () => {
+    if (soundtouchPromise === null) {
+      soundtouchPromise = import(SOUNDTOUCH_CDN);
+    }
+    return soundtouchPromise;
   };
 
   // MP3 encoding is not built into browsers; mediabunny's official extension
@@ -144,8 +155,9 @@
   };
 
   // Clone the transcript with struck words removed and every word's data-m
-  // mapped onto the edited timeline. Returns the transcript HTML.
-  const buildRetimedTranscriptHtml = (sections) => {
+  // mapped onto the edited timeline (and scaled when the playback speed is
+  // applied — data-d shrinks with the sped-up media too). Returns the HTML.
+  const buildRetimedTranscriptHtml = (sections, rate) => {
     const transcript = document.getElementById('hypertranscript');
     if (transcript === null) return null;
     const clone = transcript.cloneNode(true);
@@ -156,7 +168,11 @@
         return;
       }
       const t = parseInt(span.getAttribute('data-m'), 10) / 1000;
-      span.setAttribute('data-m', String(Math.round(mapTime(t, sections) * 1000)));
+      span.setAttribute('data-m', String(Math.round((mapTime(t, sections) / rate) * 1000)));
+      if (rate !== 1) {
+        const d = parseInt(span.getAttribute('data-d'), 10);
+        if (!isNaN(d)) span.setAttribute('data-d', String(Math.round(d / rate)));
+      }
     });
     clone.querySelectorAll('p').forEach((p) => {
       if (p.querySelector('[data-m]') === null) p.remove();
@@ -203,10 +219,60 @@
     return out;
   };
 
+  // Concatenate AudioBuffers (same sample rate) into one.
+  const concatAudioBuffers = (buffers) => {
+    if (buffers.length === 1) return buffers[0];
+    const channels = Math.max(...buffers.map((b) => b.numberOfChannels));
+    const sampleRate = buffers[0].sampleRate;
+    const length = buffers.reduce((sum, b) => sum + b.length, 0);
+    const out = new AudioBuffer({ length, numberOfChannels: channels, sampleRate });
+    let offset = 0;
+    for (const b of buffers) {
+      for (let c = 0; c < channels; c++) {
+        out.copyToChannel(b.getChannelData(Math.min(c, b.numberOfChannels - 1)), c, offset);
+      }
+      offset += b.length;
+    }
+    return out;
+  };
+
+  // Pitch-preserved time-stretch (SoundTouch/WSOLA): tempo = rate, so 1.5×
+  // yields audio 1/1.5 the length at the original pitch — matching what the
+  // player's preservesPitch playback sounds like.
+  const timeStretchBuffer = async (buffer, rate) => {
+    const st = await loadSoundtouch();
+    const shifter = new st.SoundTouch();
+    shifter.tempo = rate;
+    const source = new st.WebAudioBufferSource(buffer);
+    const filter = new st.SimpleFilter(source, shifter);
+    const FRAMES = 8192;
+    const tmp = new Float32Array(FRAMES * 2); // SoundTouch works in stereo interleaved
+    const chunks = [];
+    let n;
+    while ((n = filter.extract(tmp, FRAMES)) > 0) {
+      chunks.push(tmp.slice(0, n * 2));
+    }
+    let totalFrames = 0;
+    for (const c of chunks) totalFrames += c.length / 2;
+    const channels = Math.min(2, buffer.numberOfChannels);
+    const out = new AudioBuffer({ length: Math.max(1, totalFrames), numberOfChannels: channels, sampleRate: buffer.sampleRate });
+    const L = out.getChannelData(0);
+    const R = channels > 1 ? out.getChannelData(1) : null;
+    let i = 0;
+    for (const c of chunks) {
+      for (let j = 0; j < c.length; j += 2) {
+        L[i] = c[j];
+        if (R) R[i] = c[j + 1];
+        i++;
+      }
+    }
+    return out;
+  };
+
   // Edited media, audio-only: decode each kept section, trim the edge buffers,
   // append. AudioBufferSource plays appended buffers back-to-back from 0, so
   // the sections concatenate without any timestamp bookkeeping.
-  const exportEditedAudio = async (mb, fmt, sections, onProgress) => {
+  const exportEditedAudio = async (mb, fmt, sections, rate, onProgress) => {
     const input = await makeInput(mb);
     const track = await input.getPrimaryAudioTrack();
     if (!track) throw new Error('The media has no audio track.');
@@ -217,17 +283,28 @@
     output.addAudioTrack(source);
     await output.start();
 
+    const stretch = rate !== 1;
     const total = keptDuration(sections);
     let done = 0;
+    const collected = stretch ? [] : null;
     for (const sec of sections) {
       for await (const wrapped of sink.buffers(sec.start, sec.end)) {
         const trimmed = trimBufferToRange(wrapped.buffer, wrapped.timestamp, sec.start, sec.end);
         if (trimmed !== null) {
-          await source.add(trimmed);
+          if (stretch) {
+            collected.push(trimmed);
+          } else {
+            await source.add(trimmed);
+          }
           done += trimmed.duration;
-          onProgress(Math.min(0.99, done / total));
+          onProgress(Math.min(0.99, (done / total) * (stretch ? 0.6 : 1)));
         }
       }
+    }
+    if (stretch) {
+      const stretched = await timeStretchBuffer(concatAudioBuffers(collected), rate);
+      onProgress(0.9);
+      await source.add(stretched);
     }
     source.close();
     await output.finalize();
@@ -237,7 +314,7 @@
   // Edited media with video: decode frames per kept section and re-timestamp
   // them onto the edited timeline; audio as above (its appended timestamps
   // already match the edited timeline).
-  const exportEditedVideo = async (mb, fmt, sections, onProgress) => {
+  const exportEditedVideo = async (mb, fmt, sections, rate, onProgress) => {
     const input = await makeInput(mb);
     const vTrack = await input.getPrimaryVideoTrack();
     const aTrack = await input.getPrimaryAudioTrack();
@@ -270,6 +347,7 @@
     }
     await output.start();
 
+    const stretch = rate !== 1;
     const total = keptDuration(sections) * (aTrack ? 2 : 1);
     let done = 0;
     let offset = 0;
@@ -277,16 +355,17 @@
 
     for (const sec of sections) {
       for await (const sample of vSink.samples(sec.start, sec.end)) {
-        // clamp the first frame (which may start before the section) and keep
-        // timestamps strictly increasing across section boundaries
-        let t = offset + Math.max(0, sample.timestamp - sec.start);
+        // clamp the first frame (which may start before the section), map onto
+        // the edited timeline (÷ rate when applying the playback speed), and
+        // keep timestamps strictly increasing across section boundaries
+        let t = (offset + Math.max(0, sample.timestamp - sec.start)) / rate;
         if (t <= prevT) t = prevT + 0.001;
         prevT = t;
-        const frameDur = Math.max(sample.duration || 1 / 30, 0.001);
+        const frameDur = Math.max(sample.duration || 1 / 30, 0.001) / rate;
         sample.draw(ctx2d, 0, 0, width, height);
         sample.close();
         await vSource.add(t, frameDur);
-        done += frameDur;
+        done += frameDur * rate;
         onProgress(Math.min(0.99, done / total));
       }
       offset += sec.end - sec.start;
@@ -294,15 +373,23 @@
     vSource.close();
 
     if (aSink !== null) {
+      const collected = stretch ? [] : null;
       for (const sec of sections) {
         for await (const wrapped of aSink.buffers(sec.start, sec.end)) {
           const trimmed = trimBufferToRange(wrapped.buffer, wrapped.timestamp, sec.start, sec.end);
           if (trimmed !== null) {
-            await aSource.add(trimmed);
+            if (stretch) {
+              collected.push(trimmed);
+            } else {
+              await aSource.add(trimmed);
+            }
             done += trimmed.duration;
             onProgress(Math.min(0.99, done / total));
           }
         }
+      }
+      if (stretch) {
+        await aSource.add(await timeStretchBuffer(concatAudioBuffers(collected), rate));
       }
       aSource.close();
     }
@@ -340,6 +427,9 @@
   const sourceEntire = document.getElementById('export-source-entire');
   const sourceEdited = document.getElementById('export-source-edited');
   const editSummary = document.getElementById('export-edit-summary');
+  const rateRow = document.getElementById('export-rate-row');
+  const rateCheck = document.getElementById('export-rate');
+  const rateValue = document.getElementById('export-rate-value');
   const retimeRow = document.getElementById('export-retime-row');
   const retimeCheck = document.getElementById('export-retime');
   const progressBar = document.getElementById('export-progress');
@@ -361,8 +451,20 @@
     }
   };
 
+  const playbackRate = () => {
+    const player = document.getElementById('hyperplayer');
+    const r = player !== null ? player.playbackRate : 1;
+    return r > 0 ? r : 1;
+  };
+
+  const rateApplied = () =>
+    rateRow.style.display !== 'none' && rateCheck.checked && playbackRate() !== 1;
+
+  // The re-timed transcript makes sense whenever the exported media's timeline
+  // differs from the original: edits, an applied playback speed, or both.
   const updateRetimeVisibility = () => {
-    retimeRow.style.display = sourceEdited.checked && !sourceEdited.disabled ? 'flex' : 'none';
+    const edited = sourceEdited.checked && !sourceEdited.disabled;
+    retimeRow.style.display = edited || rateApplied() ? 'flex' : 'none';
   };
 
   const populateModal = async () => {
@@ -383,6 +485,16 @@
     } else {
       editSummary.textContent = '(no strikeouts or skipped silences)';
       sourceEntire.checked = true;
+    }
+
+    // offer the playback-speed option when the player isn't at 1×
+    const rate = playbackRate();
+    if (rate !== 1) {
+      rateValue.textContent = `${rate}×`;
+      rateRow.style.display = 'flex';
+    } else {
+      rateRow.style.display = 'none';
+      rateCheck.checked = false;
     }
     updateRetimeVisibility();
 
@@ -435,27 +547,31 @@
       if (fmt.needsMp3) await ensureMp3Encoder(mb);
 
       const edited = sourceEdited.checked && !sourceEdited.disabled;
+      const rate = rateApplied() ? playbackRate() : 1;
       const baseName = exportBaseName();
+      const suffix = `${edited ? '-edited' : ''}${rate !== 1 ? `-${rate}x` : ''}`;
       let blob;
 
-      if (!edited) {
+      if (!edited && rate === 1) {
         setStatus('Exporting entire media…');
         blob = await exportEntire(mb, fmt, setProgress);
         downloadBlob(blob, `${baseName}.${fmt.ext}`);
       } else {
+        // an applied playback speed also routes the entire media through the
+        // section pipeline (one full-length section) so it can be stretched
         const player = document.getElementById('hyperplayer');
         const duration = player && !isNaN(player.duration) ? player.duration : Infinity;
-        const sections = editedSections(duration);
-        setStatus('Exporting edited media…');
+        const sections = edited ? editedSections(duration) : [{ start: 0, end: duration }];
+        setStatus(rate !== 1 ? `Exporting at ${rate}× — pitch preserved…` : 'Exporting edited media…');
         blob = fmt.kind === 'video'
-          ? await exportEditedVideo(mb, fmt, sections, setProgress)
-          : await exportEditedAudio(mb, fmt, sections, setProgress);
-        downloadBlob(blob, `${baseName}-edited.${fmt.ext}`);
+          ? await exportEditedVideo(mb, fmt, sections, rate, setProgress)
+          : await exportEditedAudio(mb, fmt, sections, rate, setProgress);
+        downloadBlob(blob, `${baseName}${suffix}.${fmt.ext}`);
 
-        if (retimeCheck.checked) {
-          const html = buildRetimedTranscriptHtml(sections);
+        if (retimeCheck.checked && retimeRow.style.display !== 'none') {
+          const html = buildRetimedTranscriptHtml(sections, rate);
           if (html !== null) {
-            downloadBlob(new Blob([html], { type: 'text/html' }), `${baseName}-edited-transcript.html`);
+            downloadBlob(new Blob([html], { type: 'text/html' }), `${baseName}${suffix}-transcript.html`);
           }
         }
       }
@@ -475,5 +591,6 @@
   modalToggle.addEventListener('change', () => { if (modalToggle.checked) populateModal(); });
   sourceEntire.addEventListener('change', updateRetimeVisibility);
   sourceEdited.addEventListener('change', updateRetimeVisibility);
+  rateCheck.addEventListener('change', updateRetimeVisibility);
   startBtn.addEventListener('click', runExport);
 })();

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -1,0 +1,479 @@
+/**
+ * media-export.js
+ * (C) The Hyperaudio Project
+ * @version 0.7.0 — last changed in release 0.7.0
+ * @license MIT
+ *
+ * Media export via mediabunny (#289, #291, #292): export the loaded media as
+ * WAV / M4A (AAC) / Ogg (Opus) / MP3, or — when the source has video — MP4 /
+ * WebM, either:
+ *
+ *  - "Entire media": a straight conversion of the whole file (mediabunny's
+ *    Conversion API — transmuxes when possible, transcodes when needed), or
+ *  - "Edited media": with strikeouts and skipped silences removed. The kept
+ *    sections come from the same computePlayableSections model that playback
+ *    skipping uses (exposed as window.getPlayableSections). Audio is decoded
+ *    per section (AudioBufferSink), trimmed sample-accurately at the edges,
+ *    and appended (AudioBufferSource timestamps run from 0, so concatenation
+ *    is implicit). Video frames are decoded per section (VideoSampleSink) and
+ *    re-timestamped onto the edited timeline before encoding.
+ *
+ * An edited export can also download the transcript re-timed to the edited
+ * media: struck words are dropped and each word's data-m is mapped through the
+ * kept sections' cumulative offsets, so the transcript stays in sync with the
+ * exported file.
+ *
+ * mediabunny (and the MP3 encoder extension) load lazily from a CDN on first
+ * use — non-exporting users pay nothing. Formats the browser can't encode are
+ * omitted from the format list at modal-open time.
+ */
+
+(function () {
+  // The +esm builds (not dist/bundles) so the mp3-encoder extension's bare
+  // `import "mediabunny"` resolves; and EXACT lockstep versions (they release
+  // together) so the extension's rewritten import is the *same URL* as ours —
+  // one shared module instance, so registerMp3Encoder() registers into the
+  // copy we encode with. A version-range URL here would load mediabunny twice.
+  const MEDIABUNNY_CDN = 'https://cdn.jsdelivr.net/npm/mediabunny@1.50.3/+esm';
+  const MP3_ENCODER_CDN = 'https://cdn.jsdelivr.net/npm/@mediabunny/mp3-encoder@1.50.3/+esm';
+
+  let mediabunnyPromise = null;
+  let mp3Registered = false;
+
+  const loadMediabunny = () => {
+    if (mediabunnyPromise === null) {
+      mediabunnyPromise = import(MEDIABUNNY_CDN);
+    }
+    return mediabunnyPromise;
+  };
+
+  // MP3 encoding is not built into browsers; mediabunny's official extension
+  // polyfills an encoder. Returns true when MP3 encoding is available.
+  const ensureMp3Encoder = async (mb) => {
+    if (mp3Registered) return true;
+    try {
+      const ext = await import(MP3_ENCODER_CDN);
+      ext.registerMp3Encoder();
+      mp3Registered = true;
+      return true;
+    } catch (e) {
+      console.warn('MP3 encoder unavailable:', e);
+      return false;
+    }
+  };
+
+  const FORMATS = [
+    { id: 'wav',  label: 'WAV (uncompressed audio)', ext: 'wav',  mime: 'audio/wav',  kind: 'audio', codec: 'pcm-s16', make: (mb) => new mb.WavOutputFormat() },
+    { id: 'm4a',  label: 'M4A (AAC audio)',          ext: 'm4a',  mime: 'audio/mp4',  kind: 'audio', codec: 'aac',     make: (mb) => new mb.Mp4OutputFormat() },
+    { id: 'ogg',  label: 'Ogg (Opus audio)',         ext: 'ogg',  mime: 'audio/ogg',  kind: 'audio', codec: 'opus',    make: (mb) => new mb.OggOutputFormat() },
+    { id: 'mp3',  label: 'MP3 (audio)',              ext: 'mp3',  mime: 'audio/mpeg', kind: 'audio', codec: 'mp3',     make: (mb) => new mb.Mp3OutputFormat(), needsMp3: true },
+    { id: 'mp4',  label: 'MP4 (H.264 video + AAC)',  ext: 'mp4',  mime: 'video/mp4',  kind: 'video', vcodec: 'avc',  acodec: 'aac',  make: (mb) => new mb.Mp4OutputFormat() },
+    { id: 'webm', label: 'WebM (VP9 video + Opus)',  ext: 'webm', mime: 'video/webm', kind: 'video', vcodec: 'vp9', acodec: 'opus', make: (mb) => new mb.WebMOutputFormat() },
+  ];
+
+  const canEncodeAudio = async (mb, codec) => {
+    if (codec === 'pcm-s16') return true; // PCM needs no encoder
+    try { return mb.canEncodeAudio ? await mb.canEncodeAudio(codec) : true; }
+    catch (e) { return false; }
+  };
+  const canEncodeVideo = async (mb, codec) => {
+    try { return mb.canEncodeVideo ? await mb.canEncodeVideo(codec) : true; }
+    catch (e) { return false; }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Source media
+  // ---------------------------------------------------------------------------
+
+  const playerSrc = () => {
+    const player = document.getElementById('hyperplayer');
+    return player !== null ? player.src : '';
+  };
+
+  // The player src may be http(s), blob: or data: (local files restored from
+  // IndexedDB) — fetch handles all three; mediabunny reads the Blob.
+  const makeInput = async (mb) => {
+    const src = playerSrc();
+    if (!src) throw new Error('No media is loaded.');
+    let response;
+    try {
+      response = await fetch(src);
+    } catch (e) {
+      // playing cross-origin media needs no CORS, but READING its bytes does
+      throw new Error('This media source does not allow cross-origin reading (CORS), so it cannot be exported. Load the file locally and try again.');
+    }
+    if (!response.ok) throw new Error(`Could not read the media (HTTP ${response.status}).`);
+    const blob = await response.blob();
+    return new mb.Input({ formats: mb.ALL_FORMATS, source: new mb.BlobSource(blob) });
+  };
+
+  const sourceHasVideo = () => {
+    const player = document.getElementById('hyperplayer');
+    return player !== null && player.videoWidth > 0;
+  };
+
+  // ---------------------------------------------------------------------------
+  // Sections / re-timing
+  // ---------------------------------------------------------------------------
+
+  // Kept sections from the editor (strikeouts + gap-skips applied), with any
+  // Infinity end clamped to the real duration.
+  const editedSections = (duration) => {
+    const raw = typeof window.getPlayableSections === 'function' ? window.getPlayableSections() : null;
+    if (!raw) return null;
+    return raw
+      .map((s) => ({ start: Math.max(0, s.start), end: Math.min(s.end, duration) }))
+      .filter((s) => s.end > s.start + 0.001);
+  };
+
+  const keptDuration = (sections) => sections.reduce((sum, s) => sum + (s.end - s.start), 0);
+
+  const hasEdits = (sections, duration) =>
+    sections !== null &&
+    (sections.length > 1 || keptDuration(sections) < duration - 0.05);
+
+  // Map an original-media time to the edited timeline.
+  const mapTime = (t, sections) => {
+    let offset = 0;
+    for (const s of sections) {
+      if (t < s.start) return offset;
+      if (t <= s.end) return offset + (t - s.start);
+      offset += s.end - s.start;
+    }
+    return offset;
+  };
+
+  // Clone the transcript with struck words removed and every word's data-m
+  // mapped onto the edited timeline. Returns the transcript HTML.
+  const buildRetimedTranscriptHtml = (sections) => {
+    const transcript = document.getElementById('hypertranscript');
+    if (transcript === null) return null;
+    const clone = transcript.cloneNode(true);
+    clone.querySelectorAll('mark.search-mark').forEach((m) => m.replaceWith(document.createTextNode(m.textContent)));
+    clone.querySelectorAll('[data-m]').forEach((span) => {
+      if ((span.style.textDecoration || '').includes('line-through')) {
+        span.remove();
+        return;
+      }
+      const t = parseInt(span.getAttribute('data-m'), 10) / 1000;
+      span.setAttribute('data-m', String(Math.round(mapTime(t, sections) * 1000)));
+    });
+    clone.querySelectorAll('p').forEach((p) => {
+      if (p.querySelector('[data-m]') === null) p.remove();
+    });
+    clone.normalize();
+    return clone.innerHTML;
+  };
+
+  // ---------------------------------------------------------------------------
+  // Export pipelines
+  // ---------------------------------------------------------------------------
+
+  const audioBitrate = (mb) => (mb.QUALITY_MEDIUM !== undefined ? mb.QUALITY_MEDIUM : 128e3);
+  const videoBitrate = (mb) => (mb.QUALITY_MEDIUM !== undefined ? mb.QUALITY_MEDIUM : 2.5e6);
+
+  // Entire media: one straight conversion.
+  const exportEntire = async (mb, fmt, onProgress) => {
+    const input = await makeInput(mb);
+    const output = new mb.Output({ format: fmt.make(mb), target: new mb.BufferTarget() });
+    const options = { input, output };
+    if (fmt.kind === 'audio') options.video = { discard: true };
+    const conversion = await mb.Conversion.init(options);
+    conversion.onProgress = (p) => onProgress(p);
+    await conversion.execute();
+    return new Blob([output.target.buffer], { type: fmt.mime });
+  };
+
+  // Trim a decoded AudioBuffer (starting at `ts` seconds on the original
+  // timeline) to its overlap with [start, end), sample-accurately.
+  const trimBufferToRange = (buffer, ts, start, end) => {
+    const bufEnd = ts + buffer.duration;
+    const from = Math.max(ts, start);
+    const to = Math.min(bufEnd, end);
+    if (to <= from) return null;
+    if (from <= ts && to >= bufEnd) return buffer;
+    const sr = buffer.sampleRate;
+    const s = Math.max(0, Math.round((from - ts) * sr));
+    const e = Math.min(buffer.length, Math.round((to - ts) * sr));
+    if (e <= s) return null;
+    const out = new AudioBuffer({ length: e - s, numberOfChannels: buffer.numberOfChannels, sampleRate: sr });
+    for (let c = 0; c < buffer.numberOfChannels; c++) {
+      out.copyToChannel(buffer.getChannelData(c).subarray(s, e), c);
+    }
+    return out;
+  };
+
+  // Edited media, audio-only: decode each kept section, trim the edge buffers,
+  // append. AudioBufferSource plays appended buffers back-to-back from 0, so
+  // the sections concatenate without any timestamp bookkeeping.
+  const exportEditedAudio = async (mb, fmt, sections, onProgress) => {
+    const input = await makeInput(mb);
+    const track = await input.getPrimaryAudioTrack();
+    if (!track) throw new Error('The media has no audio track.');
+
+    const sink = new mb.AudioBufferSink(track);
+    const output = new mb.Output({ format: fmt.make(mb), target: new mb.BufferTarget() });
+    const source = new mb.AudioBufferSource({ codec: fmt.codec, bitrate: audioBitrate(mb) });
+    output.addAudioTrack(source);
+    await output.start();
+
+    const total = keptDuration(sections);
+    let done = 0;
+    for (const sec of sections) {
+      for await (const wrapped of sink.buffers(sec.start, sec.end)) {
+        const trimmed = trimBufferToRange(wrapped.buffer, wrapped.timestamp, sec.start, sec.end);
+        if (trimmed !== null) {
+          await source.add(trimmed);
+          done += trimmed.duration;
+          onProgress(Math.min(0.99, done / total));
+        }
+      }
+    }
+    source.close();
+    await output.finalize();
+    return new Blob([output.target.buffer], { type: fmt.mime });
+  };
+
+  // Edited media with video: decode frames per kept section and re-timestamp
+  // them onto the edited timeline; audio as above (its appended timestamps
+  // already match the edited timeline).
+  const exportEditedVideo = async (mb, fmt, sections, onProgress) => {
+    const input = await makeInput(mb);
+    const vTrack = await input.getPrimaryVideoTrack();
+    const aTrack = await input.getPrimaryAudioTrack();
+    if (!vTrack) throw new Error('The media has no video track.');
+
+    const output = new mb.Output({ format: fmt.make(mb), target: new mb.BufferTarget() });
+
+    // Route frames through a canvas rather than re-encoding the decoded samples
+    // directly: it normalises exotic source colour spaces (e.g. sRGB-tagged
+    // sources make VP9 profile-0 encoding fail) and gives explicit control of
+    // the output timestamps for the edited timeline.
+    const vSink = new mb.VideoSampleSink(vTrack);
+    const probe = await vSink.getSample(sections[0].start);
+    const width = (probe && (probe.displayWidth || probe.codedWidth)) || 640;
+    const height = (probe && (probe.displayHeight || probe.codedHeight)) || 360;
+    if (probe) probe.close();
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx2d = canvas.getContext('2d');
+
+    const vSource = new mb.CanvasSource(canvas, { codec: fmt.vcodec, bitrate: videoBitrate(mb) });
+    output.addVideoTrack(vSource);
+    let aSource = null;
+    let aSink = null;
+    if (aTrack) {
+      aSource = new mb.AudioBufferSource({ codec: fmt.acodec, bitrate: audioBitrate(mb) });
+      output.addAudioTrack(aSource);
+      aSink = new mb.AudioBufferSink(aTrack);
+    }
+    await output.start();
+
+    const total = keptDuration(sections) * (aTrack ? 2 : 1);
+    let done = 0;
+    let offset = 0;
+    let prevT = -1;
+
+    for (const sec of sections) {
+      for await (const sample of vSink.samples(sec.start, sec.end)) {
+        // clamp the first frame (which may start before the section) and keep
+        // timestamps strictly increasing across section boundaries
+        let t = offset + Math.max(0, sample.timestamp - sec.start);
+        if (t <= prevT) t = prevT + 0.001;
+        prevT = t;
+        const frameDur = Math.max(sample.duration || 1 / 30, 0.001);
+        sample.draw(ctx2d, 0, 0, width, height);
+        sample.close();
+        await vSource.add(t, frameDur);
+        done += frameDur;
+        onProgress(Math.min(0.99, done / total));
+      }
+      offset += sec.end - sec.start;
+    }
+    vSource.close();
+
+    if (aSink !== null) {
+      for (const sec of sections) {
+        for await (const wrapped of aSink.buffers(sec.start, sec.end)) {
+          const trimmed = trimBufferToRange(wrapped.buffer, wrapped.timestamp, sec.start, sec.end);
+          if (trimmed !== null) {
+            await aSource.add(trimmed);
+            done += trimmed.duration;
+            onProgress(Math.min(0.99, done / total));
+          }
+        }
+      }
+      aSource.close();
+    }
+
+    await output.finalize();
+    return new Blob([output.target.buffer], { type: fmt.mime });
+  };
+
+  // ---------------------------------------------------------------------------
+  // Downloads
+  // ---------------------------------------------------------------------------
+
+  const exportBaseName = () => {
+    const active = document.querySelector('.file-item.active');
+    const name = active !== null && active.textContent.trim() !== '' ? active.textContent.trim() : 'hyperaudio';
+    return name.replace(/\.[a-z0-9]+$/i, '');
+  };
+
+  const downloadBlob = (blob, filename) => {
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(a.href), 30000);
+  };
+
+  // ---------------------------------------------------------------------------
+  // Modal UI
+  // ---------------------------------------------------------------------------
+
+  const modalToggle = document.getElementById('export-modal');
+  const formatSelect = document.getElementById('export-format');
+  const sourceEntire = document.getElementById('export-source-entire');
+  const sourceEdited = document.getElementById('export-source-edited');
+  const editSummary = document.getElementById('export-edit-summary');
+  const retimeRow = document.getElementById('export-retime-row');
+  const retimeCheck = document.getElementById('export-retime');
+  const progressBar = document.getElementById('export-progress');
+  const statusEl = document.getElementById('export-status');
+  const startBtn = document.getElementById('export-start');
+
+  if (modalToggle === null || startBtn === null) return;
+
+  let exporting = false;
+
+  const setStatus = (text) => { statusEl.textContent = text || ''; };
+  const setProgress = (fraction) => {
+    if (fraction === null) {
+      progressBar.style.visibility = 'hidden';
+      progressBar.value = 0;
+    } else {
+      progressBar.style.visibility = 'visible';
+      progressBar.value = Math.round(fraction * 100);
+    }
+  };
+
+  const updateRetimeVisibility = () => {
+    retimeRow.style.display = sourceEdited.checked && !sourceEdited.disabled ? 'flex' : 'none';
+  };
+
+  const populateModal = async () => {
+    setStatus('');
+    setProgress(null);
+    startBtn.classList.remove('btn-disabled');
+
+    // edited availability
+    const player = document.getElementById('hyperplayer');
+    const duration = player && !isNaN(player.duration) ? player.duration : Infinity;
+    const sections = editedSections(duration);
+    const edits = hasEdits(sections, duration);
+    sourceEdited.disabled = !edits;
+    if (edits) {
+      const saved = duration - keptDuration(sections);
+      editSummary.textContent = `(${sections.length - 1} cut${sections.length - 1 === 1 ? '' : 's'}, saves ${saved.toFixed(1)}s)`;
+      sourceEdited.checked = true;
+    } else {
+      editSummary.textContent = '(no strikeouts or skipped silences)';
+      sourceEntire.checked = true;
+    }
+    updateRetimeVisibility();
+
+    // formats, gated by what this browser can encode
+    setStatus('Checking available formats…');
+    formatSelect.innerHTML = '';
+    try {
+      const mb = await loadMediabunny();
+      const withVideo = sourceHasVideo();
+      const options = [];
+      for (const fmt of FORMATS) {
+        if (fmt.kind === 'video' && !withVideo) continue;
+        let ok;
+        if (fmt.kind === 'audio') {
+          ok = fmt.needsMp3 ? (await ensureMp3Encoder(mb)) && (await canEncodeAudio(mb, fmt.codec)) : await canEncodeAudio(mb, fmt.codec);
+        } else {
+          ok = (await canEncodeVideo(mb, fmt.vcodec)) && (await canEncodeAudio(mb, fmt.acodec));
+        }
+        if (ok) {
+          const option = document.createElement('option');
+          option.value = fmt.id;
+          option.textContent = fmt.label;
+          options.push(option);
+        }
+      }
+      // append atomically so the list is never seen half-populated
+      options.forEach((o) => formatSelect.appendChild(o));
+      // default to a video format when the source has video
+      if (withVideo && formatSelect.querySelector('option[value="mp4"]') !== null) {
+        formatSelect.value = 'mp4';
+      }
+      setStatus('');
+    } catch (e) {
+      console.error(e);
+      setStatus('Could not load the export library — check your connection and try again.');
+      startBtn.classList.add('btn-disabled');
+    }
+  };
+
+  const runExport = async () => {
+    if (exporting) return;
+    const fmt = FORMATS.find((f) => f.id === formatSelect.value);
+    if (!fmt) return;
+    exporting = true;
+    startBtn.classList.add('btn-disabled');
+    setProgress(0);
+
+    try {
+      const mb = await loadMediabunny();
+      if (fmt.needsMp3) await ensureMp3Encoder(mb);
+
+      const edited = sourceEdited.checked && !sourceEdited.disabled;
+      const baseName = exportBaseName();
+      let blob;
+
+      if (!edited) {
+        setStatus('Exporting entire media…');
+        blob = await exportEntire(mb, fmt, setProgress);
+        downloadBlob(blob, `${baseName}.${fmt.ext}`);
+      } else {
+        const player = document.getElementById('hyperplayer');
+        const duration = player && !isNaN(player.duration) ? player.duration : Infinity;
+        const sections = editedSections(duration);
+        setStatus('Exporting edited media…');
+        blob = fmt.kind === 'video'
+          ? await exportEditedVideo(mb, fmt, sections, setProgress)
+          : await exportEditedAudio(mb, fmt, sections, setProgress);
+        downloadBlob(blob, `${baseName}-edited.${fmt.ext}`);
+
+        if (retimeCheck.checked) {
+          const html = buildRetimedTranscriptHtml(sections);
+          if (html !== null) {
+            downloadBlob(new Blob([html], { type: 'text/html' }), `${baseName}-edited-transcript.html`);
+          }
+        }
+      }
+
+      setProgress(1);
+      setStatus('Done — check your downloads.');
+    } catch (e) {
+      console.error(e);
+      setStatus('Export failed: ' + (e && e.message ? e.message : e));
+    } finally {
+      exporting = false;
+      startBtn.classList.remove('btn-disabled');
+      setTimeout(() => setProgress(null), 1500);
+    }
+  };
+
+  modalToggle.addEventListener('change', () => { if (modalToggle.checked) populateModal(); });
+  sourceEntire.addEventListener('change', updateRetimeVisibility);
+  sourceEdited.addEventListener('change', updateRetimeVisibility);
+  startBtn.addEventListener('click', runExport);
+})();

--- a/js/parakeet.worker.js
+++ b/js/parakeet.worker.js
@@ -1,7 +1,7 @@
 /**
  * parakeet.worker.js
  * (C) The Hyperaudio Project
- * @version 0.6.9 — last changed in release 0.6.9
+ * @version 0.7.0 — last changed in release 0.7.0
  * @license MIT
  */
 
@@ -382,7 +382,15 @@ async function transcribeWindow(s, samples, offsetSeconds) {
 
   console.log(`  window: encoder ${encMs}ms, decode ${Date.now() - decT0}ms (${encLen} frames)`);
 
-  // 4. tokens -> words (▁ marks a word start); times offset by window start
+  // 4. tokens -> words (▁ marks a word start); times offset by window start.
+  // Punctuation-only tokens (. , ? ! …) are emitted AFTER the model has heard
+  // the following pause — it concludes the sentence ended partly BECAUSE
+  // silence follows — so extending the word's end to their emission frame
+  // would absorb that pause into the word's duration (#372: "cast." with
+  // data-d="2640"). Merge their text but keep the end of the last LEXICAL
+  // token, so durations stay honest and post-sentence pauses remain real
+  // inter-word gaps (which gap skipping can then catch).
+  const PUNCT_ONLY = /^[.,!?;:…'"’”„«»()\[\]{}%\-–—]+$/;
   const words = [];
   let cur = null;
   for (let i = 0; i < tokens.length; i++) {
@@ -393,7 +401,9 @@ async function transcribeWindow(s, samples, offsetSeconds) {
       cur = { word: piece.replace(/▁/g, ""), start: sec, end: sec + FRAME_SEC };
     } else {
       cur.word += piece;
-      cur.end = sec + FRAME_SEC;
+      if (!PUNCT_ONLY.test(piece)) {
+        cur.end = sec + FRAME_SEC;
+      }
     }
   }
   if (cur) words.push(cur);


### PR DESCRIPTION
Closes #289, #290, #291, #292.

Replaces the FILE menu's single WAV item with an **Export modal** backed by [mediabunny](https://mediabunny.dev/) (WebCodecs-based; MPL-2.0, as is its MP3-encoder extension — a file-level weak copyleft, compatible with the editor's AGPL-3.0/commercial model; both are loaded unmodified from CDN, not vendored).

### What it does
- **Entire media** or **Edited media** (radio, with a "(N cuts, saves X.Xs)" summary). Edited exports **exclude struck-out words and skipped silences**, using the exact `computePlayableSections` model that playback skipping uses — what you hear in preview is what you export.
- **Formats:** WAV / M4A (AAC) / Ogg (Opus) / MP3 (#291), plus **MP4 (H.264 + AAC)** and **WebM (VP9 + Opus)** when the source has video (#292). Each format is offered only if the browser can actually encode it.
- **Re-timed transcript** (checkbox on edited exports): downloads the transcript with struck words removed and every `data-m` remapped through the kept sections' cumulative offsets — verified exact to the millisecond — so the transcript stays in sync with the exported media.
- Progress bar and clear error reporting.

### Implementation
All in one new module, `js/media-export.js`:
- mediabunny + its MP3-encoder extension **lazy-load from CDN** (nothing vendored; non-exporting users pay nothing), pinned to exact lockstep versions via jsDelivr `+esm` — a version-range URL loads mediabunny twice and MP3 registration lands in the wrong copy.
- **Entire** exports use mediabunny's `Conversion` API (transmux when possible, transcode when needed).
- **Edited audio**: decode per kept section (`AudioBufferSink`), trim edge buffers sample-accurately, append (`AudioBufferSource` timestamps run from 0, so sections concatenate implicitly).
- **Edited video**: decoded frames route through a canvas (normalises exotic colour spaces that break VP9 profile-0 encoding) with explicit edited-timeline timestamps; audio as above.
- `editor-audio-cut.js`: the old WAV click handler is removed — and with it the fallback that mutated `audioDataArray` from the handler (**#290**) — replaced by `window.getPlayableSections`, exposing the kept-sections model.

### Verification (headless Chromium, real CDN + real encodes)
- Edited WAV: **11.28s output vs 11.28s expected** (sample-accurate), from a transcript with cuts clamped against a shorter media file.
- Edited WebM: **9.30s vs 9.29s expected**, VP9 + Opus tracks confirmed via ffprobe.
- Entire-media WAV and WebM conversions correct; format list gates by encoder availability (MP3 appears once the extension registers; video formats only for video sources).
- Re-timed transcript: struck words absent; the word after a 719ms cut moves 3820ms → 3101ms exactly; earlier words untouched.

### Known limitations (by design, clear errors shown)
- The source must be **byte-readable**: local files, uploads, and Recents work; a remote URL without CORS (e.g. the default demo media) and HLS-loaded media (MSE blob) cannot be exported client-side.
- MP4 depends on the browser's H.264 encoder (present in real Chrome/Safari).
- Advanced options (bitrate/codec choices, #293) are deferred — defaults are sensible.

Bumps app version to **0.7.0**.
