### PR TITLE
Word-level VTT, caption burn-in, and export enhancements (#387)

### DIFF
--- a/__TEST__/unit/word-vtt.test.mjs
+++ b/__TEST__/unit/word-vtt.test.mjs
@@ -1,0 +1,76 @@
+// Unit tests for the word-level ("karaoke") VTT export (#387 part 1).
+// Exercises the pure logic — timestamp formatting, chunk boundaries, duration
+// backfill, speaker skipping, and the assembled VTT — without a browser DOM
+// (generateWordVtt accepts a transcript root via options.source).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { generateWordVtt, formatTimestamp, readWords, chunkWords } = require('../../js/word-vtt.js');
+
+// Build a mock transcript root: spans carry data-m/data-d in ms; a `speaker`
+// flag marks a label span (which must be excluded from the word list).
+function mockRoot(spans) {
+  return {
+    querySelectorAll: () => spans.map((s) => ({
+      getAttribute: (n) => (n === 'data-m' ? String(s.m) : String(s.d)),
+      classList: { contains: (c) => c === 'speaker' && !!s.speaker },
+      textContent: s.t,
+    })),
+  };
+}
+
+test('formatTimestamp: HH:MM:SS.mmm, clamps negatives to zero', () => {
+  assert.equal(formatTimestamp(2.65), '00:00:02.650');
+  assert.equal(formatTimestamp(3661.5), '01:01:01.500');
+  assert.equal(formatTimestamp(-1), '00:00:00.000');
+});
+
+test('chunkWords: splits on maxWords and on a pause > maxGap', () => {
+  const words = [
+    { start: 0, end: 0.3 }, { start: 0.35, end: 0.6 }, // close pair
+    { start: 2, end: 2.3 },                            // 1.4s gap -> new chunk
+  ];
+  const chunks = chunkWords(words, 5, 0.8);
+  assert.equal(chunks.length, 2);
+  assert.equal(chunks[0].length, 2);
+
+  const six = Array.from({ length: 6 }, (_, i) => ({ start: i * 0.1, end: i * 0.1 + 0.05 }));
+  const byCount = chunkWords(six, 5, 0.8);       // no gaps -> split purely by count
+  assert.deepEqual(byCount.map((c) => c.length), [5, 1]);
+});
+
+test('readWords: skips speaker labels and backfills zero durations', () => {
+  const root = mockRoot([
+    { m: 0, d: 0, t: 'SPEAKER 1', speaker: true }, // excluded
+    { m: 1000, d: 0, t: 'hello' },                 // zero dur -> filled from next start
+    { m: 1600, d: 400, t: 'world' },
+  ]);
+  const words = readWords(root);
+  assert.equal(words.length, 2);
+  assert.equal(words[0].text, 'hello');
+  assert.equal(words[0].end, 1.6);   // backfilled to next word's start
+  assert.equal(words[1].end, 2.0);   // 1.6 + 0.4
+});
+
+test('readWords: trailing zero-duration word gets a 0.4s fallback span', () => {
+  const words = readWords(mockRoot([{ m: 5000, d: 0, t: 'end' }]));
+  assert.equal(words[0].start, 5.0);
+  assert.equal(words[0].end, 5.4);
+});
+
+test('generateWordVtt: header, cue timing, inline per-word timestamps', () => {
+  const root = mockRoot([
+    { m: 1200, d: 300, t: 'So' }, { m: 1550, d: 300, t: 'if' },
+    { m: 9000, d: 400, t: 'Yeah.' },   // >0.8s gap -> second cue
+  ]);
+  const vtt = generateWordVtt({ source: root, maxWords: 5, maxGap: 0.8 });
+  assert.match(vtt, /^WEBVTT\n/);
+  assert.match(vtt, /\n00:00:01\.200 --> 00:00:01\.850\n<00:00:01\.200>So <00:00:01\.550>if\n/);
+  assert.match(vtt, /\n00:00:09\.000 --> 00:00:09\.400\n<00:00:09\.000>Yeah\.\n/);
+});
+
+test('generateWordVtt: no words yields just the header', () => {
+  assert.equal(generateWordVtt({ source: mockRoot([]) }), 'WEBVTT\n');
+});

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -754,6 +754,17 @@ body.find-replace-open .hyperaudio-transcript { padding-top: 108px; }
   color: oklch(var(--p));
 }
 
+/* Switches inside modals (export options, skip-gaps) — same build gap as the
+   player toggles: tint them primary when on, drop the global input margin, and
+   keep them from shrinking when the label text wraps. */
+.modal-box .toggle {
+  margin-bottom: 0;
+  flex-shrink: 0;
+}
+.modal-box .toggle:checked {
+  color: oklch(var(--p));
+}
+
 /* Buttons pick up an 8px margin-bottom from the global input/button rule,
    which nudges them off-centre in flex rows — neutralise in the bars. */
 .navbar .btn,

--- a/hyperaudio-template.html
+++ b/hyperaudio-template.html
@@ -2,27 +2,85 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Hyperaudio – Interactive Transcript</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hyperaudio – Interactive Transcript</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/css/hyperaudio-lite-player.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/css/share-this.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>
   <script src="https://platform.twitter.com/widgets.js"></script>
