### PR TITLE
Add AssemblyAI (Cloud) tab + Local/Cloud service switch (#390)

### DIFF
--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -765,6 +765,71 @@ body.find-replace-open .hyperaudio-transcript { padding-top: 108px; }
   color: oklch(var(--p));
 }
 
+/* Transcribe modal — Local / Cloud service switch (#390). CSS-only: the two
+   sr-only sibling radios drive both the segmented control's active state and
+   which engine tab-group is shown, so no extra JS is needed. */
+.service-mode-radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+.service-switch {
+  display: inline-flex;
+  gap: 3px;
+  margin-bottom: 16px;
+  padding: 3px;
+  border: 1px solid oklch(var(--bc) / 0.2);
+  border-radius: 9999px;
+}
+.service-switch label {
+  padding: 5px 22px;
+  border-radius: 9999px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1.2;
+  user-select: none;
+}
+#service-local:checked ~ .service-switch label[for="service-local"],
+#service-cloud:checked ~ .service-switch label[for="service-cloud"] {
+  background-color: oklch(var(--p));
+  color: oklch(var(--pc));
+}
+#cloud-group { display: none; }
+#service-cloud:checked ~ #local-group { display: none; }
+#service-cloud:checked ~ #cloud-group { display: block; }
+
+/* API key field with a show/hide eye toggle (#390). */
+.key-field {
+  position: relative;
+  width: 100%;
+  max-width: 20rem;
+}
+.key-field .input {
+  padding-right: 2.4rem;
+}
+.key-eye {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  color: inherit;
+  opacity: 0.55;
+}
+.key-eye:hover { opacity: 1; }
+
 /* Buttons pick up an 8px margin-bottom from the global input/button rule,
    which nudges them off-centre in flex rows — neutralise in the bars. */
 .navbar .btn,

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hls-source.js?v=0.6.26"></script>
   <script src="js/hyperaudio-lite-editor-deepgram.js?v=0.6.7"></script>
   <script src="js/hyperaudio-lite-editor-assemblyai.js?v=0.8.1"></script>
+  <script src="js/transcribe-prefs.js?v=0.8.1"></script>
   <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.26"></script>
   <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.7.0"></script>
   <script src="js/word-alignment.js"></script>
@@ -105,7 +106,7 @@ If you are creating an open source application under a license compatible with t
     }
     
   </style>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.8.0">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=0.8.1">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -118,7 +119,17 @@ If you are creating an open source application under a license compatible with t
    <template id="deepgram-modal-template">
     <form id="deepgram-form" name="deepgram-form">
       <div class="flex flex-col gap-4 w-full">
-        <input id="token" type="text" placeholder="Deepgram token" class="input input-bordered w-full max-w-xs" />
+        <div class="key-field">
+          <input id="token" type="password" placeholder="Deepgram token" class="input input-bordered w-full" />
+          <button type="button" class="key-eye" aria-label="Show key" tabindex="-1">
+            <svg class="eye-open" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+            <svg class="eye-closed" style="display:none" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
+          </button>
+        </div>
+        <label style="display:flex; gap:8px; align-items:center; cursor:pointer">
+          <input id="deepgram-remember-key" type="checkbox" class="toggle toggle-primary" checked />
+          <span class="label-text" style="font-size:0.85rem; opacity:0.85">Remember key on this device</span>
+        </label>
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
         <input id="deepgram-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
         <span class="label-text">or</span>
@@ -145,7 +156,17 @@ If you are creating an open source application under a license compatible with t
   <template id="assemblyai-modal-template">
     <form id="assemblyai-form" name="assemblyai-form">
       <div class="flex flex-col gap-4 w-full">
-        <input id="assemblyai-key" type="text" placeholder="AssemblyAI API key" class="input input-bordered w-full max-w-xs" />
+        <div class="key-field">
+          <input id="assemblyai-key" type="password" placeholder="AssemblyAI API key" class="input input-bordered w-full" />
+          <button type="button" class="key-eye" aria-label="Show key" tabindex="-1">
+            <svg class="eye-open" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+            <svg class="eye-closed" style="display:none" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
+          </button>
+        </div>
+        <label style="display:flex; gap:8px; align-items:center; cursor:pointer">
+          <input id="assemblyai-remember-key" type="checkbox" class="toggle toggle-primary" checked />
+          <span class="label-text" style="font-size:0.85rem; opacity:0.85">Remember key on this device</span>
+        </label>
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
         <input id="assemblyai-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
         <span class="label-text">or</span>
@@ -775,31 +796,42 @@ If you are creating an open source application under a license compatible with t
 
   <input type="checkbox" id="transcribe-modal" class="modal-toggle" />
   <div class="modal">
-    <div class="modal-box" style="max-width:42rem">
+    <div class="modal-box" style="max-width:36rem">
       <label for="transcribe-modal" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
       <h3 class="font-bold text-lg"  style="margin-bottom:16px">Transcribe</h3>
