### PR TITLE
Add test suites: Playwright e2e + unit lane (#58)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npx playwright install --with-deps chromium
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,7 @@ dist
 .pnp.*
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,node,linux
+
+# Playwright
+test-results/
+playwright-report/

--- a/__TEST__/e2e/export-cuts.spec.mjs
+++ b/__TEST__/e2e/export-cuts.spec.mjs
@@ -1,0 +1,60 @@
+// Edited media export must contain exactly the kept timeline. Uses a "tone
+// ladder" (a distinct tone per second) so the exported audio's content encodes
+// which parts of the original timeline it came from. Requires network: the
+// export modal lazy-loads mediabunny from its CDN.
+import { test, expect } from '@playwright/test';
+import { ladderWav, analyseWav, transcriptHtml } from './helpers.mjs';
+
+test('edited WAV export drops struck seconds sample-accurately', async ({ page }) => {
+  const wav = ladderWav(10); // tones: sec N = (200 + N*100) Hz
+  await page.route('**/__ladder.wav', (route) => route.fulfill({
+    body: wav, contentType: 'audio/wav',
+  }));
+  await page.goto('/index.html');
+  await page.waitForFunction(() => typeof window.getPlayableSections === 'function');
+
+  await page.evaluate(async () => {
+    const blob = await (await fetch('/__ladder.wav')).blob();
+    document.getElementById('hyperplayer').src = URL.createObjectURL(blob);
+  });
+  await page.waitForFunction(() => {
+    const p = document.getElementById('hyperplayer');
+    return p.readyState >= 1 && p.duration > 9;
+  });
+
+  // one word per second; strike seconds 3 and 7
+  const words = Array.from({ length: 10 }, (_, i) => [i * 1000, 1000, i === 3 || i === 7 ? 1 : 0]);
+  await page.evaluate((html) => {
+    document.getElementById('hypertranscript').innerHTML = html;
+  }, transcriptHtml(words));
+
+  await page.evaluate(() => {
+    const m = document.getElementById('export-modal');
+    m.checked = true;
+    m.dispatchEvent(new Event('change'));
+  });
+  await page.waitForFunction(() => document.getElementById('export-format').options.length > 0, null, { timeout: 60000 });
+  await page.selectOption('#export-format', 'wav');
+  await page.evaluate(() => {
+    const c = document.getElementById('export-retime');
+    if (c) c.checked = false;
+  });
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.click('#export-start');
+  const download = await downloadPromise;
+  await page.waitForFunction(() => document.getElementById('export-status').textContent.startsWith('Done'));
+
+  const path = await download.path();
+  const { duration, freqs } = analyseWav(await (await import('node:fs/promises')).readFile(path));
+
+  // 10s minus the two struck seconds
+  expect(Math.abs(duration - 8)).toBeLessThan(0.01);
+  // content order: 0,1,2, 4,5,6, 8,9 → tones 200,300,400,600,700,800,1000,1100
+  // (first half-window can carry a boundary transient; assert from window 1)
+  const expected = [200, 200, 300, 300, 400, 400, 600, 600, 700, 700, 800, 800, 1000, 1000, 1100, 1100];
+  expect(freqs.slice(1)).toEqual(expected.slice(1));
+  // the struck tones (500Hz, 900Hz) must not appear anywhere
+  expect(freqs).not.toContain(500);
+  expect(freqs).not.toContain(900);
+});

--- a/__TEST__/e2e/helpers.mjs
+++ b/__TEST__/e2e/helpers.mjs
@@ -1,0 +1,97 @@
+// Shared helpers for the e2e suite.
+
+// Build a mono 16-bit WAV "tone ladder": `seconds` one-second segments, each a
+// distinct pure tone (200Hz, 300Hz, …). Content encodes time, so analysing the
+// exported audio reveals exactly which parts of the timeline it contains.
+export function ladderWav(seconds = 10, sampleRate = 44100) {
+  const frames = seconds * sampleRate;
+  const buf = Buffer.alloc(44 + frames * 2);
+  buf.write('RIFF', 0); buf.writeUInt32LE(36 + frames * 2, 4); buf.write('WAVE', 8);
+  buf.write('fmt ', 12); buf.writeUInt32LE(16, 16); buf.writeUInt16LE(1, 20);
+  buf.writeUInt16LE(1, 22); buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(sampleRate * 2, 28); buf.writeUInt16LE(2, 32); buf.writeUInt16LE(16, 34);
+  buf.write('data', 36); buf.writeUInt32LE(frames * 2, 40);
+  for (let sec = 0; sec < seconds; sec++) {
+    const f = 200 + sec * 100;
+    for (let n = 0; n < sampleRate; n++) {
+      const v = Math.round(0.6 * 32767 * Math.sin(2 * Math.PI * f * n / sampleRate));
+      buf.writeInt16LE(v, 44 + (sec * sampleRate + n) * 2);
+    }
+  }
+  return buf;
+}
+
+// Parse a WAV buffer: duration plus a zero-crossing frequency estimate per
+// `win`-second window (rounded to the nearest 100Hz to shrug off boundary
+// transients).
+export function analyseWav(buf, win = 0.5) {
+  let off = 12, sr = 0, ch = 1, bits = 16, dataOff = 0, dataLen = 0;
+  while (off + 8 <= buf.length) {
+    const id = buf.toString('ascii', off, off + 4);
+    const size = buf.readUInt32LE(off + 4);
+    if (id === 'fmt ') { ch = buf.readUInt16LE(off + 10); sr = buf.readUInt32LE(off + 12); bits = buf.readUInt16LE(off + 22); }
+    if (id === 'data') { dataOff = off + 8; dataLen = size; break; }
+    off += 8 + size + (size % 2);
+  }
+  const frames = dataLen / (ch * (bits / 8));
+  const duration = frames / sr;
+  const step = Math.floor(sr * win);
+  const freqs = [];
+  for (let i = 0; i + step <= frames; i += step) {
+    let zc = 0;
+    let prev = buf.readInt16LE(dataOff + (i * ch) * 2);
+    for (let j = 1; j < step; j++) {
+      const v = buf.readInt16LE(dataOff + ((i + j) * ch) * 2);
+      if ((prev < 0) !== (v < 0)) zc++;
+      prev = v;
+    }
+    freqs.push(Math.round(zc / (2 * win) / 100) * 100);
+  }
+  return { duration, sampleRate: sr, freqs };
+}
+
+// Build transcript HTML from [startMs, durMs, struck?] triples.
+export function transcriptHtml(words) {
+  return '<article><section><p>' + words.map(([m, d, s]) =>
+    `<span data-m="${m}" data-d="${d}"${s ? ' style="text-decoration: line-through;"' : ''}>w </span>`
+  ).join('') + '</p></section></article>';
+}
+
+// In-page: set the transcript, apply gap settings, and return the kept
+// sections (clamped to `duration`) from the shipped model.
+export async function sectionsFor(page, words, { gapsOn = false, duration = 60 } = {}) {
+  return page.evaluate(({ html, gapsOn, duration }) => {
+    document.getElementById('hypertranscript').innerHTML = html;
+    const en = document.getElementById('remove-gaps-enabled');
+    en.checked = gapsOn;
+    en.dispatchEvent(new Event('change'));
+    return window.getPlayableSections()
+      .map((s) => ({ start: +s.start.toFixed(3), end: +Math.min(s.end, duration).toFixed(3) }))
+      .filter((s) => s.end > s.start + 0.0005);
+  }, { html: transcriptHtml(words), gapsOn, duration });
+}
+
+// The paragraph from #383, verbatim (struck run "lot → you're", 17.92–22.08s).
+export const ISSUE_383_WORDS = [
+  [2240, 80], [3440, 80], [5120, 640], [7280, 80], [7760, 80], [8000, 320], [8480, 720], [9760, 80],
+  [11680, 640], [12640, 80], [12960, 80], [13680, 80], [14960, 80], [17360, 400], [17840, 80],
+  [17920, 80, 1], [18080, 80, 1], [18320, 240, 1], [18960, 400, 1], [20080, 80, 1], [21040, 80, 1],
+  [21280, 400, 1], [21600, 80, 1], [21840, 240, 1],
+  [22080, 240], [22320, 80], [22480, 480], [23040, 80], [23200, 80], [23520, 80], [24000, 400],
+  [26880, 400], [28480, 400], [29280, 80], [29600, 400], [30240, 80], [30560, 80], [30800, 400],
+  [31200, 80], [31360, 80], [31520, 80], [31680, 80], [31920, 80], [32160, 80], [32400, 80],
+  [32640, 80], [32800, 80], [33120, 480], [34080, 80], [35120, 80], [35520, 320], [35920, 80],
+  [36160, 80], [36320, 80], [36480, 80], [36720, 80], [36960, 80], [37440, 80], [40400, 640],
+];
+
+// The transcript from #371, verbatim (struck fillers "um" at 14.96s and "Uh"
+// at 28.48s, gap skipping on).
+export const ISSUE_371_WORDS = [
+  [2240, 80], [3440, 80], [5120, 1920], [7280, 80], [7760, 80], [8000, 320], [8480, 720], [9760, 80],
+  [11680, 640], [12640, 80], [12960, 80], [13680, 80], [14960, 80, 1], [17360, 400], [17840, 80],
+  [17920, 80], [18080, 80], [18320, 240], [18960, 400], [20080, 80], [21040, 80], [21280, 400],
+  [21600, 80], [21840, 240], [22080, 240], [22320, 80], [22480, 480], [23040, 80], [23200, 80],
+  [23520, 80], [24000, 2640], [26880, 1360], [28480, 400, 1], [29280, 80], [29600, 400], [30240, 80],
+  [30560, 80], [30800, 400], [31200, 80], [31360, 80], [31520, 80], [31680, 80], [31920, 80],
+  [32160, 80], [32400, 80], [32640, 80], [32800, 80], [33120, 720],
+];

--- a/__TEST__/e2e/playable-sections.spec.mjs
+++ b/__TEST__/e2e/playable-sections.spec.mjs
@@ -1,0 +1,72 @@
+// Regression guards for the cut model (strikeouts + gap skipping) that drives
+// both playback skipping and edited media export. These exercise the SHIPPED
+// code via window.getPlayableSections — the exact datasets from #383 and #371.
+import { test, expect } from '@playwright/test';
+import { sectionsFor, ISSUE_383_WORDS, ISSUE_371_WORDS } from './helpers.mjs';
+
+const kept = (sections) => +sections.reduce((a, s) => a + (s.end - s.start), 0).toFixed(3);
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForFunction(() => typeof window.getPlayableSections === 'function');
+});
+
+test('#383: a struck run is ONE cut — its inter-word silences go too (gaps off)', async ({ page }) => {
+  const sections = await sectionsFor(page, ISSUE_383_WORDS, { gapsOn: false, duration: 45 });
+  // exactly one cut, spanning first struck word start → last struck word end
+  expect(sections).toEqual([
+    { start: 0, end: 17.92 },
+    { start: 22.08, end: 45 },
+  ]);
+  expect(+(45 - kept(sections)).toFixed(3)).toBe(4.16); // the reporter's arithmetic
+});
+
+test('#383: with gaps on, the edge buffer never keeps struck audio', async ({ page }) => {
+  const sections = await sectionsFor(page, ISSUE_383_WORDS, { gapsOn: true, duration: 45 });
+  // the struck-run cut must still span exactly 17.92 → 22.08 (kept words touch
+  // the run with zero gap, so no buffer applies there)
+  const endsAtRun = sections.find((s) => s.end === 17.92);
+  const resumesAfterRun = sections.find((s) => s.start === 22.08);
+  expect(endsAtRun).toBeTruthy();
+  expect(resumesAfterRun).toBeTruthy();
+});
+
+test('#371: pauses around struck filler words merge into the cut (gaps on)', async ({ page }) => {
+  const sections = await sectionsFor(page, ISSUE_371_WORDS, { gapsOn: true, duration: 58.599 });
+  // verified boundaries from the #371 fix: the "and …um… uses" region cuts
+  // [13.86 → 17.26] and "Yeah …Uh… you" cuts [28.34 → 29.18]
+  expect(sections).toEqual([
+    { start: 0, end: 2.42 },
+    { start: 3.34, end: 3.62 },
+    { start: 5.02, end: 9.3 },
+    { start: 9.66, end: 9.94 },
+    { start: 11.58, end: 13.14 },
+    { start: 13.58, end: 13.86 },
+    { start: 17.26, end: 19.46 },
+    { start: 19.98, end: 20.26 },
+    { start: 20.94, end: 28.34 },
+    { start: 29.18, end: 58.599 },
+  ]);
+});
+
+test('gaps off: a single struck word cuts exactly its own span', async ({ page }) => {
+  const sections = await sectionsFor(page, [[1000, 500], [3000, 500, 1], [6000, 500]], { gapsOn: false, duration: 10 });
+  expect(sections).toEqual([
+    { start: 0, end: 3 },
+    { start: 3.5, end: 10 },
+  ]);
+});
+
+test('overlapping struck word timings are tolerated (run end = max end)', async ({ page }) => {
+  // second struck word starts before the first ends, and ends earlier
+  const sections = await sectionsFor(page, [[1000, 500], [3000, 1000, 1], [3200, 300, 1], [6000, 500]], { gapsOn: false, duration: 10 });
+  expect(sections).toEqual([
+    { start: 0, end: 3 },
+    { start: 4, end: 10 },
+  ]);
+});
+
+test('no strikeouts, gaps off: one full section', async ({ page }) => {
+  const sections = await sectionsFor(page, [[1000, 500], [2000, 500]], { gapsOn: false, duration: 10 });
+  expect(sections).toEqual([{ start: 0, end: 10 }]);
+});

