### PR TITLE
UI polish + hyperaudio-lite 2.6.2 with punctuated-search fix (#375, 0.7.2)

### DIFF
--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -9,7 +9,12 @@ html {
   color-scheme: light;
 }
 
-body {
+/* body[data-theme] (0,1,1) outguns DaisyUI's data-theme background (which
+   paints the body white and loads after this file) without needing !important —
+   the 8px gaps around the transcript card (#375) expose the body, so it must
+   be the chrome grey for the card corners to show. */
+body,
+body[data-theme="light"] {
   font-family: system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Fira Sans','Droid Sans','Helvetica Neue',sans-serif;
   line-height: 1.8;
   background-color: #f5f5f5;
@@ -91,9 +96,9 @@ input[type="number"] {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
-  /* stop content 52px above the bottom so the Files panel's bottom lines up
-     with the transcript (which ends at the play bar, bottom:52px) */
-  padding-bottom: 52px;
+  /* stop content 60px above the bottom so the Recents card's bottom lines up
+     with the transcript card (play bar 52px + 8px float gap) */
+  padding-bottom: 60px;
 }
 
 .top-bar-container {
@@ -128,10 +133,10 @@ dialog::backdrop {
   border-radius: 0.5rem;
   overflow-y:scroll;
   position: absolute;
-  top: 70px;
+  top: 78px;             /* 8px of canvas below the navbar so the card floats */
   left: 400px;
-  right: 0;
-  bottom: 52px;          /* leave room for the docked play bar */
+  right: 16px;
+  bottom: 60px;          /* play bar (52px) + 8px gap — the corners read as a card */
   transition: left 0.5s ease;
 }
 
@@ -245,9 +250,9 @@ dialog::backdrop {
     justify-content: center;
     background-color: #ffffff;
     overflow-y:scroll;
-    top: 50px;
-    right: 0;
-    bottom: 52px;
+    top: 58px;
+    right: 16px;
+    bottom: 60px;
     padding: 8px;
   }
 
@@ -262,10 +267,9 @@ dialog::backdrop {
 
 }
 
-/* The Recents drawer backdrop and the player-collapse toggle only exist on the
-   small-screen layout; hide them by default (desktop). */
+/* The Recents drawer backdrop only exists on the small-screen layout; hide it
+   by default (desktop). */
 #drawer-backdrop { display: none; }
-#player-collapse-toggle { display: none; }
 
 /* =========================================================================
    Small-screen layout (#349) — phones and tablet portrait.
@@ -280,8 +284,8 @@ dialog::backdrop {
     --nav-h: 70px;       /* matches the navbar's inline min-height */
     --player-h: 210px;   /* video area + a 44px controls row */
   }
-  body.player-collapsed {
-    --player-h: 44px;    /* controls row only; video hidden */
+  body.video-collapsed {
+    --player-h: 44px;    /* controls row only; video hidden (audio-only button) */
   }
 
   /* the side panel no longer lays anything out — its children (player + recents)
@@ -345,13 +349,18 @@ dialog::backdrop {
     margin-top: 4px;
     overflow-x: auto;
   }
+  /* Keep the floating Regenerate button below the pinned player (its top-20
+     utility class would sit it on the video); tracks the collapse var. */
+  #regenerate-btn {
+    top: calc(var(--nav-h) + var(--player-h) + 8px);
+    right: 8px;
+    transition: top 0.25s ease;
+  }
+
   /* Paragraph timecodes live in the transcript's left margin, which the
      full-width mobile layout has no room for — hide the toggle and any nodes. */
   #player-controls label[for="show-timecodes"] { display: none !important; }
   .para-timecode { display: none; }
-  /* flip the collapse chevron when collapsed */
-  #player-collapse-toggle { display: inline-flex; }
-  body.player-collapsed #player-collapse-icon { transform: rotate(180deg); }
 
   /* transcript fills the space between the pinned player and the play bar */
   .transcript-holder {
@@ -660,4 +669,114 @@ body.find-replace-open .hyperaudio-transcript { padding-top: 108px; }
 #export-progress::-moz-progress-bar {
   background-color: oklch(var(--p));
   border-radius: 9999px;
+}
+
+/* =========================================================================
+   UI polish (#375)
+   ========================================================================= */
+
+/* Recents: the heading lives INSIDE the white card (so the card top can align
+   with the transcript card when the video is collapsed), and the card matches
+   the video/transcript corner treatment. */
+#recents-card {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  margin-top: 12px;
+  background: #ffffff;
+  border-radius: 0.5rem;
+}
+#recents-title {
+  flex-shrink: 0;
+  font-weight: 700;
+  font-size: 1.05rem;
+  padding: 12px 16px 4px;
+  margin: 0;
+}
+#recents-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  border-radius: 0 0 0.5rem 0.5rem;
+}
+
+/* The caption editor's floating Regenerate button is injected as
+   fixed top-20 right-8 with no z-index, so positioned content (the caption
+   rows / transcript holder) painted over it. Lift it above content, below
+   the drawer (45) and navbar (60). */
+#regenerate-btn { z-index: 20; }
+
+/* Video collapse (audio-only button), desktop: slide the frame shut instead
+   of a display:none pop, at the same 0.5s ease as the sidebar slide so all
+   panel motion matches. The controls row and Recents card animate in step
+   (their margins move under body.video-collapsed below). overflow hidden also
+   clips the play overlay while shut; 480px accommodates portrait videos at
+   the 368px card width. Mobile keeps its own pinned-pane animation. */
+@media screen and (min-width: 949px) {
+  #player-frame {
+    overflow: hidden;
+    max-height: 480px;
+    transition: max-height 0.5s ease, opacity 0.5s ease;
+  }
+  body.video-collapsed #player-frame {
+    max-height: 0;
+    opacity: 0;
+  }
+  #player-controls {
+    transition: margin-top 0.5s ease;
+  }
+  #recents-card {
+    transition: margin-top 0.5s ease;
+  }
+}
+
+/* Player controls row (formerly inline styles in index.html, moved here so
+   state rules below can override without !important). */
+#player-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+  width: 100%;
+}
+
+/* Speakers / Timecodes switches: the tailwind build has the DaisyUI .toggle
+   base but not the -sm / -primary variants, so size and tint them here. */
+#player-controls .toggle {
+  height: 1.25rem;
+  width: 2.5rem;
+  --handleoffset: 1.25rem;
+  margin-bottom: 0;
+  border: none;
+}
+#player-controls .toggle:checked {
+  color: oklch(var(--p));
+}
+
+/* Buttons pick up an 8px margin-bottom from the global input/button rule,
+   which nudges them off-centre in flex rows — neutralise in the bars. */
+.navbar .btn,
+#player-controls .btn,
+#player-controls button,
+#playbar .btn,
+#playbar button {
+  margin-bottom: 0;
+}
+
+/* a touch more air between the search box and the find/replace toggle */
+#find-row { gap: 6px; }
+
+/* With the video collapsed (audio-only), the controls row shares the line with
+   the navbar buttons (both centred in the 70px top band), and the Recents card
+   top aligns with the transcript card top. Values measured against the navbar
+   buttons' centre (y=35). Desktop two-pane only — the pinned-player layout
+   handles small screens. */
+@media screen and (min-width: 949px) {
+  body.video-collapsed #player-controls {
+    margin-top: 11px;
+  }
+  body.video-collapsed #recents-card {
+    margin-top: 27px;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.7.1 (last changed in release 0.7.1) -->
+<!--  Hyperaudio Lite Editor - Version 0.7.2 (last changed in release 0.7.2) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.7.1">
+  <meta name="version" content="0.7.2">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -90,7 +90,7 @@ If you are creating an open source application under a license compatible with t
     }
     
   </style>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.7.0">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.7.2">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -259,7 +259,7 @@ If you are creating an open source application under a license compatible with t
               </span>
             </button>
           </div>