-      <div role="tablist" class="tabs tabs-lifted">
 
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:135px; white-space:nowrap" aria-label="Parakeet" checked />
-        <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
-          <client-parakeet-service templateSelector="#parakeet-local-template"></client-parakeet-service>
+      <!-- Local / Cloud service switch — CSS-only via these sibling radios -->
+      <input type="radio" name="service-mode" id="service-local" class="service-mode-radio" checked />
+      <input type="radio" name="service-mode" id="service-cloud" class="service-mode-radio" />
+      <div class="service-switch" role="tablist" aria-label="Service type">
+        <label for="service-local" role="tab">Local</label>
+        <label for="service-cloud" role="tab">Cloud</label>
+      </div>
+
+      <div id="local-group">
+        <div role="tablist" class="tabs tabs-lifted">
+          <input type="radio" name="local_tabs" role="tab" class="tab" style="width:150px; white-space:nowrap" aria-label="Parakeet" checked />
+          <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
+            <client-parakeet-service templateSelector="#parakeet-local-template"></client-parakeet-service>
+          </div>
+          <input type="radio" name="local_tabs" role="tab" class="tab" style="width:150px; white-space:nowrap" aria-label="Whisper" />
+          <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
+            <client-whisper-service templateSelector="#whisper-client-template"></client-whisper-service>
+          </div>
         </div>
+      </div>
 
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:135px; white-space:nowrap" aria-label="Whisper"  />
-        <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
-          <client-whisper-service templateSelector="#whisper-client-template"></client-whisper-service>
+      <div id="cloud-group">
+        <div role="tablist" class="tabs tabs-lifted">
+          <input type="radio" name="cloud_tabs" role="tab" class="tab" style="width:150px; white-space:nowrap" aria-label="Deepgram" checked />
+          <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
+            <deepgram-service templateSelector="#deepgram-modal-template"></deepgram-service>
+          </div>
+          <input type="radio" name="cloud_tabs" role="tab" class="tab" style="width:150px; white-space:nowrap" aria-label="AssemblyAI" />
+          <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
+            <assemblyai-service templateSelector="#assemblyai-modal-template"></assemblyai-service>
+          </div>
         </div>
-
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:135px; white-space:nowrap" aria-label="Deepgram"  />
-        <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
-          <deepgram-service templateSelector="#deepgram-modal-template"></deepgram-service>
-        </div>
-
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:135px; white-space:nowrap" aria-label="AssemblyAI"  />
-        <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
-          <assemblyai-service templateSelector="#assemblyai-modal-template"></assemblyai-service>
-        </div>
-
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/audio-source.js?v=0.6.24"></script>
   <script src="js/hls-source.js?v=0.6.26"></script>
   <script src="js/hyperaudio-lite-editor-deepgram.js?v=0.6.7"></script>
+  <script src="js/hyperaudio-lite-editor-assemblyai.js?v=0.8.1"></script>
   <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.26"></script>
   <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.7.0"></script>
   <script src="js/word-alignment.js"></script>
@@ -137,6 +138,33 @@ If you are creating an open source application under a license compatible with t
       </div>
       <div class="modal-action">
         <label id="transcribe-btn" for="transcribe-modal" class="btn btn-primary btn-disabled" aria-disabled="true">TRANSCRIBE</label>
+      </div>
+    </form>
+  </template>
+
+  <template id="assemblyai-modal-template">
+    <form id="assemblyai-form" name="assemblyai-form">
+      <div class="flex flex-col gap-4 w-full">
+        <input id="assemblyai-key" type="text" placeholder="AssemblyAI API key" class="input input-bordered w-full max-w-xs" />
+        <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
+        <input id="assemblyai-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
+        <span class="label-text">or</span>
+        <input id="assemblyai-file" name="file" type="file" class="file-input w-full max-w-xs" title="" />
+        <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
+
+        <span class="label-text">Model</span>
+        <select id="assemblyai-model" name="assemblyai-model" class="select select-bordered w-full max-w-xs"></select>
+
+        <span class="label-text">Language</span>
+        <select id="assemblyai-language" name="assemblyai-language" class="select select-bordered w-full max-w-xs"></select>
+
+        <label style="display:flex; gap:8px; align-items:center; cursor:pointer">
+          <input id="assemblyai-diarize" type="checkbox" class="toggle toggle-primary" />
+          <span class="label-text">Detect speakers (diarization)</span>
+        </label>
+      </div>
+      <div class="modal-action">
+        <label id="assemblyai-submit-btn" for="transcribe-modal" class="btn btn-primary btn-disabled" aria-disabled="true">TRANSCRIBE</label>
       </div>
     </form>
   </template>
@@ -747,24 +775,29 @@ If you are creating an open source application under a license compatible with t
 
   <input type="checkbox" id="transcribe-modal" class="modal-toggle" />
   <div class="modal">