+  <style>
+    body {
+      margin: 0;
+      background: #f7f7f8;
+      color: #1a1a1a;
+    }
+    /* Constrain everything to a comfortable reading column and centre it. */
+    .ht-wrap {
+      max-width: 40rem;
+      margin: 0 auto;
+      padding: 28px 18px 56px;
+    }
+    /* A modest, centred player rather than a full-width one. */
+    #hyperplayer {
+      width: 100%;
+      max-width: 420px;
+      display: block;
+      margin: 0 auto 24px;
+      border-radius: 10px;
+      background: #000;
+      box-shadow: 0 4px 18px rgba(0, 0, 0, 0.14);
+    }
+    /* The transcript stays a scroll box (the read-along autoscroll scrolls
+       within it), but with a constrained line length and calmer styling.
+       ID selector overrides the player CSS's .hyperaudio-transcript rules. */
+    #hypertranscript {
+      max-width: 34rem;
+      margin: 0 auto;
+      height: 58vh;
+      min-height: 320px;
+      overflow-y: auto;
+      border: 1px solid #e6e6e6;
+      border-radius: 12px;
+      background: #fff;
+      padding: 20px 24px;
+      font-size: 1.06rem;
+      line-height: 1.75;
+    }
+    /* Read-along contrast: spoken text solid, upcoming text muted. */
+    .hyperaudio-transcript .read,
+    .hyperaudio-transcript .active > .active { color: #111; }
+    .hyperaudio-transcript .unread { color: #a2a2a2; }
+    .hyperaudio-transcript .speaker { font-weight: 700; }
+    /* Playback-speed control, kept subtle under the transcript. */
+    .ht-controls {
+      max-width: 34rem;
+      margin: 16px auto 0;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 0.85rem;
+      color: #666;
+    }
+    .ht-controls input[type="range"] { flex: 0 0 130px; }
+  </style>
 </head>
 <body>
-  <video id="hyperplayer" class="hyperaudio-player" style="z-index: 5000000; position:relative; width:100%" src="{sourcemedia}" type="video/mp4" controls>
-    <track id="hyperplayer-vtt" label="English" kind="subtitles" srclang="en" src="{sourcevtt}">
-  </video>
+  <main class="ht-wrap">
+    <video id="hyperplayer" class="hyperaudio-player" playsinline controls src="{sourcemedia}" type="video/mp4">
+      <track id="hyperplayer-vtt" label="English" kind="subtitles" srclang="en" src="{sourcevtt}">
+    </video>
 
-  <div id="hypertranscript" class="hyperaudio-transcript" style="overflow-y:scroll; height:600px; position:relative; border-style:dashed; border-width: 1px; border-color:#999; padding: 8px">
+    <div id="hypertranscript" class="hyperaudio-transcript">
 {hypertranscript}
-  </div>
-  
-  <p>
-    <form id="searchForm" style="float:right">
-      Playback Rate <span id="currentPbr">1</span><input id="pbr" type="range" value="1" min="0.5" max="3" step="0.1" style="width:50px">
-    </form>
-  </p>
-  
+    </div>
+
+    <div class="ht-controls">
+      <label for="pbr">Speed</label>
+      <input id="pbr" type="range" value="1" min="0.5" max="3" step="0.1">
+      <span id="currentPbr">1</span>×
+    </div>
+  </main>
+
   <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/hyperaudio-lite.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/hyperaudio-lite-extension.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/share-this.js"></script>
@@ -42,6 +100,19 @@
   let playOnClick = true;
 
   new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick);
+
+  // Wire the playback-speed slider to the player.
+  (function () {
+    var pbr = document.getElementById("pbr");
+    var player = document.getElementById("hyperplayer");
+    var out = document.getElementById("currentPbr");
+    if (pbr && player) {
+      pbr.addEventListener("input", function () {
+        player.playbackRate = parseFloat(pbr.value);
+        if (out) { out.textContent = pbr.value; }
+      });
+    }
+  })();
 
   </script>
 </body>

--- a/hyperaudio-template.html
+++ b/hyperaudio-template.html
@@ -51,17 +51,6 @@
     .hyperaudio-transcript .active > .active { color: #111; }
     .hyperaudio-transcript .unread { color: #a2a2a2; }
     .hyperaudio-transcript .speaker { font-weight: 700; }
-    /* Playback-speed control, kept subtle under the transcript. */
-    .ht-controls {
-      max-width: 34rem;
-      margin: 16px auto 0;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      font-size: 0.85rem;
-      color: #666;
-    }
-    .ht-controls input[type="range"] { flex: 0 0 130px; }
   </style>
 </head>
 <body>
@@ -72,12 +61,6 @@
 
     <div id="hypertranscript" class="hyperaudio-transcript">
 {hypertranscript}
-    </div>
-
-    <div class="ht-controls">
-      <label for="pbr">Speed</label>
-      <input id="pbr" type="range" value="1" min="0.5" max="3" step="0.1">
-      <span id="currentPbr">1</span>×
     </div>
   </main>
 
@@ -100,19 +83,6 @@
   let playOnClick = true;
 
   new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick);
-
-  // Wire the playback-speed slider to the player.
-  (function () {
-    var pbr = document.getElementById("pbr");
-    var player = document.getElementById("hyperplayer");
-    var out = document.getElementById("currentPbr");
-    if (pbr && player) {
-      pbr.addEventListener("input", function () {
-        player.playbackRate = parseFloat(pbr.value);
-        if (out) { out.textContent = pbr.value; }
-      });
-    }
-  })();
 
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -684,13 +684,27 @@ If you are creating an open source application under a license compatible with t
       </div>
       <label class="label-text" for="export-format">Format</label>
       <select id="export-format" class="select select-bordered w-full" style="margin-top:4px"></select>
+      <label id="export-adjust-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
+        <input type="checkbox" id="export-adjust" class="toggle toggle-primary" />
+        <span class="label-text">Adjust speed / length (pitch preserved)</span>
+      </label>
+      <div id="export-adjust-panel" style="display:none; margin-top:10px; padding-left:2px">
+        <div style="display:flex; gap:10px; align-items:center; flex-wrap:wrap">
+          <span class="label-text" style="min-width:48px">Speed</span>
+          <input id="export-speed-slider" type="range" min="0.25" max="4" step="0.05" value="1" class="range range-xs range-primary" style="flex:1; min-width:110px" aria-label="Export speed" />
+          <input id="export-speed" type="number" min="0.25" max="4" step="0.05" value="1" class="input input-bordered input-sm" style="width:92px" aria-label="Export speed factor" />
+          <span class="label-text">×</span>
+        </div>
+        <div style="display:flex; gap:10px; align-items:center; margin-top:8px">
+          <span class="label-text" style="min-width:48px">Length</span>
+          <input id="export-length" type="text" inputmode="numeric" placeholder="m:ss" class="input input-bordered input-sm" style="width:92px" aria-label="Export length" />
+          <span id="export-length-orig" class="label-text" style="opacity:0.6"></span>
+        </div>
+        <div id="export-adjust-readout" style="font-size:85%; opacity:0.8; margin-top:8px"></div>
+      </div>
       <label id="export-burn-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
         <input type="checkbox" id="export-burn" class="toggle toggle-primary" />
         <span class="label-text">Burn captions into the video (word-level highlight)</span>
-      </label>
-      <label id="export-rate-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
-        <input type="checkbox" id="export-rate" class="toggle toggle-primary" />
-        <span class="label-text">Apply the playback speed (<span id="export-rate-value">1×</span>) — pitch preserved</span>
       </label>
       <label id="export-retime-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
         <input type="checkbox" id="export-retime" class="toggle toggle-primary" />

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.7.6 (last changed in release 0.7.6) -->
+<!--  Hyperaudio Lite Editor - Version 0.7.7 (last changed in release 0.7.7) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.7.6">
+  <meta name="version" content="0.7.7">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">

--- a/index.html
+++ b/index.html
@@ -684,6 +684,9 @@ If you are creating an open source application under a license compatible with t
       </div>
       <label class="label-text" for="export-format">Format</label>
       <select id="export-format" class="select select-bordered w-full" style="margin-top:4px"></select>
+      <label class="label-text" for="export-name" style="display:block; margin-top:14px">Save as</label>
+      <input id="export-name" type="text" class="input input-bordered w-full" style="margin-top:4px" placeholder="file name (no extension)" />
+      <div style="font-size:82%; opacity:0.7; margin-top:6px">All exported files use this name. The interactive transcript links the video by it — keep the downloads together in one folder.</div>
       <label id="export-adjust-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
         <input type="checkbox" id="export-adjust" class="toggle toggle-primary" />
         <span class="label-text">Adjust speed / length (pitch preserved)</span>

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@ If you are creating an open source application under a license compatible with t
     }
     
   </style>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.7.6">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.7.7">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -350,9 +350,10 @@ If you are creating an open source application under a license compatible with t
                 </span>
               </li>
               <li><a id="download-vtt" href="" download="hyperaudio.vtt">WebVTT (Captions)</a></li>
+              <li><a id="download-vtt-words" href="" download="hyperaudio.words.vtt">WebVTT (Word-level / Karaoke)</a></li>
               <li><a id="download-srt" href="" download="hyperaudio.srt">SRT (Captions)</a></li>
               <li><a id="download-html" href="" download="hypertranscript.html">HTML</a></li>
-              <li><a id="download-hypertranscript" href="" download="hyperaudio.html">Interactive Transcript</a></li>
+              <li><label id="download-hypertranscript" for="interactive-export-modal">Interactive Transcript</label></li>
               <li><label for="export-modal">Media (WAV / MP3 / MP4…)</label></li>
               <hr
               class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-25 dark:border-neutral-200" />
@@ -429,6 +430,9 @@ If you are creating an open source application under a license compatible with t
               <!--<caption-service></caption-service>-->
             </div>
           </div>
+          <label id="export-media-btn" for="export-modal" class="btn btn-square btn-primary tooltip" data-tip="Export media" style="margin-right:4px" aria-label="Export media">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-download"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+          </label>
           <label for="transcribe-modal" class="btn btn-primary gap-2">
             <span id="transcribe-label">NEW</span>
             <span id="transcribe-label-mobile">NEW</span>
@@ -680,18 +684,46 @@ If you are creating an open source application under a license compatible with t
       </div>
       <label class="label-text" for="export-format">Format</label>
       <select id="export-format" class="select select-bordered w-full" style="margin-top:4px"></select>
+      <label id="export-burn-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
+        <input type="checkbox" id="export-burn" class="toggle toggle-primary" />
+        <span class="label-text">Burn captions into the video (word-level highlight)</span>
+      </label>
       <label id="export-rate-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
-        <input type="checkbox" id="export-rate" class="checkbox checkbox-primary checkbox-sm" />
+        <input type="checkbox" id="export-rate" class="toggle toggle-primary" />
         <span class="label-text">Apply the playback speed (<span id="export-rate-value">1×</span>) — pitch preserved</span>
       </label>
       <label id="export-retime-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
-        <input type="checkbox" id="export-retime" class="checkbox checkbox-primary checkbox-sm" checked />
-        <span class="label-text">Also download the transcript re-timed to the exported media</span>
+        <input type="checkbox" id="export-retime" class="toggle toggle-primary" />
+        <span class="label-text">Download an interactive transcript (re-timed, links the exported media)</span>
+      </label>
+      <label id="export-vtt-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
+        <input type="checkbox" id="export-vtt" class="toggle toggle-primary" />
+        <span class="label-text">Download WebVTT (.vtt) captions</span>
+      </label>
+      <label id="export-srt-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
+        <input type="checkbox" id="export-srt" class="toggle toggle-primary" />
+        <span class="label-text">Download SRT (.srt) captions</span>
       </label>
       <progress id="export-progress" class="progress progress-primary w-full" value="0" max="100" style="visibility:hidden; margin-top:14px"></progress>
       <div id="export-status" aria-live="polite" style="font-size:85%; opacity:0.75; min-height:1.3em; margin-top:2px"></div>
       <div class="modal-action">
         <button id="export-start" class="btn btn-primary">EXPORT</button>
+      </div>
+    </div>
+  </div>
+
+  <input type="checkbox" id="interactive-export-modal" class="modal-toggle" />
+  <div class="modal">
+    <div class="modal-box" style="max-width:26rem">
+      <label for="interactive-export-modal" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+      <h3 class="font-bold text-lg" style="margin-bottom:12px">Export interactive transcript</h3>
+      <label class="label-text" for="interactive-media-filename">Media file or URL</label>
+      <input id="interactive-media-filename" type="text" class="input input-bordered w-full" placeholder="e.g. my-video.mp4" style="margin-top:4px" />
+      <div style="font-size:85%; opacity:0.75; margin-top:8px">
+        The page links to your media by this path and loads the Hyperaudio Lite player so words stay clickable. For a local file, save the downloaded HTML in the same folder as the media file so it can be found.
+      </div>
+      <div class="modal-action">
+        <button id="interactive-export-download" class="btn btn-primary">Download</button>
       </div>
     </div>
   </div>
@@ -816,7 +848,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite.js?v=2.6.2"></script>
   <script src="js/hyperaudio-lite-extension.js?v=0.7.2"></script>
   <script src="js/caption.js?v=0.7.1"></script>
-  <script src="js/editor-core.js?v=0.7.3"></script>
+  <script src="js/editor-core.js?v=0.7.7"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -895,9 +927,11 @@ If you are creating an open source application under a license compatible with t
     }
 
   </style>
