### PR TITLE
Coalesce struck runs into one cut — their inter-word silences must go too (#383, 0.7.4)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.7.3 (last changed in release 0.7.3) -->
+<!--  Hyperaudio Lite Editor - Version 0.7.4 (last changed in release 0.7.4) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.7.3">
+  <meta name="version" content="0.7.4">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -891,7 +891,7 @@ If you are creating an open source application under a license compatible with t
 
   <!-- service worker script for PWA -->
   <script src="js/editor-service-worker.js?v=0.6.12"></script>
-  <script type="module" src="js/editor-audio-cut.js?v=0.7.0"></script>
+  <script type="module" src="js/editor-audio-cut.js?v=0.7.4"></script>
 
 
   <script src="js/editor-svg.js?v=0.6.12"></script>

--- a/js/editor-audio-cut.js
+++ b/js/editor-audio-cut.js
@@ -253,21 +253,35 @@
     let prevKeptEnd = null;
     let pendingStruck = [];
 
+    // A run of struck words in one region is always ONE cut spanning from the
+    // first struck word's start to the last one's end, so the silences BETWEEN
+    // struck words go with them (cutting only the word spans left those pauses
+    // playing back-to-back — audible fragments of the struck region).
+    const struckRunCut = (struckSpans) => {
+      if (struckSpans.length === 0) return null;
+      let end = struckSpans[0].end;
+      struckSpans.forEach(s => { if (s.end > end) end = s.end; }); // tolerate overlapping word timings
+      return { start: struckSpans[0].start, end };
+    };
+
     const flushRegion = (regionStart, regionEnd, struckSpans, bufferLeft, bufferRight) => {
+      const run = struckRunCut(struckSpans);
       if (removeGapsEnabled && regionStart !== null) {
         const struckTotal = struckSpans.reduce((sum, s) => sum + (s.end - s.start), 0);
         const effectivePause = (regionEnd - regionStart) - struckTotal;
         if (effectivePause > gapThreshold) {
-          const cutStart = regionStart + (bufferLeft ? gapBuffer : 0);
-          const cutEnd = regionEnd - (bufferRight ? gapBuffer : 0);
+          // cut the whole region; the edge buffers protect the neighbouring
+          // kept words' tails, but never at the price of keeping struck audio
+          const cutStart = Math.min(regionStart + (bufferLeft ? gapBuffer : 0), run !== null ? run.start : Infinity);
+          const cutEnd = Math.max(regionEnd - (bufferRight ? gapBuffer : 0), run !== null ? run.end : -Infinity);
           if (cutEnd > cutStart) {
             cuts.push({ start: cutStart, end: cutEnd });
             return;
           }
         }
       }
-      // gaps kept (or gap skipping off): cut only the struck words themselves
-      struckSpans.forEach(s => cuts.push({ start: s.start, end: s.end }));
+      // gaps kept (or gap skipping off): cut the struck run whole
+      if (run !== null) cuts.push(run);
     };
 
     words.forEach(word => {
@@ -280,7 +294,8 @@
         if (regionStart !== null && word.start > regionStart) {
           flushRegion(regionStart, word.start, pendingStruck, prevKeptEnd !== null, true);
         } else {
-          pendingStruck.forEach(s => cuts.push({ start: s.start, end: s.end }));
+          const run = struckRunCut(pendingStruck);
+          if (run !== null) cuts.push(run);
         }
       }
       pendingStruck = [];


### PR DESCRIPTION
Fixes #383 — a regression from the #371 rework of `computePlayableSections` (0.7.0).

### Symptom
With gap skipping off, striking a run of consecutive words cut each word span individually, leaving the **silences between the struck words** playing back-to-back — audible sped-up fragments of the struck region, in playback and export alike (shared model).

### Fix
A struck run is again **one cut from the first struck word's start to the last one's end** (tolerating overlapping word timings), restoring the pre-#371 semantics. With gap skipping on, the whole-region cut also never keeps struck audio for the sake of the edge buffer (`min(regionStart+buffer, runStart)` / `max(regionEnd−buffer, runEnd)`).

### Verification
- The reported paragraph (struck run `lot → you're`, 17.92–22.08s): **exactly 4.16s removed in a single cut**, matching the reporter's arithmetic; confirmed fixed by ear on the original media.
- The #371 behaviour is retained (pauses around struck fillers merge when gap skipping is on).
- The export regression suite and the tone-ladder cut-accuracy test (distinct tone per second; spectral analysis of the exported audio) remain sample-exact.

Bumps app version to **0.7.4**.