--- a/__TEST__/e2e/responsive.spec.mjs
+++ b/__TEST__/e2e/responsive.spec.mjs
@@ -1,0 +1,46 @@
+// The phone layout (#349/#375): pinned player, Recents drawer, and the
+// audio-only collapse. Runs at 390×844.
+import { test, expect } from '@playwright/test';
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+const rect = (page, sel) => page.evaluate((s) => {
+  const r = document.querySelector(s).getBoundingClientRect();
+  return { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) };
+}, sel);
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+});
+
+test('single-column stack with no horizontal overflow', async ({ page }) => {
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
+  expect(overflow).toBeLessThanOrEqual(1);
+  const navbar = await rect(page, '.main-panel');
+  const player = await rect(page, '#player-pane');
+  const transcript = await rect(page, '.transcript-holder');
+  const playbar = await rect(page, '#playbar');
+  expect(player.y).toBeGreaterThanOrEqual(navbar.h - 1);
+  expect(transcript.y).toBeGreaterThanOrEqual(player.y + player.h - 2);
+  expect(playbar.y).toBeGreaterThan(transcript.y);
+});
+
+test('Recents drawer slides in via the sidebar toggle and closes on backdrop', async ({ page }) => {
+  expect((await rect(page, '#recents-pane')).x).toBeLessThan(0); // off-canvas
+  await page.click('#sidebar-toggle');
+  await page.waitForTimeout(350);
+  expect((await rect(page, '#recents-pane')).x).toBeGreaterThanOrEqual(0);
+  await page.mouse.click(375, 422); // exposed backdrop right of the 320px drawer
+  await page.waitForTimeout(350);
+  expect((await rect(page, '#recents-pane')).x).toBeLessThan(0);
+});
+
+test('audio-only collapses the pinned player to the controls strip', async ({ page }) => {
+  const before = (await rect(page, '.transcript-holder')).y;
+  await page.click('#audio-only-btn');
+  await page.waitForTimeout(400);
+  expect((await rect(page, '#player-pane')).h).toBeLessThan(60);
+  expect((await rect(page, '.transcript-holder')).y).toBeLessThan(before);
+  expect(await page.evaluate(() => document.body.classList.contains('video-collapsed'))).toBe(true);
+});