-    <div class="modal-box" style="max-width:36rem">
+    <div class="modal-box" style="max-width:42rem">
       <label for="transcribe-modal" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
       <h3 class="font-bold text-lg"  style="margin-bottom:16px">Transcribe</h3>
       <div role="tablist" class="tabs tabs-lifted">
 
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:165px; white-space:nowrap" aria-label="Parakeet" checked />
+        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:135px; white-space:nowrap" aria-label="Parakeet" checked />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
           <client-parakeet-service templateSelector="#parakeet-local-template"></client-parakeet-service>
         </div>
 
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:165px; white-space:nowrap" aria-label="Whisper"  />
+        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:135px; white-space:nowrap" aria-label="Whisper"  />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
           <client-whisper-service templateSelector="#whisper-client-template"></client-whisper-service>
         </div>
 
-        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:165px; white-space:nowrap" aria-label="Deepgram"  />
+        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:135px; white-space:nowrap" aria-label="Deepgram"  />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
           <deepgram-service templateSelector="#deepgram-modal-template"></deepgram-service>
+        </div>
+
+        <input type="radio" name="my_tabs_2" role="tab" class="tab" style="width:135px; white-space:nowrap" aria-label="AssemblyAI"  />
+        <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
+          <assemblyai-service templateSelector="#assemblyai-modal-template"></assemblyai-service>
         </div>
 
       </div>

--- a/index.html
+++ b/index.html
@@ -178,11 +178,6 @@ If you are creating an open source application under a license compatible with t
 
         <span class="label-text">Language</span>
         <select id="assemblyai-language" name="assemblyai-language" class="select select-bordered w-full max-w-xs"></select>
-
-        <label style="display:flex; gap:8px; align-items:center; cursor:pointer">
-          <input id="assemblyai-diarize" type="checkbox" class="toggle toggle-primary" />
-          <span class="label-text">Detect speakers (diarization)</span>
-        </label>
       </div>
       <div class="modal-action">
         <label id="assemblyai-submit-btn" for="transcribe-modal" class="btn btn-primary btn-disabled" aria-disabled="true">TRANSCRIBE</label>
@@ -823,13 +818,13 @@ If you are creating an open source application under a license compatible with t
 
       <div id="cloud-group">
         <div role="tablist" class="tabs tabs-lifted">
-          <input type="radio" name="cloud_tabs" role="tab" class="tab" style="width:150px; white-space:nowrap" aria-label="Deepgram" checked />
-          <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
-            <deepgram-service templateSelector="#deepgram-modal-template"></deepgram-service>
-          </div>
-          <input type="radio" name="cloud_tabs" role="tab" class="tab" style="width:150px; white-space:nowrap" aria-label="AssemblyAI" />
+          <input type="radio" name="cloud_tabs" role="tab" class="tab" style="width:150px; white-space:nowrap" aria-label="AssemblyAI" checked />
           <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
             <assemblyai-service templateSelector="#assemblyai-modal-template"></assemblyai-service>
+          </div>
+          <input type="radio" name="cloud_tabs" role="tab" class="tab" style="width:150px; white-space:nowrap" aria-label="Deepgram" />
+          <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
+            <deepgram-service templateSelector="#deepgram-modal-template"></deepgram-service>
           </div>
         </div>
       </div>

