### PR TITLE
Fix duplicate element ids: regenerate button + close-modal labels (#379, 0.7.6)

### DIFF
--- a/__TEST__/e2e/dom-hygiene.spec.mjs
+++ b/__TEST__/e2e/dom-hygiene.spec.mjs
@@ -1,0 +1,55 @@
+// DOM hygiene: element ids must be unique — duplicate ids make
+// getElementById/querySelector silently return whichever comes first in the
+// DOM, so selectors hit the right element only by accident of markup order
+// (#379: two elements shared id="regenerate-btn"). Checked on load and again
+// in caption mode, which injects extra UI at runtime.
+import { test, expect } from '@playwright/test';
+
+const duplicateIds = (page) => page.evaluate(() => {
+  const seen = new Map();
+  document.querySelectorAll('[id]').forEach((el) => {
+    seen.set(el.id, (seen.get(el.id) || 0) + 1);
+  });
+  return [...seen.entries()].filter(([, n]) => n > 1).map(([id, n]) => `${id}×${n}`);
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+});
+
+test('no duplicate element ids on load', async ({ page }) => {
+  expect(await duplicateIds(page)).toEqual([]);
+});
+
+test('no duplicate element ids in caption mode; regenerate controls distinct (#379)', async ({ page }) => {
+  await page.click('#caption-editor-btn');
+  await page.waitForSelector('#regenerate-float-btn', { timeout: 30000 });
+
+  expect(await duplicateIds(page)).toEqual([]);
+
+  // the floating button and the captions-modal button are separate elements
+  const roles = await page.evaluate(() => {
+    const float = document.getElementById('regenerate-float-btn');
+    const modal = document.getElementById('regenerate-btn');
+    const cs = getComputedStyle(float);
+    const bb = float.getBoundingClientRect();
+    const topEl = document.elementFromPoint(bb.x + bb.width / 2, bb.y + bb.height / 2);
+    return {
+      floatIsLabel: float.tagName === 'LABEL',
+      floatFixed: cs.position === 'fixed',
+      floatZ: cs.zIndex,
+      floatClickable: topEl === float || float.contains(topEl),
+      modalIsButton: modal !== null && modal.tagName === 'BUTTON',
+      distinct: float !== modal,
+    };
+  });
+  expect(roles).toEqual({
+    floatIsLabel: true,
+    floatFixed: true,
+    floatZ: '20',
+    floatClickable: true,
+    modalIsButton: true,
+    distinct: true,
+  });
+});

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -351,7 +351,7 @@ dialog::backdrop {
   }
   /* Keep the floating Regenerate button below the pinned player (its top-20
      utility class would sit it on the video); tracks the collapse var. */
-  #regenerate-btn {
+  #regenerate-float-btn {
     top: calc(var(--nav-h) + var(--player-h) + 8px);
     right: 8px;
     transition: top 0.25s ease;
@@ -705,7 +705,7 @@ body.find-replace-open .hyperaudio-transcript { padding-top: 108px; }
    fixed top-20 right-8 with no z-index, so positioned content (the caption
    rows / transcript holder) painted over it. Lift it above content, below
    the drawer (45) and navbar (60). */
-#regenerate-btn { z-index: 20; }
+#regenerate-float-btn { z-index: 20; }
 
 /* Video collapse (audio-only button), desktop: slide the frame shut instead
    of a display:none pop, at the same 0.5s ease as the sidebar slide so all

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.7.5 (last changed in release 0.7.5) -->
+<!--  Hyperaudio Lite Editor - Version 0.7.6 (last changed in release 0.7.6) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.7.5">
+  <meta name="version" content="0.7.6">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -104,7 +104,7 @@ If you are creating an open source application under a license compatible with t
     }
     
   </style>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.7.2">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.7.6">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -699,7 +699,7 @@ If you are creating an open source application under a license compatible with t
   <input type="checkbox" id="transcribe-modal" class="modal-toggle" />
   <div class="modal">
     <div class="modal-box" style="max-width:36rem">
-      <label id="close-modal" for="transcribe-modal" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+      <label for="transcribe-modal" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
       <h3 class="font-bold text-lg"  style="margin-bottom:16px">Transcribe</h3>
       <div role="tablist" class="tabs tabs-lifted">
 
@@ -725,7 +725,7 @@ If you are creating an open source application under a license compatible with t
   <input type="checkbox" id="align-modal" class="modal-toggle" />
   <div class="modal">
     <div class="modal-box">
-      <label id="close-modal" for="align-modal" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+      <label for="align-modal" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
       <h3 class="font-bold text-lg"  style="margin-bottom:16px">Align</h3>
       
       <div class="flex flex-col gap-4 w-full">
@@ -798,7 +798,7 @@ If you are creating an open source application under a license compatible with t
   <input type="checkbox" id="regenerate-captions-modal" class="modal-toggle" />
   <div class="modal">
     <div class="modal-box">
-      <label id="close-modal" for="regenerate-captions-modal" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+      <label for="regenerate-captions-modal" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
       <div class="flex flex-col gap-4 w-full">
         <h3 class="font-bold text-lg">Caption Regeneration </h3>
         <p>Any changes you made to the captions will be lost.</p>
@@ -832,7 +832,7 @@ If you are creating an open source application under a license compatible with t
   <div class="modal">
   <div class="modal-box">
     <div class="flex flex-col gap-4 w-full">
-      <label id="close-modal" for="file-save-dialog" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+      <label for="file-save-dialog" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
       <h3 class="font-bold text-lg">Save to Local Storage</h3>
       <input type="text" id="save-localstorage-filename" name="save-localstorage-filename" placeholder="File name" class="input input-bordered w-full max-w-xs" />
     </div>
@@ -851,7 +851,7 @@ If you are creating an open source application under a license compatible with t
   <div class="modal">
   <div class="modal-box">
     <div class="flex flex-col gap-4 w-full">
-      <label id="close-modal" for="file-load-dialog" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+      <label for="file-load-dialog" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
       <h3 class="font-bold text-lg">Load from Local Storage</h3>
       <select id="load-localstorage-filename" class="select select-bordered w-full max-w-xs">
       </select>
@@ -868,7 +868,7 @@ If you are creating an open source application under a license compatible with t
 
   <script src="js/editor-file-menu.js?v=0.6.12"></script>
 
-  <script src="./js/hyperaudio-lite-editor-export.js" type="module"> </script>
+  <script src="./js/hyperaudio-lite-editor-export.js?v=0.7.6" type="module"> </script>
   <!-- end of localstorage additions -->
 
   <!-- caption editor additions -->
@@ -895,7 +895,7 @@ If you are creating an open source application under a license compatible with t
     }
 
   </style>
-  <script src="js/editor-main.js?v=0.7.2"></script>
+  <script src="js/editor-main.js?v=0.7.6"></script>
   <script src="js/find-replace.js?v=0.6.29"></script>
   <script src="js/media-export.js?v=0.7.5"></script>
   <!-- end of caption editor additions -->

--- a/js/editor-main.js
+++ b/js/editor-main.js
@@ -21,7 +21,7 @@
       }
       
 
-      holder.innerHTML = '<div class="modal-action"><label id="regenerate-btn" for="regenerate-captions-modal" class="fixed top-20 right-8 btn btn-outline btn-primary" >Regenerate <svg id="regenerate-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-restart"><path d="M21 6H3"></path><path d="M7 12H3"></path><path d="M7 18H3"></path><path d="M12 18a5 5 0 0 0 9-3 4.5 4.5 0 0 0-4.5-4.5c-1.33 0-2.54.54-3.41 1.41L11 14"></path><path d="M11 10v4h4"></path></svg></label></div>';
+      holder.innerHTML = '<div class="modal-action"><label id="regenerate-float-btn" for="regenerate-captions-modal" class="fixed top-20 right-8 btn btn-outline btn-primary" >Regenerate <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-restart"><path d="M21 6H3"></path><path d="M7 12H3"></path><path d="M7 18H3"></path><path d="M12 18a5 5 0 0 0 9-3 4.5 4.5 0 0 0-4.5-4.5c-1.33 0-2.54.54-3.41 1.41L11 14"></path><path d="M11 10v4h4"></path></svg></label></div>';
 
       if (captionCache === null ) {
         let newDiv = document.createElement('div');

--- a/js/hyperaudio-lite-editor-export.js
+++ b/js/hyperaudio-lite-editor-export.js
@@ -125,7 +125,7 @@ class ImportDeepgramJson extends HTMLElement {
     <div class="modal">
     <div class="modal-box">
       <div class="flex flex-col gap-4 w-full">
-        <label id="close-modal" for="file-import-deepgram-json-dialog" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+        <label for="file-import-deepgram-json-dialog" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
         <h3 class="font-bold text-lg">Import Deepgram JSON Dialog</h3>
         <input id="deepgram-json-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
         <span class="label-text">or use local media file</span>
@@ -252,7 +252,7 @@ class ImportSrt extends HTMLElement {
     <div class="modal">
     <div class="modal-box">
       <div class="flex flex-col gap-4 w-full">
-        <label id="close-modal" for="file-import-srt-dialog" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+        <label for="file-import-srt-dialog" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
         <h3 class="font-bold text-lg">Import SRT Dialog</h3>
         <input id="srt-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
         <span class="label-text">or use local media file</span>
@@ -376,7 +376,7 @@ class ImportVtt extends HTMLElement {
     <div class="modal">
     <div class="modal-box">
       <div class="flex flex-col gap-4 w-full">
-        <label id="close-modal" for="file-import-vtt-dialog" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+        <label for="file-import-vtt-dialog" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
         <h3 class="font-bold text-lg">Import VTT Dialog</h3>
         <input id="vtt-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
         <span class="label-text">or use local media file</span>


### PR DESCRIPTION
Fixes #379.

### Duplicate ids removed
- **`regenerate-btn`** — the caption editor's injected floating label is renamed to **`regenerate-float-btn`**; the two #375 CSS rules written for it (z-index; mobile position below the pinned player) are repointed; the captions-modal button keeps `regenerate-btn` and `editor-main.js`'s enable-call now targets it unambiguously. The injected copy's decorative duplicate `regenerate-icon` id is dropped too.
- **`close-modal`** — duplicated across **eight** modal ✕ labels (five in `index.html`, three injected by `hyperaudio-lite-editor-export.js`) and never referenced as a selector: removed from all (labels work via `for=`, styling via classes).

### New regression guard
`__TEST__/e2e/dom-hygiene.spec.mjs` asserts **element ids are unique** on load and in caption mode, and that the two regenerate controls are distinct, fixed/z-indexed and clickable. It flagged the `close-modal` duplicates the moment it first ran — the second one was found *by* the guard, not by reading code.

Suite: **15/15 passing**. No behaviour change intended; bumps app version to **0.7.6**.