--- a/__TEST__/e2e/search.spec.mjs
+++ b/__TEST__/e2e/search.spec.mjs
@@ -1,0 +1,38 @@
+// Search highlighting, including the punctuated-match fix ported from
+// hyperaudio-lite 2.6.2 (#260 upstream): matching compares punctuation-stripped
+// text, and the highlight must cover the whole raw word.
+import { test, expect } from '@playwright/test';
+
+const search = (page, query) => page.evaluate((q) => {
+  const sb = document.querySelector('#search-box');
+  sb.value = q;
+  sb.dispatchEvent(new KeyboardEvent('keyup'));
+  return [...document.querySelectorAll('#hypertranscript mark.search-mark')].map((m) => m.textContent);
+}, query);
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+});
+
+test('plain search marks every occurrence', async ({ page }) => {
+  const marks = await search(page, 'captions');
+  expect(marks.length).toBeGreaterThanOrEqual(2);
+  marks.forEach((m) => expect(m.toLowerCase()).toBe('captions'));
+});
+
+test('matches with internal punctuation highlight whole', async ({ page }) => {
+  await page.evaluate(() => {
+    document.querySelector('#hypertranscript p').insertAdjacentHTML(
+      'beforeend', '<span data-m="57000" data-d="300">SPEAKER-2 </span>');
+  });
+  expect(await search(page, 'speaker2')).toEqual(['SPEAKER-2']);
+  expect(await search(page, 'speaker-2')).toEqual(['SPEAKER-2']);
+  expect((await search(page, "we'll")).length).toBeGreaterThan(0);
+});
+
+test('clearing the query clears the marks', async ({ page }) => {
+  await search(page, 'captions');
+  const after = await search(page, '');
+  expect(after).toEqual([]);
+});