--- a/js/hyperaudio-lite-editor-assemblyai.js
+++ b/js/hyperaudio-lite-editor-assemblyai.js
@@ -1,0 +1,346 @@
+/**
+ * hyperaudio-lite-editor-assemblyai.js
+ * (C) The Hyperaudio Project
+ * @version 0.8.1 — last changed in release 0.8.1
+ * @license MIT
+ *
+ * AssemblyAI (Cloud) transcription — called directly from the browser with the
+ * user's own API key, no backend (#390). AssemblyAI's REST API is CORS-open
+ * (Access-Control-Allow-Origin: *), so `fetch` from the page works. Unlike
+ * Deepgram's single synchronous call, the flow is async:
+ *   1. upload the file  -> upload_url   (skipped when a public URL is supplied)
+ *   2. POST /transcript -> transcript id
+ *   3. poll  /transcript/{id} until status is completed / error
+ *
+ * The completed transcript's word list (start/end in MILLISECONDS) is parsed
+ * into the same data-m / data-d spans the other engines emit. Reuses the global
+ * helpers transcribingSvg / errorSvg (editor-svg.js) and setTranscriptBusy /
+ * setTranscriptionInfo (editor-core.js).
+ */
+
+const ASSEMBLYAI_BASE = "https://api.assemblyai.com/v2";
+const ASSEMBLYAI_POLL_MS = 3000;
+const assemblyaiSleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const ASSEMBLYAI_MODELS = [
+  { value: "best", label: "Best (most accurate)" },
+  { value: "nano", label: "Nano (fast, more languages)" },
+];
+
+const ASSEMBLYAI_LANGUAGES = [
+  { value: "auto", label: "Auto-detect" },
+  { value: "en", label: "English" },
+  { value: "es", label: "Spanish" },
+  { value: "fr", label: "French" },
+  { value: "de", label: "German" },
+  { value: "it", label: "Italian" },
+  { value: "pt", label: "Portuguese" },
+  { value: "nl", label: "Dutch" },
+  { value: "hi", label: "Hindi" },
+  { value: "ja", label: "Japanese" },
+  { value: "zh", label: "Chinese" },
+  { value: "ko", label: "Korean" },
+  { value: "ru", label: "Russian" },
+  { value: "uk", label: "Ukrainian" },
+  { value: "tr", label: "Turkish" },
+];
+
+let assemblyaiTranscriptionStart = 0;
+let assemblyaiTranscriptionMeta = {};
+
+class AssemblyAIService extends HTMLElement {
+  constructor() {
+    super();
+  }
+
+  clearMediaUrl(event) {
+    event.preventDefault();
+    document.querySelector('#assemblyai-media').value = "";
+  }
+
+  clearFilePicker(event) {
+    event.preventDefault();
+    document.querySelector('#assemblyai-file').value = "";
+  }
+
+  updatePlayerWithLocalFile() {
+    const file = document.querySelector('#assemblyai-file').files[0];
+    if (!file) return;
+    document.querySelector("#hyperplayer").src = URL.createObjectURL(file);
+  }
+
+  getData() {
+    // If in caption mode, switch back to transcript view so the loader shows and
+    // the result lands in the right place (#transcript-editor-btn no-ops when
+    // already in transcript mode).
+    document.querySelector('#transcript-editor-btn')?.click();
+    document.querySelector('#hypertranscript').innerHTML =
+      '<div class="vertically-centre"><center>Transcribing….</center><br/><img src="' + transcribingSvg + '" width="50" alt="transcribing" style="margin: auto; display: block;"></div>';
+    if (typeof setTranscriptBusy === 'function') {
+      setTranscriptBusy(true);
+    }
+
+    const apiKey = document.querySelector('#assemblyai-key').value.trim();
+    const language = document.querySelector('#assemblyai-language').value;
+    const model = document.querySelector('#assemblyai-model').value;
+    const diarize = document.querySelector('#assemblyai-diarize').checked;
+    let media = document.querySelector('#assemblyai-media').value.trim();
+    const file = document.querySelector('#assemblyai-file').files[0];
+
+    if (apiKey === "" || (file === undefined && media === "")) {
+      document.querySelector('#hypertranscript').innerHTML =
+        assemblyaiErrorHtml("Please provide your AssemblyAI API key and either a media link or a file.");
+      if (typeof setTranscriptBusy === 'function') {
+        setTranscriptBusy(false);
+      }
+      return;
+    }
+
+    if (file === undefined && !/^https?:\/\//i.test(media)) {
+      media = "https://" + media;
+    }
+
+    assemblyaiTranscriptionStart = Date.now();
+    assemblyaiTranscriptionMeta = {
+      service: "AssemblyAI (cloud)",
+      model: document.querySelector('#assemblyai-model').selectedOptions[0]?.textContent || model,
+      language: document.querySelector('#assemblyai-language').selectedOptions[0]?.textContent || language,
+    };
+
+    // point the player at the media now so click-to-seek works after transcribing
+    const player = document.querySelector("#hyperplayer");
+    if (file !== undefined) {
+      player.src = URL.createObjectURL(file);
+    } else {
+      player.src = media;
+      document.querySelector('#assemblyai-media').value = "";
+    }
+
+    runAssemblyAI(apiKey, file, media, { language, model, diarize }).catch(displayAssemblyAIError);
+  }
+
+  connectedCallback() {
+    const templateSelector = this.getAttribute("templateSelector");
+    if (templateSelector === null || document.querySelector(templateSelector) === null) {
+      return;
+    }
+    this.innerHTML = document.querySelector(templateSelector).innerHTML;
+    document.querySelector(templateSelector).remove();
+    this.configureOptions();
+    addAssemblyAIListeners(this);
+  }
+
+  configureOptions() {
+    const modelSel = this.querySelector('#assemblyai-model');
+    ASSEMBLYAI_MODELS.forEach((m, i) => {
+      const o = document.createElement('option');
+      o.value = m.value;
+      o.textContent = m.label;
+      if (i === 0) o.selected = true;
+      modelSel.appendChild(o);
+    });
+    const langSel = this.querySelector('#assemblyai-language');
+    ASSEMBLYAI_LANGUAGES.forEach((l, i) => {
+      const o = document.createElement('option');
+      o.value = l.value;
+      o.textContent = l.label;
+      if (i === 0) o.selected = true;
+      langSel.appendChild(o);
+    });
+  }
+}
+customElements.define('assemblyai-service', AssemblyAIService);
+
+function addAssemblyAIListeners(el) {
+  document.querySelector('#assemblyai-file').addEventListener('change', el.clearMediaUrl);
+  document.querySelector('#assemblyai-media').addEventListener('change', el.clearFilePicker);
+  document.querySelector('#assemblyai-file').addEventListener('change', el.updatePlayerWithLocalFile);
+
+  document.querySelector('#assemblyai-submit-btn').addEventListener('click', (event) => {
+    if (document.querySelector('#assemblyai-submit-btn').classList.contains('btn-disabled')) {
+      event.preventDefault();
+      return;
+    }
+    el.getData();
+  });
+
+  // Enable TRANSCRIBE only once there's a key AND a file or media link.
+  const updateState = () => {
+    const hasFile = document.querySelector('#assemblyai-file').files.length > 0;
+    const hasMedia = document.querySelector('#assemblyai-media').value.trim() !== '';
+    const hasKey = document.querySelector('#assemblyai-key').value.trim() !== '';
+    const button = document.querySelector('#assemblyai-submit-btn');
+    if (hasKey && (hasFile || hasMedia)) {
+      button.classList.remove('btn-disabled');
+      button.setAttribute('aria-disabled', 'false');
+    } else {
+      button.classList.add('btn-disabled');
+      button.setAttribute('aria-disabled', 'true');
+    }
+  };
+  document.querySelector('#assemblyai-file').addEventListener('change', updateState);
+  document.querySelector('#assemblyai-media').addEventListener('input', updateState);
+  document.querySelector('#assemblyai-key').addEventListener('input', updateState);
+}
+
+// upload (if a file) -> submit -> poll to completion
+async function runAssemblyAI(apiKey, file, media, opts) {
+  let audioUrl = media;
+
+  if (file !== undefined) {
+    setAssemblyAIStatus("Uploading…");
+    const up = await fetch(`${ASSEMBLYAI_BASE}/upload`, {
+      method: 'POST',
+      headers: { 'Authorization': apiKey },
+      body: file,
+    });
+    if (!up.ok) throw new Error(up.status);
+    audioUrl = (await up.json()).upload_url;
+  }
+
+  setAssemblyAIStatus("Submitting…");
+  const params = {
+    audio_url: audioUrl,
+    speech_model: opts.model,
+    speaker_labels: !!opts.diarize,
+  };
+  if (opts.language === "auto") {
+    params.language_detection = true;
+  } else {
+    params.language_code = opts.language;
+  }
+
+  const submit = await fetch(`${ASSEMBLYAI_BASE}/transcript`, {
+    method: 'POST',
+    headers: { 'Authorization': apiKey, 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  });
+  if (!submit.ok) throw new Error(submit.status);
+  const id = (await submit.json()).id;
+
+  for (;;) {
+    await assemblyaiSleep(ASSEMBLYAI_POLL_MS);
+    const poll = await fetch(`${ASSEMBLYAI_BASE}/transcript/${id}`, {
+      headers: { 'Authorization': apiKey },
+    });
+    if (!poll.ok) throw new Error(poll.status);
+    const json = await poll.json();
+    if (json.status === 'completed') {
+      if (!json.words || json.words.length === 0) {
+        displayAssemblyAINoWords();
+        return;
+      }
+      assemblyaiParseData(json);
+      return;
+    }
+    if (json.status === 'error') {
+      throw new Error(json.error || 'transcription error');
+    }
+    setAssemblyAIStatus("Transcribing…");
+  }
+}
+
+function setAssemblyAIStatus(text) {
+  const el = document.querySelector('#hypertranscript .vertically-centre center');
+  if (el) el.textContent = text;
+}
+
+// Build the transcript HTML from AssemblyAI's word list (start/end in ms) — the
+// same data-m / data-d span shape the other engines produce.
+function assemblyaiParseData(json) {
+  const maxWordsInPara = 100;
+  const significantGapInSeconds = 4.0;
+  const words = json.words;
+  const showDiarization = words.some((w) => w.speaker !== null && w.speaker !== undefined);
+
+  let hyperTranscript = "<article>\n <section>\n  <p>\n   ";
+  let previousEndSec = 0;
+  let wordsInPara = 0;
+
+  const language = json.language_code || (document.querySelector('#assemblyai-language') || {}).value || "";
+  const track = document.querySelector('#hyperplayer-vtt');
+  if (track) {
+    track.label = language;
+    track.srcLang = language;
+  }
+
+  words.forEach((element, index) => {
+    const startSec = element.start / 1000;
+    const endSec = element.end / 1000;
+    wordsInPara++;
+
+    // paragraph break on a long gap (only after sentence-final punctuation) or
+    // when a paragraph gets too long
+    if ((previousEndSec !== 0 && (startSec - previousEndSec) > significantGapInSeconds) || wordsInPara > maxWordsInPara) {
+      const prevWord = (words[index - 1] && words[index - 1].text) || "";
+      const lastChar = prevWord.charAt(prevWord.length - 1);
+      if (lastChar === "." || lastChar === "?" || lastChar === "!") {
+        hyperTranscript += "\n  </p>\n  <p>\n   ";
+        wordsInPara = 0;
+      }
+    }
+
+    // new paragraph + speaker label on speaker change (or the first word)
+    if ((showDiarization && index > 0 && element.speaker !== words[index - 1].speaker) || index === 0) {
+      if (index > 0) {
+        hyperTranscript += "\n  </p>\n  <p>\n   ";
+        wordsInPara = 0;
+      }
+      if (showDiarization) {
+        hyperTranscript += `<span class="speaker" data-m='${element.start}' data-d='0'>[speaker-${element.speaker}] </span>`;
+      }
+    }
+
+    hyperTranscript += `<span data-m='${element.start}' data-d='${element.end - element.start}'>${element.text} </span>`;
+    previousEndSec = endSec;
+  });
+
+  hyperTranscript += "\n </p> \n </section>\n</article>\n ";
+  hyperTranscript = hyperTranscript.replace(/<p>\s*<\/p>\s*/g, '');
+
+  document.querySelector("#hypertranscript").innerHTML = hyperTranscript;
+
+  const showSpeakers = document.querySelector('#show-speakers');
+  document.querySelectorAll('.speaker').forEach((speaker) => {
+    speaker.style.display = (showSpeakers && showSpeakers.checked) ? "inline" : "none";
+  });
+
+  document.querySelector('#download-html').setAttribute('href', 'data:text/html,' + encodeURIComponent(hyperTranscript));
+
+  if (typeof setTranscriptionInfo === 'function' && assemblyaiTranscriptionStart !== 0) {
+    setTranscriptionInfo({ ...assemblyaiTranscriptionMeta, seconds: (Date.now() - assemblyaiTranscriptionStart) / 1000 });
+  }
+  if (typeof setTranscriptBusy === 'function') {
+    setTranscriptBusy(false);
+  }
+
+  document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+  document.dispatchEvent(new CustomEvent('hyperaudioGenerateCaptionsFromTranscript'));
+}
+
+function assemblyaiErrorHtml(message) {
+  return '<div class="vertically-centre"><img src="' + errorSvg + '" width="50" alt="error" style="margin: auto; display: block;"><br/><center>' + message + '</center></div>';
+}
+
+function displayAssemblyAIError(error) {
+  if (typeof setTranscriptBusy === 'function') {
+    setTranscriptBusy(false);
+  }
+  const e = "" + (error && error.message ? error.message : error);
+  let msg = "Sorry.<br/>An unexpected error has occurred.";
+  if (e.indexOf("401") >= 0 || e.indexOf("403") >= 0) {
+    msg = "Sorry.<br/>The API key appears to be invalid.";
+  } else if (e.indexOf("400") >= 0 || e.indexOf("422") >= 0) {
+    msg = "Sorry.<br/>The media could not be read — check the file or URL.";
+  }
+  document.querySelector('#hypertranscript').innerHTML = assemblyaiErrorHtml(msg);
+  console.error("AssemblyAI error:", error);
+}
+
+function displayAssemblyAINoWords() {
+  if (typeof setTranscriptBusy === 'function') {
+    setTranscriptBusy(false);
+  }
+  document.querySelector('#hypertranscript').innerHTML =
+    assemblyaiErrorHtml("Sorry.<br/>No words were detected.<br/>Please verify that the audio contains speech.");
+}

--- a/js/hyperaudio-lite-editor-assemblyai.js
+++ b/js/hyperaudio-lite-editor-assemblyai.js
@@ -23,8 +23,8 @@ const ASSEMBLYAI_POLL_MS = 3000;
 const assemblyaiSleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 const ASSEMBLYAI_MODELS = [
-  { value: "best", label: "Best (most accurate)" },
-  { value: "nano", label: "Nano (fast, more languages)" },
+  { value: "universal-3-5-pro", label: "Universal-3.5 Pro (highest accuracy, 18 languages)" },
+  { value: "universal-2", label: "Universal-2 (cost-effective, 99 languages)" },
 ];
 
 const ASSEMBLYAI_LANGUAGES = [
@@ -200,7 +200,7 @@ async function runAssemblyAI(apiKey, file, media, opts) {
   setAssemblyAIStatus("Submitting…");
   const params = {
     audio_url: audioUrl,
-    speech_model: opts.model,
+    speech_models: [opts.model],   // plural array; singular speech_model is deprecated
     speaker_labels: true,
   };
   if (opts.language === "auto") {

--- a/js/hyperaudio-lite-editor-assemblyai.js
+++ b/js/hyperaudio-lite-editor-assemblyai.js
@@ -83,7 +83,6 @@ class AssemblyAIService extends HTMLElement {
     const apiKey = document.querySelector('#assemblyai-key').value.trim();
     const language = document.querySelector('#assemblyai-language').value;
     const model = document.querySelector('#assemblyai-model').value;
-    const diarize = document.querySelector('#assemblyai-diarize').checked;
     let media = document.querySelector('#assemblyai-media').value.trim();
     const file = document.querySelector('#assemblyai-file').files[0];
 
@@ -116,7 +115,7 @@ class AssemblyAIService extends HTMLElement {
       document.querySelector('#assemblyai-media').value = "";
     }
 
-    runAssemblyAI(apiKey, file, media, { language, model, diarize }).catch(displayAssemblyAIError);
+    runAssemblyAI(apiKey, file, media, { language, model }).catch(displayAssemblyAIError);
   }
 
   connectedCallback() {
@@ -202,7 +201,7 @@ async function runAssemblyAI(apiKey, file, media, opts) {
   const params = {
     audio_url: audioUrl,
     speech_model: opts.model,
-    speaker_labels: !!opts.diarize,
+    speaker_labels: true,
   };
   if (opts.language === "auto") {
     params.language_detection = true;

--- a/js/transcribe-prefs.js
+++ b/js/transcribe-prefs.js
@@ -21,7 +21,7 @@
   // (Deepgram repopulates its language list from the chosen model).
   const MODEL_IDS = ['language-model', 'assemblyai-model', 'model-name-input'];
   const VALUE_IDS = ['token', 'assemblyai-key', 'language', 'assemblyai-language'];
-  const CHECK_IDS = ['assemblyai-diarize', 'deepgram-remember-key', 'assemblyai-remember-key'];
+  const CHECK_IDS = ['deepgram-remember-key', 'assemblyai-remember-key'];
   // A key is only persisted while its "remember" toggle is on (opt-out).
   const REMEMBER_MAP = { 'token': 'deepgram-remember-key', 'assemblyai-key': 'assemblyai-remember-key' };
 

--- a/js/transcribe-prefs.js
+++ b/js/transcribe-prefs.js
@@ -1,0 +1,142 @@
+/**
+ * transcribe-prefs.js
+ * (C) The Hyperaudio Project
+ * @version 0.8.1 — last changed in release 0.8.1
+ * @license MIT
+ *
+ * Remembers the Transcribe modal's choices across sessions (#390): the
+ * Local/Cloud service switch, the selected engine tab in each group, each
+ * engine's model / language / options, and the cloud API keys. Also wires the
+ * standard show/hide "eye" toggle on the key fields.
+ *
+ * The keys live in localStorage in plain text — same trust model as pasting a
+ * bring-your-own key into the page at all; convenient for a personal tool, and
+ * the user can clear site data to remove them.
+ */
+
+(function () {
+  const PREFS_KEY = 'hyperaudioTranscribePrefs';
+
+  // Text/selse inputs persisted by value. Models are restored before languages
+  // (Deepgram repopulates its language list from the chosen model).
+  const MODEL_IDS = ['language-model', 'assemblyai-model', 'model-name-input'];
+  const VALUE_IDS = ['token', 'assemblyai-key', 'language', 'assemblyai-language'];
+  const CHECK_IDS = ['assemblyai-diarize', 'deepgram-remember-key', 'assemblyai-remember-key'];
+  // A key is only persisted while its "remember" toggle is on (opt-out).
+  const REMEMBER_MAP = { 'token': 'deepgram-remember-key', 'assemblyai-key': 'assemblyai-remember-key' };
+
+  const byId = (id) => document.getElementById(id);
+
+  function savePrefs() {
+    const prefs = { values: {}, checks: {} };
+    prefs.serviceMode = byId('service-cloud') && byId('service-cloud').checked ? 'cloud' : 'local';
+    const localEngine = document.querySelector('input[name="local_tabs"]:checked');
+    const cloudEngine = document.querySelector('input[name="cloud_tabs"]:checked');
+    if (localEngine) prefs.localEngine = localEngine.getAttribute('aria-label');
+    if (cloudEngine) prefs.cloudEngine = cloudEngine.getAttribute('aria-label');
+    [...MODEL_IDS, ...VALUE_IDS].forEach((id) => {
+      const el = byId(id);
+      if (!el) return;
+      // don't persist a key whose "remember" toggle is off
+      const remId = REMEMBER_MAP[id];
+      if (remId) { const rem = byId(remId); if (rem && !rem.checked) return; }
+      prefs.values[id] = el.value;
+    });
+    CHECK_IDS.forEach((id) => { const el = byId(id); if (el) prefs.checks[id] = el.checked; });
+    try { localStorage.setItem(PREFS_KEY, JSON.stringify(prefs)); } catch (e) { /* private mode */ }
+  }
+
+  function restorePrefs() {
+    let prefs;
+    try { prefs = JSON.parse(localStorage.getItem(PREFS_KEY)); } catch (e) { return; }
+    if (!prefs) return;
+
+    // service switch (the CSS reacts to :checked to show the right group)
+    const modeEl = byId(prefs.serviceMode === 'cloud' ? 'service-cloud' : 'service-local');
+    if (modeEl) modeEl.checked = true;
+
+    // engine tab within each group
+    const selectTab = (name, label) => {
+      if (!label) return;
+      const r = document.querySelector(`input[name="${name}"][aria-label="${label}"]`);
+      if (r) r.checked = true;
+    };
+    selectTab('local_tabs', prefs.localEngine);
+    selectTab('cloud_tabs', prefs.cloudEngine);
+
+    const vals = prefs.values || {};
+    // keys + models first; dispatch change on models so dependent language lists
+    // repopulate before we set the saved language
+    ['token', 'assemblyai-key'].forEach((id) => { const el = byId(id); if (el && vals[id] != null) el.value = vals[id]; });
+    MODEL_IDS.forEach((id) => {
+      const el = byId(id);
+      if (el && vals[id] != null && hasOption(el, vals[id])) {
+        el.value = vals[id];
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    });
+    VALUE_IDS.forEach((id) => {
+      if (id === 'token' || id === 'assemblyai-key') return; // already set
+      const el = byId(id);
+      if (el && vals[id] != null && (el.tagName !== 'SELECT' || hasOption(el, vals[id]))) el.value = vals[id];
+    });
+    (prefs.checks ? Object.keys(prefs.checks) : []).forEach((id) => { const el = byId(id); if (el) el.checked = !!prefs.checks[id]; });
+
+    // let each engine re-evaluate its TRANSCRIBE button now the key is filled in
+    ['token', 'assemblyai-key', 'assemblyai-media', 'deepgram-media'].forEach((id) => {
+      const el = byId(id);
+      if (el) el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+
+  const hasOption = (select, value) =>
+    select.tagName !== 'SELECT' || Array.from(select.options).some((o) => o.value === value);
+
+  function wireSaveListeners() {
+    const ids = ['service-local', 'service-cloud', ...MODEL_IDS, ...VALUE_IDS, ...CHECK_IDS];
+    ids.forEach((id) => {
+      const el = byId(id);
+      if (el && !el.dataset.prefWired) {
+        el.dataset.prefWired = '1';
+        el.addEventListener('change', savePrefs);
+        if (el.tagName === 'INPUT' && el.type !== 'checkbox' && el.type !== 'radio') el.addEventListener('input', savePrefs);
+      }
+    });
+    document.querySelectorAll('input[name="local_tabs"], input[name="cloud_tabs"]').forEach((el) => {
+      if (!el.dataset.prefWired) { el.dataset.prefWired = '1'; el.addEventListener('change', savePrefs); }
+    });
+  }
+
+  // Standard show/hide eye toggle on any `.key-field` (password input + button).
+  function wireKeyEyes() {
+    document.querySelectorAll('.key-eye').forEach((btn) => {
+      if (btn.dataset.wired) return;
+      btn.dataset.wired = '1';
+      btn.addEventListener('click', () => {
+        const input = btn.parentElement.querySelector('input');
+        if (!input) return;
+        const reveal = input.type === 'password';
+        input.type = reveal ? 'text' : 'password';
+        const open = btn.querySelector('.eye-open');
+        const closed = btn.querySelector('.eye-closed');
+        if (open) open.style.display = reveal ? 'none' : '';
+        if (closed) closed.style.display = reveal ? '' : 'none';
+        btn.setAttribute('aria-label', reveal ? 'Hide key' : 'Show key');
+      });
+    });
+  }
+
+  function init() {
+    wireKeyEyes();
+    restorePrefs();
+    wireSaveListeners();
+  }
+
+  // Engine custom elements render their templates synchronously as the body is
+  // parsed, so by DOMContentLoaded the fields exist; a 0ms defer is belt-and-braces.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => setTimeout(init, 0));
+  } else {
+    setTimeout(init, 0);
+  }
+})();


### PR DESCRIPTION
Closes #390.

Adds AssemblyAI as a browser-only cloud transcription option and reorganises the Transcribe modal so it scales past four engines.

### AssemblyAI (Cloud) tab
- New `js/hyperaudio-lite-editor-assemblyai.js` (`assemblyai-service`), mirroring the Deepgram client but using AssemblyAI's async flow — **upload → submit → poll** — all direct `fetch` calls with the user's own key (the REST API is CORS-open, verified). Word list (start/end in ms) parses into the same `data-m`/`data-d` spans as the other engines.
- Model dropdown: **Universal-3.5 Pro** (default) and **Universal-2** (cost-effective, 99 languages), sent as the current `speech_models` array. Auto-detect or explicit language; speaker labels always on (matching Deepgram).

### Transcribe modal: Local / Cloud switch
- A CSS-only segmented **Local ‖ Cloud** switch; each side shows just its engines as tabs (Parakeet/Whisper · AssemblyAI/Deepgram, alphabetical). Scales cleanly past four.

### Remembered choices + key handling
- `js/transcribe-prefs.js` persists the service switch, selected engine, model/language, and API keys in localStorage; restored on load.
- Deepgram token + AssemblyAI key are password fields with a show/hide **eye** toggle.
- Per-key **"Remember key on this device"** toggle (default on); opting out stops persisting and drops any stored copy.

### Notes
- Keys live in localStorage in plain text (same trust model as pasting a bring-your-own key); the opt-out covers shared machines.
- Model field values confirmed against AssemblyAI's current API docs; a live transcription is the final check.