-          <div id="player-controls" style="display:flex; align-items:center; gap:8px; margin-top:4px; width:100%;">
+          <div id="player-controls">
             <button id="pip-btn" type="button" class="btn btn-square btn-outline btn-sm tooltip" data-tip="Picture-in-picture" aria-label="Picture-in-picture" onclick="togglePictureInPicture()">
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-picture-in-picture-2"><path d="M21 9V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h4"/><rect width="10" height="7" x="12" y="13" rx="2"/></svg>
             </button>
@@ -268,29 +268,23 @@ If you are creating an open source application under a license compatible with t
             </button>
             <label for="show-speakers" style="display:flex; align-items:center; gap:6px; margin-left:4px; cursor:pointer; white-space:nowrap;">
               Speakers
-              <input type="checkbox" id="show-speakers" name="show-speakers" checked="checked" class="checkbox checkbox-primary checkbox-sm"/>
+              <input type="checkbox" id="show-speakers" name="show-speakers" checked="checked" class="toggle toggle-primary"/>
             </label>
             <label for="show-timecodes" style="display:flex; align-items:center; gap:6px; margin-left:4px; cursor:pointer; white-space:nowrap;">
               Timecodes
-              <input type="checkbox" id="show-timecodes" name="show-timecodes" class="checkbox checkbox-primary checkbox-sm"/>
+              <input type="checkbox" id="show-timecodes" name="show-timecodes" class="toggle toggle-primary"/>
             </label>
             <label id="info-btn" for="info-modal" class="btn btn-square btn-ghost btn-sm tooltip" data-tip="Transcription info" aria-label="Transcription info" style="margin-left:auto;">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-info"><circle cx="12" cy="12" r="10"></circle><line x1="12" x2="12" y1="16" y2="12"></line><line x1="12" x2="12.01" y1="8" y2="8"></line></svg>
             </label>