--- a/__TEST__/unit/README.md
+++ b/__TEST__/unit/README.md
@@ -1,0 +1,30 @@
+# Unit test lane (`npm run test:unit`)
+
+Runs `node --test` against this directory — no dependencies, no browser,
+millisecond feedback.
+
+**It is empty by design.** Today every editor module touches the DOM at load
+time, so nothing can be imported into Node directly; behaviour is covered by
+the Playwright e2e suite in `../e2e/` instead.
+
+## Modularisation: how this lane fills up
+
+The path to unit tests is **modularisation**: when a feature change or refactor
+earns its release anyway, extract the pure logic into its own importable module
+(DOM reading stays in a thin wrapper) and add its tests here. Candidates, in
+rough order of value:
+
+- **The cut model** (`computePlayableSections`'s arithmetic in
+  `editor-audio-cut.js`) — the #371/#383 regressions were pure timing logic; a
+  pure `computeCutSections(words, duration, opts)` would guard them at unit
+  speed.
+- **Export re-timing** (`mapTime` / `buildRetimedTranscriptHtml`'s maths in
+  `media-export.js`).
+- **Search helpers** (`normalise` / `findRawRange` in
+  `hyperaudio-lite-extension.js` — ported from upstream, which already
+  unit-tests them in its own repo).
+- **Caption/format converters** (`html-json-converter.js`).
+
+Rule of thumb: never bump a release *only* to make something testable — but
+when a module is being touched anyway, leave its logic purer than you found it
+and add the unit tests in the same change.

