### PR TITLE
Show the app version in the info panel (0.7.3)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.7.2 (last changed in release 0.7.2) -->
+<!--  Hyperaudio Lite Editor - Version 0.7.3 (last changed in release 0.7.3) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.7.2">
+  <meta name="version" content="0.7.3">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -367,6 +367,7 @@ If you are creating an open source application under a license compatible with t
               <p id="summary" class="py-4"></p>
               <h3 class="text-lg font-bold">Topics</h3>
               <p id="topics" class="py-4"></p>
+              <p id="app-version" style="margin-top:8px; font-size:75%; opacity:0.55; text-align:right"></p>
             </div>
           </div>
         </div>
@@ -801,7 +802,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite.js?v=2.6.2"></script>
   <script src="js/hyperaudio-lite-extension.js?v=0.7.2"></script>
   <script src="js/caption.js?v=0.7.1"></script>
-  <script src="js/editor-core.js?v=0.7.2"></script>
+  <script src="js/editor-core.js?v=0.7.3"></script>
 
 
   <import-deepgram-json></import-deepgram-json>

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -1,6 +1,14 @@
 /* Extracted verbatim from index.html (#334) — loaded as a classic script in the same document order. */
 
-    console.log("version 3");
+  // Show the app version (from <meta name="version">) in the info modal, so a
+  // bug report can say exactly which build it is — including a stale cached one.
+  {
+    const versionMeta = document.querySelector('meta[name="version"]');
+    const versionOut = document.getElementById('app-version');
+    if (versionMeta !== null && versionOut !== null) {
+      versionOut.textContent = `Editor v${versionMeta.content}`;
+    }
+  }
 
   // Populates the Transcription section of the info modal. Called by the
   // transcription modules (Whisper, Deepgram) when a transcription completes.


### PR DESCRIPTION
Adds a small muted **"Editor vX.Y.Z"** line at the bottom of the info modal, read live from `<meta name="version">` — so version bumps propagate automatically, and users on a stale cached build (GitHub Pages) can report exactly what they're running.

Also removes a stray `console.log("version 3")` debug line from the top of `editor-core.js`.

Verified headlessly: renders "Editor v0.7.3", no console errors.

Bumps app version to **0.7.3**.