-            <!-- Collapse the pinned player to reclaim editing space (phone layout only, #349) -->
-            <button id="player-collapse-toggle" type="button" class="btn btn-square btn-ghost btn-sm" aria-label="Collapse player" aria-expanded="true">
-              <svg id="player-collapse-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m18 15-6-6-6 6"/></svg>
-            </button>
           </div>
         </div>
 
         <div id="recents-pane" style="display:flex; flex-direction:column; flex:1 1 auto; min-height:0;">
-          <div class="tabs" style="justify-content:flex-start; margin-top:12px; flex-shrink:0;">
-            <a class="tab tab-lifted tab-active"><strong style="font-size:1.1rem">Recents</strong></a>
-          </div>
-          <div style="display: flex; overflow-y:scroll; flex:1 1 auto; min-height:0;">
-            <div style="width:100%; height:100%;">
-              <ul id="file-picker" class="menu menu-compact bg-base-100 w-full" style="height:100%; border-radius:0.5rem;">
+          <div id="recents-card">
+            <h2 id="recents-title">Recents</h2>
+            <div id="recents-scroll">
+              <ul id="file-picker" class="menu menu-compact bg-base-100 w-full">
               </ul>
             </div>
           </div>
@@ -804,10 +798,10 @@ If you are creating an open source application under a license compatible with t
 
 
   <script src="js/hyperaudio-push-notification.js"></script>
-  <script src="js/hyperaudio-lite.js?v=2.6.0"></script>
-  <script src="js/hyperaudio-lite-extension.js?v=0.6.21"></script>
+  <script src="js/hyperaudio-lite.js?v=2.6.2"></script>
+  <script src="js/hyperaudio-lite-extension.js?v=0.7.2"></script>
   <script src="js/caption.js?v=0.7.1"></script>
-  <script src="js/editor-core.js?v=0.7.1"></script>
+  <script src="js/editor-core.js?v=0.7.2"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -855,7 +849,7 @@ If you are creating an open source application under a license compatible with t
   </div>
  
 
-  <script src="./js/hyperaudio-lite-editor-storage.js?v=0.6.25"></script>
+  <script src="./js/hyperaudio-lite-editor-storage.js?v=0.7.2"></script>
 
   <script src="js/editor-file-menu.js?v=0.6.12"></script>
 
@@ -886,13 +880,13 @@ If you are creating an open source application under a license compatible with t
     }
 
   </style>