--- a/__TEST__/unit/helpers.test.mjs
+++ b/__TEST__/unit/helpers.test.mjs
@@ -1,0 +1,13 @@
+// Unit lane smoke test — also validates the e2e suite's measuring instrument:
+// the WAV builder/analyser used by export-cuts.spec.mjs must be trustworthy for
+// its verdicts to mean anything.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ladderWav, analyseWav } from '../e2e/helpers.mjs';
+
+test('ladderWav/analyseWav round-trip: duration and tone timeline', () => {
+  const { duration, sampleRate, freqs } = analyseWav(ladderWav(3));
+  assert.equal(sampleRate, 44100);
+  assert.ok(Math.abs(duration - 3) < 0.001);
+  assert.deepEqual(freqs, [200, 200, 300, 300, 400, 400]);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "hyperaudio-lite-editor",
       "devDependencies": {
+        "@playwright/test": "^1.49.0",
         "autoprefixer": "^10.4.14",
         "cssnano": "^6.0.1",
         "daisyui": "^4.4.2",
@@ -111,6 +113,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@trysound/sax": {
@@ -1088,6 +1106,38 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
     "cssnano": "^6.0.1",
     "daisyui": "^4.4.2",
     "postcss": "^8.4.24",
-    "tailwindcss": "^3.3.2"
+    "tailwindcss": "^3.3.2",
+    "@playwright/test": "^1.49.0"
+  },
+  "name": "hyperaudio-lite-editor",
+  "private": true,
+  "scripts": {
+    "test": "npm run test:unit && npm run test:e2e",
+    "test:unit": "node --test \"__TEST__/unit/**/*.test.mjs\"",
+    "test:e2e": "playwright test"
   }
 }

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,19 @@
+// Playwright end-to-end tests for the editor (see __TEST__/e2e/).
+// The suite loads the real page from a static server and drives the shipped
+// code — no production files are modified for testing.
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '__TEST__/e2e',
+  timeout: 120000,
+  retries: process.env.CI ? 1 : 0,
+  use: {
+    baseURL: 'http://localhost:4173',
+    viewport: { width: 1280, height: 800 },
+  },
+  webServer: {
+    command: 'python3 -m http.server 4173',
+    port: 4173,
+    reuseExistingServer: true,
+  },
+});