-  <script src="js/editor-main.js?v=0.7.6"></script>
+  <script src="js/editor-main.js?v=0.7.7"></script>
   <script src="js/find-replace.js?v=0.6.29"></script>
-  <script src="js/media-export.js?v=0.7.5"></script>
+  <script src="js/media-export.js?v=0.7.7"></script>
+  <!-- word-level / karaoke VTT export (#387 part 1) -->
+  <script src="js/word-vtt.js?v=0.7.7"></script>
   <!-- end of caption editor additions -->
 
   <!-- responsive small-screen UI toggles (#349) -->

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -75,8 +75,6 @@
 
   window.document.addEventListener('hyperaudioInit', hyperaudio, false);
   window.document.addEventListener('hyperaudioGenerateCaptionsFromTranscript', hyperaudioGenerateCaptionsFromTranscript, false);
-  window.document.addEventListener('hyperaudioTranscriptLoaded', updateInteractiveTranscriptDownloadLink, false);
-
   let hyperaudioTemplate = "";
 
   fetch('hyperaudio-template.html')
@@ -90,6 +88,55 @@
   .catch(function(err) {
       console.log('Failed to fetch page: ', err);
   });
+
+  // Interactive-transcript export dialog. The exported page links the media by a
+  // RELATIVE path (or its URL), never the session-only blob: URL — so, saved
+  // next to the media file, it plays and stays interactive (the template already
+  // loads the hyperaudio-lite lib from CDN and boots it). The user confirms the
+  // media reference because a freshly-uploaded file's real name isn't retained.
+  {
+    const iaModal = document.getElementById('interactive-export-modal');
+    const iaInput = document.getElementById('interactive-media-filename');
+    const iaDownload = document.getElementById('interactive-export-download');
+
+    // Remote media can be linked by its URL as-is; a blob:/data: source (local
+    // upload or Recents) has no usable path, so the field starts empty for the
+    // user to type the local filename.
+    const guessMediaSrc = () => {
+      const src = document.querySelector('#hyperplayer') ? document.querySelector('#hyperplayer').src : '';
+      return /^https?:/i.test(src) ? src : '';
+    };
+
+    if (iaModal !== null && iaInput !== null) {
+      iaModal.addEventListener('change', () => {
+        if (iaModal.checked && iaInput.value.trim() === '') {
+          iaInput.value = guessMediaSrc();
+        }
+      });
+    }
+
+    if (iaDownload !== null && iaInput !== null) {
+      iaDownload.addEventListener('click', () => {
+        const mediaSrc = iaInput.value.trim();
+        if (mediaSrc === '') { iaInput.focus(); return; }
+        const track = document.querySelector('#hyperplayer-vtt');
+        // function replacements so a literal $ in the transcript/filename isn't
+        // treated as a replacement pattern
+        const html = hyperaudioTemplate
+          .replace('{hypertranscript}', () => getTranscriptData())
+          .replace('{sourcemedia}', () => mediaSrc)
+          .replace('{sourcevtt}', () => (track !== null ? track.src : ''));
+        const blob = new Blob([html], { type: 'text/html' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'interactive-transcript.html';
+        a.click();
+        setTimeout(() => URL.revokeObjectURL(url), 0);
+        if (iaModal !== null) iaModal.checked = false;
+      });
+    }
+  }
 
   /* ----------------------------------------------------------- */
 
@@ -396,7 +443,6 @@
 
         let hypertranscript = rootnode.innerHTML.replace(/ class=".*?"/g, '');
         document.querySelector('#download-html').setAttribute('href', 'data:text/html,'+encodeURIComponent(hypertranscript));
-        updateInteractiveTranscriptDownloadLink();
 
         if (isTranscriptFocused === true && updateCaptionsFromTranscript === true) {
           const words = document.querySelectorAll("[data-m]");
@@ -548,19 +594,6 @@
     //track.srclang = "en";
     track.src = "data:text/vtt,"+encodeURIComponent(subs.vtt);
 
-    document
-      .querySelector("#download-hypertranscript")
-      .setAttribute(
-        "href",
-        "data:text/html," +
-          encodeURIComponent(
-            hyperaudioTemplate
-              .replace("{hypertranscript}", hypertranscript)
-              .replace("{sourcemedia}", sourceMedia)
-              .replace("{sourcevtt}", track.src)
-          )
-      );
-
     // check to see if it's an mp3 or m4a, in which case we don't display captions
     let extension = document.querySelector('#hyperplayer').src.split('.').pop();
     if (extension === "mp3" || extension === "m4a") {
@@ -569,27 +602,6 @@
       document.querySelector('#hyperplayer').textTracks[0].mode = "showing";
     }
     return subs.data;
-  }
-
-  function updateInteractiveTranscriptDownloadLink() {
-
-    // m4a ?
-    //let isAudio = document.querySelector('#hyperplayer').src.split('.').pop() === "mp3";
-
-    document
-    .querySelector("#download-hypertranscript")
-    .setAttribute(
-      "href",
-      "data:text/html," +
-        encodeURIComponent(
-          hyperaudioTemplate
-            .replace("{hypertranscript}", getTranscriptData())
-            // check to see if it's an mp3, in which case we don't display captions
-            .replace("{sourcemedia}", document.querySelector("#hyperplayer").src) 
-            .replace("{sourcevtt}", document.querySelector("#hyperplayer-vtt").src)
-            //.replace("{sourcevtt}", isAudio ? "" : document.querySelector("#hyperplayer-vtt").src)
-        )
-    );
   }
 
   function hasParent(element, parent) {

--- a/js/editor-main.js
+++ b/js/editor-main.js
@@ -445,19 +445,6 @@
       let track = document.querySelector('#hyperplayer-vtt');
       track.src = "data:text/vtt,"+encodeURIComponent(vttCaptions);
 
-      document
-      .querySelector("#download-hypertranscript")
-      .setAttribute(
-        "href",
-        "data:text/html," +
-          encodeURIComponent(
-            hyperaudioTemplate
-              .replace("{hypertranscript}", getTranscriptData())
-              .replace("{sourcemedia}", document.querySelector("#hyperplayer").src)
-              .replace("{sourcevtt}", track.src)
-          )
-      );
-
       document.querySelector('#download-vtt').setAttribute('href', "data:text/vtt,"+encodeURIComponent(vttCaptions));
       document.querySelector('#download-srt').setAttribute('href', "data:text/srt,"+encodeURIComponent(srtCaptions));
     }

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -570,6 +570,7 @@
 
   const modalToggle = document.getElementById('export-modal');
   const formatSelect = document.getElementById('export-format');
+  const nameInput = document.getElementById('export-name');
   const sourceEntire = document.getElementById('export-source-entire');
   const sourceEdited = document.getElementById('export-source-edited');
   const editSummary = document.getElementById('export-edit-summary');
@@ -755,6 +756,9 @@
       sourceEntire.checked = true;
     }
 
+    // default the export name to the project/media base name
+    if (nameInput !== null) nameInput.value = exportBaseName();
+
     // restore the user's last export-option choices (default: all off)
     const opts = loadExportOpts();
     burnCheck.checked = opts.burn === true;
@@ -833,8 +837,10 @@
       const wantRetime = retimeCheck.checked && retimeRow.style.display !== 'none';
       const wantVtt = vttCheck !== null && vttCheck.checked && vttRow.style.display !== 'none';
       const wantSrt = srtCheck !== null && srtCheck.checked && srtRow.style.display !== 'none';
-      const baseName = exportBaseName();
-      const suffix = `${edited ? '-edited' : ''}${rate !== 1 ? `-${rateLabel}x` : ''}${burn ? '-captioned' : ''}`;
+      // user-chosen export name (verbatim, so the media file and the transcript's
+      // <video src> always agree); light sanitise for filename safety
+      const rawName = nameInput !== null ? nameInput.value.trim() : '';
+      const baseName = (rawName || exportBaseName() || 'export').replace(/[\/\\:*?"<>|]+/g, '_');
 
       const player = document.getElementById('hyperplayer');
       const duration = player && !isNaN(player.duration) ? player.duration : Infinity;
@@ -855,14 +861,14 @@
           ? await exportEditedVideo(mb, fmt, sections, rate, setProgress, captions)
           : await exportEditedAudio(mb, fmt, sections, rate, setProgress);
       }
-      const mediaName = straightCopy ? `${baseName}.${fmt.ext}` : `${baseName}${suffix}.${fmt.ext}`;
+      const mediaName = `${baseName}.${fmt.ext}`;
       const outputs = [{ blob, name: mediaName }];
 
       // 2. caption sidecars + interactive transcript, all re-timed to the export
       if (wantRetime || wantVtt || wantSrt) {
         const subs = genRetimedCaptions(sections, rate);
-        const vttName = `${baseName}${suffix}.vtt`;
-        const srtName = `${baseName}${suffix}.srt`;
+        const vttName = `${baseName}.vtt`;
+        const srtName = `${baseName}.srt`;
         if (wantVtt && subs && subs.vtt) {
           outputs.push({ blob: new Blob([subs.vtt], { type: 'text/vtt' }), name: vttName });
         }
@@ -881,7 +887,7 @@
           }
           const html = buildInteractiveExportHtml(sections, rate, encodeURI(mediaName), trackSrc);
           if (html !== null) {
-            outputs.push({ blob: new Blob([html], { type: 'text/html' }), name: `${baseName}${suffix}-transcript.html` });
+            outputs.push({ blob: new Blob([html], { type: 'text/html' }), name: `${baseName}-transcript.html` });
           }
         }
       }

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -573,9 +573,14 @@
   const sourceEntire = document.getElementById('export-source-entire');
   const sourceEdited = document.getElementById('export-source-edited');
   const editSummary = document.getElementById('export-edit-summary');
-  const rateRow = document.getElementById('export-rate-row');
-  const rateCheck = document.getElementById('export-rate');
-  const rateValue = document.getElementById('export-rate-value');
+  const adjustRow = document.getElementById('export-adjust-row');
+  const adjustCheck = document.getElementById('export-adjust');
+  const adjustPanel = document.getElementById('export-adjust-panel');
+  const speedInput = document.getElementById('export-speed');
+  const speedSlider = document.getElementById('export-speed-slider');
+  const lengthInput = document.getElementById('export-length');
+  const lengthOrigEl = document.getElementById('export-length-orig');
+  const adjustReadout = document.getElementById('export-adjust-readout');
   const retimeRow = document.getElementById('export-retime-row');
   const retimeCheck = document.getElementById('export-retime');
   const vttRow = document.getElementById('export-vtt-row');
@@ -609,8 +614,79 @@
     return r > 0 ? r : 1;
   };
 
-  const rateApplied = () =>
-    rateRow.style.display !== 'none' && rateCheck.checked && playbackRate() !== 1;
+  // --- speed / length ("stretch to fit") ------------------------------------
+  const RATE_MIN = 0.25, RATE_MAX = 4;
+  const clampRate = (r) => (r > 0 ? Math.min(RATE_MAX, Math.max(RATE_MIN, r)) : 1);
+  const adjustApplied = () =>
+    adjustRow !== null && adjustRow.style.display !== 'none' && adjustCheck.checked;
+  const exportRate = () => (adjustApplied() ? clampRate(parseFloat(speedInput.value)) : 1);
+
+  // The EDITED content length (seconds) is what speed and target-length trade
+  // against, so it tracks the Entire/Edited choice.
+  const currentContentLength = () => {
+    const player = document.getElementById('hyperplayer');
+    const dur = player && !isNaN(player.duration) ? player.duration : 0;
+    if (!dur) return 0;
+    const edited = sourceEdited.checked && !sourceEdited.disabled;
+    return keptDuration(edited ? editedSections(dur) : [{ start: 0, end: dur }]);
+  };
+
+  const fmtLen = (s) => {
+    s = Math.max(0, Math.round(s));
+    return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+  };
+  const parseLen = (str) => {
+    const t = String(str).trim();
+    if (t === '') return NaN;
+    if (t.includes(':')) {
+      const [m, s] = t.split(':');
+      const mm = parseInt(m, 10), ss = parseInt(s, 10);
+      return (isNaN(mm) || isNaN(ss)) ? NaN : mm * 60 + ss;
+    }
+    const n = parseFloat(t);
+    return isNaN(n) ? NaN : n;
+  };
+
+  const updateAdjustReadout = () => {
+    if (adjustReadout === null) return;
+    const rate = clampRate(parseFloat(speedInput.value));
+    const len = currentContentLength() / rate;
+    const warn = (rate < 0.5 || rate > 2) ? '  ⚠ noticeable quality loss' : '';
+    adjustReadout.textContent = `→ ${fmtLen(len)} at ${+rate.toFixed(2)}×, pitch preserved${warn}`;
+  };
+  // Speed is the source of truth; mirror it to the slider and derive the length.
+  const syncFromSpeed = () => {
+    const rate = clampRate(parseFloat(speedInput.value));
+    speedInput.value = String(+rate.toFixed(2));
+    if (speedSlider !== null) speedSlider.value = String(rate);
+    if (lengthInput !== null) lengthInput.value = fmtLen(currentContentLength() / rate);
+    updateAdjustReadout();
+  };
+  const syncFromSlider = () => {
+    speedInput.value = String(+parseFloat(speedSlider.value).toFixed(2));
+    syncFromSpeed();
+  };
+  const syncFromLength = () => {
+    const target = parseLen(lengthInput.value);
+    const content = currentContentLength();
+    if (target > 0 && content > 0) {
+      speedInput.value = String(+clampRate(content / target).toFixed(2));
+    }
+    syncFromSpeed();   // reformat length to the (possibly clamped) rate
+  };
+  const updateAdjustVisibility = () => {
+    if (adjustPanel === null || adjustCheck === null || adjustRow === null) return;
+    adjustPanel.style.display =
+      (adjustCheck.checked && adjustRow.style.display !== 'none') ? 'block' : 'none';
+  };
+  // Content length changed (Entire vs Edited) — refresh the "was m:ss" hint and
+  // re-derive the length from the current speed.
+  const refreshAdjustForContent = () => {
+    if (adjustRow === null) return;
+    const orig = currentContentLength();
+    if (lengthOrigEl !== null) lengthOrigEl.textContent = orig > 0 ? `(was ${fmtLen(orig)})` : '';
+    if (adjustCheck.checked) syncFromSpeed();
+  };
 
   // The re-timed transcript makes sense whenever the exported media's timeline
   // differs from the original: edits, an applied playback speed, or both.
@@ -650,7 +726,8 @@
     try {
       window.localStorage.setItem(EXPORT_OPTS_KEY, JSON.stringify({
         burn: burnCheck.checked,
-        rate: rateCheck.checked,
+        adjust: adjustCheck !== null && adjustCheck.checked,
+        speed: adjustCheck !== null ? clampRate(parseFloat(speedInput.value)) : 1,
         retime: retimeCheck.checked,
         vtt: vttCheck !== null && vttCheck.checked,
         srt: srtCheck !== null && srtCheck.checked,
@@ -685,15 +762,17 @@
     if (vttCheck !== null) vttCheck.checked = opts.vtt === true;
     if (srtCheck !== null) srtCheck.checked = opts.srt === true;
 
-    // offer the playback-speed option when the player isn't at 1×
-    const rate = playbackRate();
-    if (rate !== 1) {
-      rateValue.textContent = `${rate}×`;
-      rateRow.style.display = 'flex';
-      rateCheck.checked = opts.rate === true;
-    } else {
-      rateRow.style.display = 'none';
-      rateCheck.checked = false;
+    // speed / length: offer it whenever there's media; restore the toggle and
+    // the last speed, defaulting to the player's current rate so a playback
+    // speed set in the editor still carries into the export.
+    if (adjustRow !== null) {
+      adjustRow.style.display = currentContentLength() > 0 ? 'flex' : 'none';
+      adjustCheck.checked = opts.adjust === true;
+      const startSpeed = clampRate(typeof opts.speed === 'number' ? opts.speed : playbackRate());
+      speedInput.value = String(+startSpeed.toFixed(2));
+      refreshAdjustForContent();
+      syncFromSpeed();
+      updateAdjustVisibility();
     }
     updateRetimeVisibility();
 
@@ -747,14 +826,15 @@
       if (fmt.needsMp3) await ensureMp3Encoder(mb);
 
       const edited = sourceEdited.checked && !sourceEdited.disabled;
-      const rate = rateApplied() ? playbackRate() : 1;
+      const rate = exportRate();
+      const rateLabel = +rate.toFixed(2);
       const burn = fmt.kind === 'video' && burnRow !== null &&
         burnRow.style.display !== 'none' && burnCheck.checked;
       const wantRetime = retimeCheck.checked && retimeRow.style.display !== 'none';
       const wantVtt = vttCheck !== null && vttCheck.checked && vttRow.style.display !== 'none';
       const wantSrt = srtCheck !== null && srtCheck.checked && srtRow.style.display !== 'none';
       const baseName = exportBaseName();
-      const suffix = `${edited ? '-edited' : ''}${rate !== 1 ? `-${rate}x` : ''}${burn ? '-captioned' : ''}`;
+      const suffix = `${edited ? '-edited' : ''}${rate !== 1 ? `-${rateLabel}x` : ''}${burn ? '-captioned' : ''}`;
 
       const player = document.getElementById('hyperplayer');
       const duration = player && !isNaN(player.duration) ? player.duration : Infinity;
@@ -770,7 +850,7 @@
         blob = await exportEntire(mb, fmt, setProgress);
       } else {
         const captions = burn ? buildCaptionChunks(sections, rate) : null;
-        setStatus(burn ? 'Exporting with captions…' : (rate !== 1 ? `Exporting at ${rate}× — pitch preserved…` : 'Exporting edited media…'));
+        setStatus(burn ? 'Exporting with captions…' : (rate !== 1 ? `Exporting at ${rateLabel}× — pitch preserved…` : 'Exporting edited media…'));
         blob = fmt.kind === 'video'
           ? await exportEditedVideo(mb, fmt, sections, rate, setProgress, captions)
           : await exportEditedAudio(mb, fmt, sections, rate, setProgress);
@@ -826,11 +906,20 @@
   };
 
   modalToggle.addEventListener('change', () => { if (modalToggle.checked) populateModal(); });
-  sourceEntire.addEventListener('change', updateRetimeVisibility);
-  sourceEdited.addEventListener('change', updateRetimeVisibility);
-  rateCheck.addEventListener('change', updateRetimeVisibility);
+  sourceEntire.addEventListener('change', () => { updateRetimeVisibility(); refreshAdjustForContent(); });
+  sourceEdited.addEventListener('change', () => { updateRetimeVisibility(); refreshAdjustForContent(); });
   formatSelect.addEventListener('change', updateBurnVisibility);
-  [burnCheck, rateCheck, retimeCheck, vttCheck, srtCheck].forEach((el) => {
+  if (adjustCheck !== null) {
+    adjustCheck.addEventListener('change', () => {
+      updateAdjustVisibility();
+      if (adjustCheck.checked) syncFromSpeed();
+      saveExportOpts();
+    });
+    speedInput.addEventListener('input', () => { syncFromSpeed(); saveExportOpts(); });
+    if (speedSlider !== null) speedSlider.addEventListener('input', () => { syncFromSlider(); saveExportOpts(); });
+    lengthInput.addEventListener('change', () => { syncFromLength(); saveExportOpts(); });
+  }
+  [burnCheck, retimeCheck, vttCheck, srtCheck].forEach((el) => {
     if (el !== null) el.addEventListener('change', saveExportOpts);
   });
   startBtn.addEventListener('click', runExport);

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -1,7 +1,7 @@
 /**
  * media-export.js
  * (C) The Hyperaudio Project
- * @version 0.7.5 — last changed in release 0.7.5
+ * @version 0.7.7 — last changed in release 0.7.7
  * @license MIT
  *
  * Media export via mediabunny (#289, #291, #292): export the loaded media as
@@ -22,6 +22,11 @@
  * media: struck words are dropped and each word's data-m is mapped through the
  * kept sections' cumulative offsets, so the transcript stays in sync with the
  * exported file.
+ *
+ * A video export can optionally BURN word-level captions into the frames (#387):
+ * the same re-timed word data is grouped into short karaoke chunks (word-vtt.js)
+ * and drawn onto each frame's canvas — a read-along highlight (spoken words full
+ * white, upcoming words dimmed) — before the frame is encoded.
  *
  * mediabunny (and the MP3 encoder extension) are vendored under js/vendor/
  * (#381, so export works offline) and load lazily on first use —
@@ -183,6 +188,144 @@
     return clone.innerHTML;
   };
 
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  // Re-timed WebVTT + SRT captions for the exported (edited) media. Generated
+  // off a DETACHED copy of the re-timed transcript via the shared caption.js, so
+  // struck words are dropped and times map onto the edited timeline. Passing a
+  // non-existent playerId makes caption()'s player-side effects (setting the live
+  // track src, forcing captions to show) a no-op — the live editor is untouched.
+  // Returns { vtt, srt } or null.
+  const genRetimedCaptions = (sections, rate) => {
+    if (typeof caption !== 'function') return null;
+    const inner = buildRetimedTranscriptHtml(sections, rate);
+    if (inner === null) return null;
+    const host = document.createElement('div');
+    const t = document.createElement('div');
+    t.id = 'hypertranscript';
+    t.innerHTML = inner;
+    host.appendChild(t);
+    try {
+      return caption().init('hypertranscript', 'media-export-no-player', '37', '21', null, null, host);
+    } catch (e) {
+      console.warn('Caption generation for export failed:', e);
+      return null;
+    }
+  };
+
+  // A standalone interactive transcript page (hyperaudio-lite from CDN) that
+  // links the exported media by its relative filename; the transcript is the
+  // re-timed, struck-words-removed clone. trackSrc: a captions URL to link/embed,
+  // or null to omit the <track> entirely (e.g. when captions are burned in).
+  const buildInteractiveExportHtml = (sections, rate, mediaSrc, trackSrc) => {
+    if (typeof hyperaudioTemplate !== 'string' || hyperaudioTemplate === '') return null;
+    const inner = buildRetimedTranscriptHtml(sections, rate);
+    if (inner === null) return null;
+    let html = hyperaudioTemplate
+      .replace('{hypertranscript}', () => inner)
+      .replace('{sourcemedia}', () => mediaSrc)
+      .replace('{sourcevtt}', () => (trackSrc || ''));
+    if (!trackSrc) html = html.replace(/<track[^>]*>/i, '');
+    return html;
+  };
+
+  // Word chunks for burn-in, already mapped onto the EDITED/output timeline.
+  // buildRetimedTranscriptHtml drops struck words and maps each data-m through
+  // the kept sections (÷ rate), so feeding its output to the shared chunker
+  // (word-vtt.js) yields chunks whose times line up with the `t` the video loop
+  // stamps on each frame — no separate mapping needed here. Returns null when
+  // there is no transcript, no words, or word-vtt.js isn't loaded.
+  const buildCaptionChunks = (sections, rate) => {
+    if (typeof window.hyperaudioWordChunks !== 'function') return null;
+    const html = buildRetimedTranscriptHtml(sections, rate);
+    if (html === null) return null;
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    const chunks = window.hyperaudioWordChunks({ source: tmp });
+    return chunks.length ? chunks : null;
+  };
+
+  // Read-along caption colours, matching the editor transcript's states: the
+  // word currently being spoken is accented (cf. .highlight.active), words
+  // already spoken are full white (.read), upcoming words dimmed (.unread).
+  const CAPTION_READ = 'rgba(255,255,255,1)';
+  const CAPTION_ACTIVE = '#ffe14d';
+  const CAPTION_UNREAD = 'rgba(255,255,255,0.45)';
+
+  // Paint the active caption chunk onto the frame for output-timeline time `t`.
+  // Chunks are held until the next one starts so captions stay continuous.
+  // Legibility comes from a soft shadow + a THIN outline: a thick stroke eats
+  // the fill on slender glyph strokes and bleeds into letter counters (the holes
+  // in o/e/a/d), so it is kept small and the fill is drawn shadow-free on top.
+  const drawCaptionOverlay = (ctx, t, chunks, w, h) => {
+    let active = null;
+    for (const c of chunks) {
+      if (c[0].start <= t) active = c; else break;
+    }
+    if (active === null) return;
+
+    // Exactly one active word: the last whose start has been reached. Earlier
+    // words are "read", later ones "unread".
+    let activeIdx = -1;
+    for (let i = 0; i < active.length; i++) {
+      if (active[i].start <= t) activeIdx = i; else break;
+    }
+
+    const fontSize = Math.max(16, Math.round(h * 0.055));
+    ctx.save();
+    ctx.font = `700 ${fontSize}px -apple-system, "Helvetica Neue", Arial, sans-serif`;
+    ctx.textBaseline = 'alphabetic';
+    ctx.lineJoin = 'round';
+    const spaceW = ctx.measureText(' ').width;
+    const maxWidth = w * 0.86;
+
+    // wrap the chunk's words into lines that fit the safe width, keeping each
+    // word's index within the chunk so its read/active/unread state is known
+    const lines = [];
+    let line = [];
+    let lineW = 0;
+    for (let i = 0; i < active.length; i++) {
+      const wW = ctx.measureText(active[i].text).width;
+      if (line.length && lineW + spaceW + wW > maxWidth) {
+        lines.push(line);
+        line = [];
+        lineW = 0;
+      }
+      lineW += (line.length ? spaceW : 0) + wW;
+      line.push({ text: active[i].text, index: i });
+    }
+    if (line.length) lines.push(line);
+
+    const lineH = fontSize * 1.25;
+    const bottomMargin = h * 0.10;                       // lower-third, safe-area
+    let y = h - bottomMargin - (lines.length - 1) * lineH;
+    const strokeW = Math.max(2, fontSize * 0.06);
+    for (const ln of lines) {
+      let total = 0;
+      ln.forEach((e, i) => { total += (i ? spaceW : 0) + ctx.measureText(e.text).width; });
+      let x = (w - total) / 2;                            // centre each line
+      for (let i = 0; i < ln.length; i++) {
+        if (i) x += spaceW;
+        const { text, index } = ln[i];
+        // shadow halo + thin outline for legibility over any footage
+        ctx.shadowColor = 'rgba(0,0,0,0.9)';
+        ctx.shadowBlur = fontSize * 0.16;
+        ctx.lineWidth = strokeW;
+        ctx.strokeStyle = 'rgba(0,0,0,0.9)';
+        ctx.strokeText(text, x, y);
+        // crisp fill with the shadow disabled so interiors stay clean
+        ctx.shadowColor = 'transparent';
+        ctx.shadowBlur = 0;
+        ctx.fillStyle = index < activeIdx ? CAPTION_READ
+          : (index === activeIdx ? CAPTION_ACTIVE : CAPTION_UNREAD);
+        ctx.fillText(text, x, y);
+        x += ctx.measureText(text).width;
+      }
+      y += lineH;
+    }
+    ctx.restore();
+  };
+
   // ---------------------------------------------------------------------------
   // Export pipelines
   // ---------------------------------------------------------------------------
@@ -316,7 +459,7 @@
   // Edited media with video: decode frames per kept section and re-timestamp
   // them onto the edited timeline; audio as above (its appended timestamps
   // already match the edited timeline).
-  const exportEditedVideo = async (mb, fmt, sections, rate, onProgress) => {
+  const exportEditedVideo = async (mb, fmt, sections, rate, onProgress, captions) => {
     const input = await makeInput(mb);
     const vTrack = await input.getPrimaryVideoTrack();
     const aTrack = await input.getPrimaryAudioTrack();
@@ -366,6 +509,7 @@
         const frameDur = Math.max(sample.duration || 1 / 30, 0.001) / rate;
         sample.draw(ctx2d, 0, 0, width, height);
         sample.close();
+        if (captions) drawCaptionOverlay(ctx2d, t, captions, width, height);
         await vSource.add(t, frameDur);
         done += frameDur * rate;
         onProgress(Math.min(0.99, done / total));
@@ -434,6 +578,12 @@
   const rateValue = document.getElementById('export-rate-value');
   const retimeRow = document.getElementById('export-retime-row');
   const retimeCheck = document.getElementById('export-retime');
+  const vttRow = document.getElementById('export-vtt-row');
+  const vttCheck = document.getElementById('export-vtt');
+  const srtRow = document.getElementById('export-srt-row');
+  const srtCheck = document.getElementById('export-srt');
+  const burnRow = document.getElementById('export-burn-row');
+  const burnCheck = document.getElementById('export-burn');
   const progressBar = document.getElementById('export-progress');
   const statusEl = document.getElementById('export-status');
   const startBtn = document.getElementById('export-start');
@@ -464,9 +614,48 @@
 
   // The re-timed transcript makes sense whenever the exported media's timeline
   // differs from the original: edits, an applied playback speed, or both.
+  // The transcript/caption sidecars (interactive transcript, VTT, SRT) are all
+  // offered whenever there's a transcript to derive them from — they re-time
+  // themselves to whatever edits/speed the export uses.
   const updateRetimeVisibility = () => {
-    const edited = sourceEdited.checked && !sourceEdited.disabled;
-    retimeRow.style.display = edited || rateApplied() ? 'flex' : 'none';
+    const show = hasTranscript() ? 'flex' : 'none';
+    retimeRow.style.display = show;
+    if (vttRow !== null) vttRow.style.display = show;
+    if (srtRow !== null) srtRow.style.display = show;
+  };
+
+  const hasTranscript = () => {
+    const t = document.getElementById('hypertranscript');
+    return t !== null && t.querySelector('[data-m]') !== null;
+  };
+
+  // Burn-in is a video-only, frame-by-frame operation and needs a transcript to
+  // draw. Offer it only when both hold (#387 part 2).
+  const updateBurnVisibility = () => {
+    if (burnRow === null) return;
+    const fmt = FORMATS.find((f) => f.id === formatSelect.value);
+    const show = fmt && fmt.kind === 'video' && hasTranscript();
+    burnRow.style.display = show ? 'flex' : 'none';
+  };
+
+  // Persist the option toggles so the user's choices stick across sessions.
+  // Defaults are all-off; a stored value overrides on open, and any change
+  // re-saves. Rate is stored too but only applied when the media isn't at 1×.
+  const EXPORT_OPTS_KEY = 'hyperaudioExportOptions';
+  const loadExportOpts = () => {
+    try { return JSON.parse(window.localStorage.getItem(EXPORT_OPTS_KEY)) || {}; }
+    catch (e) { return {}; }
+  };
+  const saveExportOpts = () => {
+    try {
+      window.localStorage.setItem(EXPORT_OPTS_KEY, JSON.stringify({
+        burn: burnCheck.checked,
+        rate: rateCheck.checked,
+        retime: retimeCheck.checked,
+        vtt: vttCheck !== null && vttCheck.checked,
+        srt: srtCheck !== null && srtCheck.checked,
+      }));
+    } catch (e) { /* storage unavailable (private mode / quota) — non-fatal */ }
   };
 
   const populateModal = async () => {
@@ -489,11 +678,19 @@
       sourceEntire.checked = true;
     }
 
+    // restore the user's last export-option choices (default: all off)
+    const opts = loadExportOpts();
+    burnCheck.checked = opts.burn === true;
+    retimeCheck.checked = opts.retime === true;
+    if (vttCheck !== null) vttCheck.checked = opts.vtt === true;
+    if (srtCheck !== null) srtCheck.checked = opts.srt === true;
+
     // offer the playback-speed option when the player isn't at 1×
     const rate = playbackRate();
     if (rate !== 1) {
       rateValue.textContent = `${rate}×`;
       rateRow.style.display = 'flex';
+      rateCheck.checked = opts.rate === true;
     } else {
       rateRow.style.display = 'none';
       rateCheck.checked = false;
@@ -528,6 +725,7 @@
       if (withVideo && formatSelect.querySelector('option[value="mp4"]') !== null) {
         formatSelect.value = 'mp4';
       }
+      updateBurnVisibility();
       setStatus('');
     } catch (e) {
       console.error(e);
@@ -550,32 +748,69 @@
 
       const edited = sourceEdited.checked && !sourceEdited.disabled;
       const rate = rateApplied() ? playbackRate() : 1;
+      const burn = fmt.kind === 'video' && burnRow !== null &&
+        burnRow.style.display !== 'none' && burnCheck.checked;
+      const wantRetime = retimeCheck.checked && retimeRow.style.display !== 'none';
+      const wantVtt = vttCheck !== null && vttCheck.checked && vttRow.style.display !== 'none';
+      const wantSrt = srtCheck !== null && srtCheck.checked && srtRow.style.display !== 'none';
       const baseName = exportBaseName();
-      const suffix = `${edited ? '-edited' : ''}${rate !== 1 ? `-${rate}x` : ''}`;
-      let blob;
+      const suffix = `${edited ? '-edited' : ''}${rate !== 1 ? `-${rate}x` : ''}${burn ? '-captioned' : ''}`;
 
-      if (!edited && rate === 1) {
+      const player = document.getElementById('hyperplayer');
+      const duration = player && !isNaN(player.duration) ? player.duration : Infinity;
+      const sections = edited ? editedSections(duration) : [{ start: 0, end: duration }];
+
+      // 1. the media file. Burning captions requires the frame-by-frame canvas
+      // path, so it always routes through the section pipeline (as an applied
+      // speed does), even for an unedited "entire" export at 1×.
+      let blob;
+      const straightCopy = !edited && rate === 1 && !burn;
+      if (straightCopy) {
         setStatus('Exporting entire media…');
         blob = await exportEntire(mb, fmt, setProgress);
-        downloadBlob(blob, `${baseName}.${fmt.ext}`);
       } else {
-        // an applied playback speed also routes the entire media through the
-        // section pipeline (one full-length section) so it can be stretched
-        const player = document.getElementById('hyperplayer');
-        const duration = player && !isNaN(player.duration) ? player.duration : Infinity;
-        const sections = edited ? editedSections(duration) : [{ start: 0, end: duration }];
-        setStatus(rate !== 1 ? `Exporting at ${rate}× — pitch preserved…` : 'Exporting edited media…');
+        const captions = burn ? buildCaptionChunks(sections, rate) : null;
+        setStatus(burn ? 'Exporting with captions…' : (rate !== 1 ? `Exporting at ${rate}× — pitch preserved…` : 'Exporting edited media…'));
         blob = fmt.kind === 'video'
-          ? await exportEditedVideo(mb, fmt, sections, rate, setProgress)
+          ? await exportEditedVideo(mb, fmt, sections, rate, setProgress, captions)
           : await exportEditedAudio(mb, fmt, sections, rate, setProgress);
-        downloadBlob(blob, `${baseName}${suffix}.${fmt.ext}`);
+      }
+      const mediaName = straightCopy ? `${baseName}.${fmt.ext}` : `${baseName}${suffix}.${fmt.ext}`;
+      const outputs = [{ blob, name: mediaName }];
 
-        if (retimeCheck.checked && retimeRow.style.display !== 'none') {
-          const html = buildRetimedTranscriptHtml(sections, rate);
+      // 2. caption sidecars + interactive transcript, all re-timed to the export
+      if (wantRetime || wantVtt || wantSrt) {
+        const subs = genRetimedCaptions(sections, rate);
+        const vttName = `${baseName}${suffix}.vtt`;
+        const srtName = `${baseName}${suffix}.srt`;
+        if (wantVtt && subs && subs.vtt) {
+          outputs.push({ blob: new Blob([subs.vtt], { type: 'text/vtt' }), name: vttName });
+        }
+        if (wantSrt && subs && subs.srt) {
+          outputs.push({ blob: new Blob([subs.srt], { type: 'text/plain' }), name: srtName });
+        }
+        if (wantRetime) {
+          // captions track inside the interactive transcript:
+          //   burned in    -> none (they are already painted into the video)
+          //   VTT exported -> link the sidecar .vtt file
+          //   otherwise    -> embed the re-timed VTT inline (self-contained)
+          let trackSrc = null;
+          if (!burn) {
+            if (wantVtt) trackSrc = encodeURI(vttName);
+            else if (subs && subs.vtt) trackSrc = 'data:text/vtt,' + encodeURIComponent(subs.vtt);
+          }
+          const html = buildInteractiveExportHtml(sections, rate, encodeURI(mediaName), trackSrc);
           if (html !== null) {
-            downloadBlob(new Blob([html], { type: 'text/html' }), `${baseName}${suffix}-transcript.html`);
+            outputs.push({ blob: new Blob([html], { type: 'text/html' }), name: `${baseName}${suffix}-transcript.html` });
           }
         }
+      }
+
+      // 3. hand the browser each file, spaced out so Safari doesn't drop all but
+      // the last of a multi-file download
+      for (let i = 0; i < outputs.length; i++) {
+        downloadBlob(outputs[i].blob, outputs[i].name);
+        if (i < outputs.length - 1) await sleep(250);
       }
 
       setProgress(1);
@@ -594,5 +829,9 @@
   sourceEntire.addEventListener('change', updateRetimeVisibility);
   sourceEdited.addEventListener('change', updateRetimeVisibility);
   rateCheck.addEventListener('change', updateRetimeVisibility);
+  formatSelect.addEventListener('change', updateBurnVisibility);
+  [burnCheck, rateCheck, retimeCheck, vttCheck, srtCheck].forEach((el) => {
+    if (el !== null) el.addEventListener('change', saveExportOpts);
+  });
   startBtn.addEventListener('click', runExport);
 })();

--- a/js/word-vtt.js
+++ b/js/word-vtt.js
@@ -1,0 +1,170 @@
+/**
+ * word-vtt.js
+ * (C) The Hyperaudio Project
+ * @version 0.7.7 — last changed in release 0.7.7
+ * @license MIT
+ *
+ * Word-level ("karaoke") WebVTT export (#387, part 1).
+ *
+ * Standard caption VTT (js/caption.js) groups words into phrase-length cues and
+ * emits only cue-level timing. This module instead emits cues that carry
+ * per-word timing via inline WebVTT timestamp tags:
+ *
+ *     00:00:01.200 --> 00:00:02.640
+ *     <00:00:01.200>So <00:00:01.550>if <00:00:01.900>you're …
+ *
+ * Browsers highlight these live during playback, and the burn-in renderer
+ * (#387 part 2) uses them for per-word karaoke animation.
+ *
+ * Source is the live #hypertranscript DOM (per-word data-m/data-d), so the
+ * output reflects the user's edits. caption.js is left untouched — it is
+ * vendored verbatim from upstream.
+ *
+ * Loaded as a plain <script>; exposes `generateWordVtt` as a global and
+ * self-wires the #download-vtt-words menu link. Also exported for unit tests.
+ */
+
+(function () {
+  const DEFAULTS = {
+    maxWords: 5,    // words per karaoke chunk
+    maxGap: 0.8,    // seconds; a longer pause starts a new chunk
+    selector: '#hypertranscript',
+  };
+
+  // seconds -> HH:MM:SS.mmm
+  function formatTimestamp(t) {
+    if (!(t >= 0)) t = 0;
+    const hh = Math.floor(t / 3600);
+    const mm = Math.floor((t % 3600) / 60);
+    const ss = Math.floor(t % 60);
+    const ms = Math.round((t - Math.floor(t)) * 1000);
+    const pad = (n, w) => String(n).padStart(w, '0');
+    return `${pad(hh, 2)}:${pad(mm, 2)}:${pad(ss, 2)}.${pad(ms, 3)}`;
+  }
+
+  // Pull the ordered word list out of a transcript root. Speaker labels carry a
+  // data-m too, so they are skipped; empty/whitespace spans are ignored.
+  function readWords(root) {
+    const words = [];
+    root.querySelectorAll('[data-m]').forEach((span) => {
+      if (span.classList.contains('speaker')) return;
+      const text = (span.textContent || '').trim();
+      if (!text) return;
+      const start = parseInt(span.getAttribute('data-m'), 10) / 1000;
+      if (isNaN(start)) return;
+      let dur = parseInt(span.getAttribute('data-d'), 10) / 1000;
+      if (isNaN(dur) || dur < 0) dur = 0;
+      words.push({ start, end: start + dur, text });
+    });
+    // Fill missing/zero durations from the next word's start so every word has a
+    // non-degenerate span for the renderer to sweep across.
+    for (let i = 0; i < words.length; i++) {
+      if (!(words[i].end > words[i].start)) {
+        words[i].end = i + 1 < words.length
+          ? Math.max(words[i].start, words[i + 1].start)
+          : words[i].start + 0.4;
+      }
+    }
+    return words;
+  }
+
+  // Break the flat word list into short karaoke chunks: a new chunk starts once
+  // the current one hits maxWords or a pause longer than maxGap opens up.
+  function chunkWords(words, maxWords, maxGap) {
+    const chunks = [];
+    let cur = [];
+    for (let i = 0; i < words.length; i++) {
+      if (cur.length > 0) {
+        const gap = words[i].start - cur[cur.length - 1].end;
+        if (cur.length >= maxWords || gap > maxGap) {
+          chunks.push(cur);
+          cur = [];
+        }
+      }
+      cur.push(words[i]);
+    }
+    if (cur.length) chunks.push(cur);
+    return chunks;
+  }
+
+  // Resolve options.source (a selector string, an element, or unset → default
+  // selector) to a transcript root element, or a falsy value if none.
+  function resolveRoot(opts) {
+    if (typeof opts.source === 'string' || opts.source == null) {
+      return typeof document !== 'undefined' && document.querySelector(opts.source || opts.selector);
+    }
+    return opts.source;
+  }
+
+  /**
+   * Build the word chunks from a transcript root — the shared unit behind both
+   * the VTT export and the burn-in renderer (#387 part 2). Each chunk is an
+   * array of `{ text, start, end }` (seconds). Empty array if no words.
+   * @param {Object} [options] maxWords, maxGap, source (see generateWordVtt)
+   * @returns {Array<Array<{text:string,start:number,end:number}>>}
+   */
+  function buildWordChunks(options) {
+    const opts = Object.assign({}, DEFAULTS, options || {});
+    const root = resolveRoot(opts);
+    if (!root) return [];
+    const words = readWords(root);
+    if (!words.length) return [];
+    return chunkWords(words, opts.maxWords, opts.maxGap);
+  }
+
+  /**
+   * Build word-level ("karaoke") WebVTT from the live transcript.
+   * @param {Object} [options]
+   * @param {number} [options.maxWords=5]  words per chunk
+   * @param {number} [options.maxGap=0.8]  seconds; longer pause splits a chunk
+   * @param {string|Element} [options.source='#hypertranscript'] transcript root
+   * @returns {string} a WebVTT document (just the header if there are no words)
+   */
+  function generateWordVtt(options) {
+    const chunks = buildWordChunks(options);
+    let vtt = 'WEBVTT\n';
+    chunks.forEach((chunk) => {
+      const start = chunk[0].start;
+      const end = chunk[chunk.length - 1].end;
+      const line = chunk
+        .map((w) => `<${formatTimestamp(w.start)}>${w.text}`)
+        .join(' ');
+      vtt += `\n${formatTimestamp(start)} --> ${formatTimestamp(end)}\n${line}\n`;
+    });
+    return vtt;
+  }
+
+  // Self-wire the menu link: generate on click so the download always reflects
+  // the current transcript state. Drive the download from a throwaway anchor
+  // rather than mutating this link's href mid-click, which is more reliable
+  // across browsers.
+  function wireDownloadLink() {
+    const link = typeof document !== 'undefined' && document.getElementById('download-vtt-words');
+    if (!link) return;
+    link.addEventListener('click', (event) => {
+      event.preventDefault();
+      const vtt = generateWordVtt();
+      const blob = new Blob([vtt], { type: 'text/vtt' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = link.getAttribute('download') || 'hyperaudio.words.vtt';
+      a.click();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    });
+  }
+
+  if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', wireDownloadLink);
+    } else {
+      wireDownloadLink();
+    }
+    window.generateWordVtt = generateWordVtt;
+    window.hyperaudioWordChunks = buildWordChunks;
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { generateWordVtt, buildWordChunks, formatTimestamp, readWords, chunkWords };
+  }
+})();


### PR DESCRIPTION
Builds out captioning and media export, mostly around #387.

### Word-level VTT (#387 part 1)
- `js/word-vtt.js`: word-level ("karaoke") WebVTT from the live transcript (inline per-word timestamps), plus a shared chunker reused by the burn-in.
- "WebVTT (Word-level / Karaoke)" item in the FILE menu.
- Unit tests (`__TEST__/unit/word-vtt.test.mjs`).

### Caption burn-in (#387 part 2)
- A per-frame read-along overlay drawn in the mediabunny video pipeline — spoken words solid, current word accented, upcoming dimmed — mapped onto the edited/output timeline; thin outline + shadow for legibility.

### Export UI & outputs
- **Top-level Export button** in the toolbar.
- **Export media modal** now optionally emits an **interactive transcript** (hyperaudio-lite page linking the exported media) plus **WebVTT/SRT** sidecars, all re-timed to the edited media. The transcript links the VTT unless captions are burned in (then no track); otherwise it embeds it.
- **Speed / length control** ("stretch to fit"): fine speed 0.25x-4x *or* a target length, linked and clamped, pitch-preserved (WSOLA); the transcript, sidecars and burn-in all track the chosen rate.
- **"Save as" field**: one user-chosen name for every output, so the media file and the transcript's `<video src>` always agree (fixes the interactive transcript referencing the wrong file).
- Options are toggles (matching the rest of the UI), default off, remembered in localStorage.

### Interactive transcript page
- Redesigned exported template: smaller centred video, constrained reading column, calmer typography.

### Also
- Standalone FILE > Interactive Transcript dialog (relative media link).
- Removed vestigial `data:` href-building for the interactive-transcript download.

### Notes / follow-ups
- Version markers are provisional `0.7.7`; `<meta name="version">` still reads `0.7.6` — reconcile at release.
- A standalone FILE > Interactive Transcript dialog now overlaps the modal's version — candidate to retire.
- Burn-in and re-timed VTT/SRT still want a manual/e2e pass before release.