-  <script src="js/editor-main.js?v=0.6.14"></script>
+  <script src="js/editor-main.js?v=0.7.2"></script>
   <script src="js/find-replace.js?v=0.6.29"></script>
   <script src="js/media-export.js?v=0.7.0"></script>
   <!-- end of caption editor additions -->
 
   <!-- responsive small-screen UI toggles (#349) -->
-  <script src="js/responsive.js?v=0.6.27"></script>
+  <script src="js/responsive.js?v=0.7.2"></script>
 
   <!-- service worker script for PWA -->
   <script src="js/editor-service-worker.js?v=0.6.12"></script>

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -459,7 +459,11 @@
       if (sidebarOpen === true) {
         document.querySelector('.holder').style.left = 0;
         document.querySelector('.main-panel').style.left = 0;
-        document.querySelector('.transcript-holder').style.left = 0;
+        document.querySelector('.transcript-holder').style.left = '16px';
+        // slide the side panel off-screen too — otherwise it lingers
+        // underneath and the video peeks through the 8px gap above the
+        // floating transcript card (#375)
+        document.querySelector('.side-panel').style.left = '-400px';
         document.querySelector('#sidebar-close-icon').style.display = "none";
         document.querySelector('#sidebar-open-icon').style.display = "block";
         sidebarOpen = false;
@@ -467,6 +471,7 @@
         document.querySelector('.holder').style.left = "400px";
         document.querySelector('.main-panel').style.left = "400px";
         document.querySelector('.transcript-holder').style.left = "400px";
+        document.querySelector('.side-panel').style.left = '0px';
         document.querySelector('#sidebar-close-icon').style.display = "block";
         document.querySelector('#sidebar-open-icon').style.display = "none";
         sidebarOpen = true;

--- a/js/editor-main.js
+++ b/js/editor-main.js
@@ -207,12 +207,11 @@
         return;
       }
       const on = video.classList.toggle('audio-only');
-      video.style.display = on ? 'none' : '';
-      // no video frame to hover over in audio-only mode, so hide the overlay too
-      const overlay = document.querySelector('#media-play-overlay');
-      if (overlay !== null) {
-        overlay.style.display = on ? 'none' : '';
-      }
+      // body.video-collapsed drives everything in CSS: #player-frame slides
+      // shut (animated max-height/opacity — no display:none pop), the controls
+      // row aligns with the navbar, and the Recents card aligns with the
+      // transcript card (#375). Audio keeps playing throughout.
+      document.body.classList.toggle('video-collapsed', on);
       btn.classList.toggle('btn-active', on);
       btn.setAttribute('aria-pressed', String(on));
       btn.setAttribute('data-tip', on ? 'Show video' : 'Audio only');

--- a/js/hyperaudio-lite-editor-storage.js
+++ b/js/hyperaudio-lite-editor-storage.js
@@ -359,7 +359,7 @@ function loadLocalStorageOptions(storage = window.localStorage) {
   setFileSelectListeners();
 
   if (storage.length === 0) {
-    filePicker.insertAdjacentHTML("beforeend", `<li style="padding-left:16px; padding-top:16px">No files saved.</li>`);
+    filePicker.insertAdjacentHTML("beforeend", `<li style="padding:8px 16px; opacity:0.55">No files saved.</li>`);
   }
 }
 

--- a/js/hyperaudio-lite-extension.js
+++ b/js/hyperaudio-lite-extension.js
@@ -21,12 +21,14 @@ document.querySelector('#search-box').addEventListener("keyup", (event) => {
 });
 
 
-// searchPhrase + helpers ported verbatim from hyperaudio-lite v2.5.1's
+// searchPhrase + helpers ported verbatim from hyperaudio-lite v2.6.2's
 // extension. Walks consecutive [data-m] spans for multi-word phrases; for each
 // matching span it wraps just the matched substring in a <mark class="search-mark">
 // so only the searched characters are highlighted, not the whole word. Matching
 // is substring-based, so word fragments are found as you type.
 const SEARCH_PUNCT = /[.,\-\/#!$%\^&\*;:{}=_`~()\?\s]/g;
+// Non-global copy for single-character tests (a /g regex is stateful in .test()).
+const SEARCH_PUNCT_CHAR = new RegExp(SEARCH_PUNCT.source);
 const normalise = (text) => text.toLowerCase().replace(SEARCH_PUNCT, '');
 
 const clearPreviousSearch = () => {
@@ -39,15 +41,43 @@ const clearPreviousSearch = () => {
   });
 };
 
+// Find the range of `original` whose normalised form matches `needle` (already
+// lowercased and punctuation-stripped): walk the raw text consuming needle
+// characters and skipping punctuation inside the match (#260). Returns
+// [start, end) indices into `original`, or null when the needle isn't present.
+const findRawRange = (original, needle) => {
+  const lower = original.toLowerCase();
+  for (let start = 0; start < lower.length; start++) {
+    if (lower[start] !== needle[0]) continue;
+    let oi = start;
+    let ni = 0;
+    while (oi < lower.length && ni < needle.length) {
+      if (lower[oi] === needle[ni]) {
+        oi++;
+        ni++;
+      } else if (SEARCH_PUNCT_CHAR.test(lower[oi])) {
+        oi++;
+      } else {
+        break;
+      }
+    }
+    if (ni === needle.length) return [start, oi];
+  }
+  return null;
+};
+
 // Wrap the first occurrence of `needle` (case-insensitive) inside `span`'s
-// text with <mark class="search-mark">. Punctuation stays outside the mark.
+// text with <mark class="search-mark">. Leading and trailing punctuation stay
+// outside the mark; punctuation inside the match (the dash in "SPEAKER-2" for
+// the needle "speaker2") is included, so the visible word is highlighted
+// whole even though matching compares punctuation-stripped text (#260).
 const highlightSubstring = (span, needle) => {
   const original = span.textContent;
-  const idx = original.toLowerCase().indexOf(needle);
-  if (idx < 0) return;
-  const before = original.slice(0, idx);
-  const hit = original.slice(idx, idx + needle.length);
-  const after = original.slice(idx + needle.length);
+  const range = findRawRange(original, needle);
+  if (range === null) return;
+  const before = original.slice(0, range[0]);
+  const hit = original.slice(range[0], range[1]);
+  const after = original.slice(range[1]);
   span.textContent = '';
   if (before) span.append(before);
   const mark = document.createElement('mark');

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.6.0 */
+/*! Version 2.6.2 */
 
 'use strict';
 

--- a/js/responsive.js
+++ b/js/responsive.js
@@ -1,30 +1,21 @@
 /**
  * responsive.js
  * (C) The Hyperaudio Project
- * @version 0.6.27 — last changed in release 0.6.27
+ * @version 0.7.2 — last changed in release 0.7.2
  * @license MIT
  *
  * Small-screen UI toggles for the responsive layout (#349):
- *  - collapse/expand the pinned player to reclaim editing space;
- *  - open/close the Recents off-canvas drawer via the existing #sidebar-toggle.
+ * open/close the Recents off-canvas drawer via the existing #sidebar-toggle.
+ * (Collapsing the pinned player is handled by the audio-only button, which
+ * sets body.video-collapsed — see toggleAudioOnly in editor-main.js, #375.)
  *
- * Layout itself is CSS (css/hyperaudio-lite-editor.css, @media max-width:768px);
+ * Layout itself is CSS (css/hyperaudio-lite-editor.css, @media max-width:948px);
  * this only flips classes on <body>. No editor logic is touched.
  */
 
 (function () {
   const body = document.body;
   const mobile = window.matchMedia('(max-width: 948px)');
-
-  // --- Pinned player collapse ------------------------------------------------
-  const collapseBtn = document.getElementById('player-collapse-toggle');
-  if (collapseBtn !== null) {
-    collapseBtn.addEventListener('click', () => {
-      const collapsed = body.classList.toggle('player-collapsed');
-      collapseBtn.setAttribute('aria-expanded', String(!collapsed));
-      collapseBtn.setAttribute('aria-label', collapsed ? 'Expand player' : 'Collapse player');
-    });
-  }
 
   // --- Recents drawer --------------------------------------------------------
   const openDrawer = () => body.classList.add('drawer-open');


### PR DESCRIPTION
Closes #375. Two commits: the UI polish set, and a hyperaudio-lite 2.6.2 bump with the punctuated-search fix ported.

## UI polish (#375)
- **Transcript as a floating rounded card**: 16px right gutter, 8px gaps below the navbar and above the play bar, matching 16px left gutter when the sidebar is collapsed. The declared corners were invisible for two stacked reasons — flush at the screen edges, and DaisyUI paints the `<body>` white so the new gaps were white-on-white; a higher-specificity `body[data-theme]` rule pins the chrome grey (no `!important`).
- **Recents**: the heading lives inside the white card; with the video collapsed the card top aligns exactly with the transcript card (both 78px), bottoms align too. Muted empty state.
- **Animated video collapse**: the audio-only button slides the frame shut (max-height/opacity — no `display:none` pop) at the same **0.5s ease** as the sidebar slide, with the controls row and Recents card gliding in step. Desktop centres the controls on the navbar line (centre 35 = navbar buttons); mobile collapses the pinned pane to the 44px strip with the controls at the top. The separate mobile collapse chevron is **removed** — audio-only is the single collapse control.
- **Sidebar collapse slides the side panel off-screen** — it previously lingered underneath, and the video peeked through the new gap above the transcript.
- **Speakers / Timecodes as switches** (view on/off semantics; DaisyUI toggle base + custom sm sizing/primary tint since the tailwind build lacks those variants). Row fits with ~33px headroom.
- **Caption editor's floating Regenerate button**: gains a z-index (caption rows painted over it) and on mobile sits below the pinned player, tracking the collapse.
- Cascade hygiene: `#player-controls` inline styles moved into the stylesheet so state rules win normally.

## hyperaudio-lite 2.6.2 + search fix
- Core re-vendored verbatim (only the version string changed 2.6.0 → 2.6.2).
- The extension's search fix (hyperaudio-lite#260) ported into the editor-customised extension: matches whose raw text contains internal punctuation now highlight whole (`speaker2` → **SPEAKER-2**, `we'll` with its apostrophe). Find & replace shares the path, so replacing punctuated matches works too.

## Verification (headless Chromium)
Alignments exact in both collapse states; toggles drive their features; slides uniform at 0.5s; regenerate button clickable via `elementFromPoint`; punctuated and plain searches verified; mobile layout suite passes.

Known pre-existing wart (not touched): duplicate `id="regenerate-btn"` (captions modal + injected floating button).

Bumps app version to **0.7.2**.