### PR DESCRIPTION
Part of #58 (retitled to reflect the strategy).

Adds automated tests with **zero production changes** (no version bump):

### Playwright e2e — `npm run test:e2e` (13 tests, ~5s)
- **`playable-sections.spec.mjs`** — the cut model through the real page: the exact **#383** paragraph (a struck run is ONE cut, 17.92→22.08, 4.16s removed — the regression that shipped in 0.7.0 can't return silently) and the exact **#371** dataset (pauses around struck fillers merge; full section boundary list), plus single-word / overlapping-timings / no-edit cases.
- **`export-cuts.spec.mjs`** — edited WAV export against a tone-ladder (a distinct tone per second, so the output's content encodes the timeline): duration exact, struck tones provably absent.
- **`search.spec.mjs`** — punctuated-match highlighting (hyperaudio-lite#260) + plain search + clearing.
- **`responsive.spec.mjs`** — phone stack, Recents drawer, audio-only collapse (#349/#375).

### Unit lane — `npm run test:unit` (`node --test`, zero dependencies)
Seeded with a test validating the e2e suite's own WAV builder/analyser. `__TEST__/unit/README.md` sets out the **modularisation strategy**: pure logic (cut model, export re-timing maths, search helpers, converters) gets extracted into importable modules when a change earns its release anyway — unit tests land in the same change, and a release is never cut purely for testability.

### CI
`.github/workflows/test.yml` runs both lanes on push to main and on PRs (installs Chromium; the export test needs network for the mediabunny CDN, which runners have).

Vendored `hyperaudio-lite.js`/`caption.js` are Jest-tested upstream since 2.6.0 — not duplicated here.
