### PR TITLE
Add Parakeet (HuggingFace) cloud transcription tab (#307)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.8.1 (last changed in release 0.8.1) -->
+<!--  Hyperaudio Lite Editor - Version 0.8.2 (last changed in release 0.8.2) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.8.1">
+  <meta name="version" content="0.8.2">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -43,7 +43,8 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hls-source.js?v=0.6.26"></script>
   <script src="js/hyperaudio-lite-editor-deepgram.js?v=0.6.7"></script>
   <script src="js/hyperaudio-lite-editor-assemblyai.js?v=0.8.1"></script>
-  <script src="js/transcribe-prefs.js?v=0.8.1"></script>
+  <script src="js/hyperaudio-lite-editor-parakeet.js?v=0.8.2"></script>
+  <script src="js/transcribe-prefs.js?v=0.8.2"></script>
   <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.26"></script>
   <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.7.0"></script>
   <script src="js/word-alignment.js"></script>
@@ -181,6 +182,36 @@ If you are creating an open source application under a license compatible with t
       </div>
       <div class="modal-action">
         <label id="assemblyai-submit-btn" for="transcribe-modal" class="btn btn-primary btn-disabled" aria-disabled="true">TRANSCRIBE</label>
+      </div>
+    </form>
+  </template>
+
+  <template id="parakeet-hf-modal-template">
+    <form id="parakeet-hf-form" name="parakeet-hf-form">
+      <div class="flex flex-col gap-4 w-full">
+        <div class="key-field">
+          <input id="parakeet-hf-key" type="password" placeholder="HuggingFace token" class="input input-bordered w-full" />
+          <button type="button" class="key-eye" aria-label="Show key" tabindex="-1">
+            <svg class="eye-open" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+            <svg class="eye-closed" style="display:none" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
+          </button>
+        </div>
+        <label style="display:flex; gap:8px; align-items:center; cursor:pointer">
+          <input id="parakeet-hf-remember-key" type="checkbox" class="toggle toggle-primary" checked />
+          <span class="label-text" style="font-size:0.85rem; opacity:0.85">Remember key on this device</span>
+        </label>
+        <span class="label-text" style="font-size:0.8rem; opacity:0.7">Create a free token at huggingface.co/settings/tokens</span>
+        <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
+        <input id="parakeet-hf-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
+        <span class="label-text">or</span>
+        <input id="parakeet-hf-file" name="file" type="file" class="file-input w-full max-w-xs" title="" />
+        <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
+
+        <span class="label-text">Language</span>
+        <select id="parakeet-hf-language" name="parakeet-hf-language" class="select select-bordered w-full max-w-xs"></select>
+      </div>
+      <div class="modal-action">
+        <label id="parakeet-hf-submit-btn" for="transcribe-modal" class="btn btn-primary btn-disabled" aria-disabled="true">TRANSCRIBE</label>
       </div>
     </form>
   </template>
@@ -825,6 +856,10 @@ If you are creating an open source application under a license compatible with t
           <input type="radio" name="cloud_tabs" role="tab" class="tab" style="width:150px; white-space:nowrap" aria-label="Deepgram" />
           <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
             <deepgram-service templateSelector="#deepgram-modal-template"></deepgram-service>
+          </div>
+          <input type="radio" name="cloud_tabs" role="tab" class="tab" style="width:150px; white-space:nowrap" aria-label="Parakeet (HF)" />
+          <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-10">
+            <parakeet-hf-service templateSelector="#parakeet-hf-modal-template"></parakeet-hf-service>
           </div>
         </div>
       </div>

--- a/js/hyperaudio-lite-editor-parakeet.js
+++ b/js/hyperaudio-lite-editor-parakeet.js
@@ -1,0 +1,306 @@
+/**
+ * hyperaudio-lite-editor-parakeet.js
+ * (C) The Hyperaudio Project
+ * @version 0.8.2 — last changed in release 0.8.2
+ * @license MIT
+ *
+ * Parakeet (HuggingFace) cloud transcription (#307) — NVIDIA Parakeet TDT 0.6B
+ * v3 served through HuggingFace's inference router, called directly from the
+ * browser with the user's own HF token (no server; the router endpoint is
+ * CORS-open). Unlike AssemblyAI's async upload→poll, this is a single
+ * synchronous multipart POST (like Deepgram):
+ *
+ *   POST router.huggingface.co/together/v1/audio/transcriptions
+ *     model=nvidia/parakeet-tdt-0.6b-v3, file=<audio>,
+ *     response_format=verbose_json, timestamp_granularities[]=word
+ *
+ * Response (verified): { language, duration, text, words:[{word,start,end}] }
+ * with start/end in SECONDS. Parsed into the same data-m/data-d spans the other
+ * engines emit; no speaker labels (Parakeet doesn't diarize). Reuses the global
+ * helpers transcribingSvg / errorSvg and setTranscriptBusy / setTranscriptionInfo.
+ */
+
+const PARAKEET_HF_ENDPOINT = "https://router.huggingface.co/together/v1/audio/transcriptions";
+const PARAKEET_HF_MODEL = "nvidia/parakeet-tdt-0.6b-v3";
+
+// Parakeet TDT 0.6B v3 — 25 European languages. "auto" omits the language field
+// (the endpoint auto-detects, verified).
+const PARAKEET_HF_LANGUAGES = [
+  { value: "auto", label: "Auto-detect" },
+  { value: "bg", label: "Bulgarian" },
+  { value: "hr", label: "Croatian" },
+  { value: "cs", label: "Czech" },
+  { value: "da", label: "Danish" },
+  { value: "nl", label: "Dutch" },
+  { value: "en", label: "English" },
+  { value: "et", label: "Estonian" },
+  { value: "fi", label: "Finnish" },
+  { value: "fr", label: "French" },
+  { value: "de", label: "German" },
+  { value: "el", label: "Greek" },
+  { value: "hu", label: "Hungarian" },
+  { value: "it", label: "Italian" },
+  { value: "lv", label: "Latvian" },
+  { value: "lt", label: "Lithuanian" },
+  { value: "mt", label: "Maltese" },
+  { value: "pl", label: "Polish" },
+  { value: "pt", label: "Portuguese" },
+  { value: "ro", label: "Romanian" },
+  { value: "ru", label: "Russian" },
+  { value: "sk", label: "Slovak" },
+  { value: "sl", label: "Slovenian" },
+  { value: "es", label: "Spanish" },
+  { value: "sv", label: "Swedish" },
+  { value: "uk", label: "Ukrainian" },
+];
+
+let parakeetHfTranscriptionStart = 0;
+let parakeetHfTranscriptionMeta = {};
+
+class ParakeetHFService extends HTMLElement {
+  constructor() {
+    super();
+  }
+
+  clearMediaUrl(event) {
+    event.preventDefault();
+    document.querySelector('#parakeet-hf-media').value = "";
+  }
+
+  clearFilePicker(event) {
+    event.preventDefault();
+    document.querySelector('#parakeet-hf-file').value = "";
+  }
+
+  updatePlayerWithLocalFile() {
+    const file = document.querySelector('#parakeet-hf-file').files[0];
+    if (!file) return;
+    document.querySelector("#hyperplayer").src = URL.createObjectURL(file);
+  }
+
+  getData() {
+    document.querySelector('#transcript-editor-btn')?.click();
+    document.querySelector('#hypertranscript').innerHTML =
+      '<div class="vertically-centre"><center>Transcribing….</center><br/><img src="' + transcribingSvg + '" width="50" alt="transcribing" style="margin: auto; display: block;"></div>';
+    if (typeof setTranscriptBusy === 'function') {
+      setTranscriptBusy(true);
+    }
+
+    const apiKey = document.querySelector('#parakeet-hf-key').value.trim();
+    const language = document.querySelector('#parakeet-hf-language').value;
+    let media = document.querySelector('#parakeet-hf-media').value.trim();
+    const file = document.querySelector('#parakeet-hf-file').files[0];
+
+    if (apiKey === "" || (file === undefined && media === "")) {
+      document.querySelector('#hypertranscript').innerHTML =
+        parakeetHfErrorHtml("Please provide your HuggingFace token and either a media link or a file.");
+      if (typeof setTranscriptBusy === 'function') {
+        setTranscriptBusy(false);
+      }
+      return;
+    }
+
+    if (file === undefined && !/^https?:\/\//i.test(media)) {
+      media = "https://" + media;
+    }
+
+    parakeetHfTranscriptionStart = Date.now();
+    parakeetHfTranscriptionMeta = {
+      service: "Parakeet (HuggingFace, cloud)",
+      model: "Parakeet TDT 0.6B v3",
+      language: document.querySelector('#parakeet-hf-language').selectedOptions[0]?.textContent || language,
+    };
+
+    const player = document.querySelector("#hyperplayer");
+    if (file !== undefined) {
+      player.src = URL.createObjectURL(file);
+    } else {
+      player.src = media;
+      document.querySelector('#parakeet-hf-media').value = "";
+    }
+
+    runParakeetHF(apiKey, file, media, { language }).catch(displayParakeetHfError);
+  }
+
+  connectedCallback() {
+    const templateSelector = this.getAttribute("templateSelector");
+    if (templateSelector === null || document.querySelector(templateSelector) === null) {
+      return;
+    }
+    this.innerHTML = document.querySelector(templateSelector).innerHTML;
+    document.querySelector(templateSelector).remove();
+    this.configureOptions();
+    addParakeetHFListeners(this);
+  }
+
+  configureOptions() {
+    const langSel = this.querySelector('#parakeet-hf-language');
+    PARAKEET_HF_LANGUAGES.forEach((l, i) => {
+      const o = document.createElement('option');
+      o.value = l.value;
+      o.textContent = l.label;
+      if (i === 0) o.selected = true;
+      langSel.appendChild(o);
+    });
+  }
+}
+customElements.define('parakeet-hf-service', ParakeetHFService);
+
+function addParakeetHFListeners(el) {
+  document.querySelector('#parakeet-hf-file').addEventListener('change', el.clearMediaUrl);
+  document.querySelector('#parakeet-hf-media').addEventListener('change', el.clearFilePicker);
+  document.querySelector('#parakeet-hf-file').addEventListener('change', el.updatePlayerWithLocalFile);
+
+  document.querySelector('#parakeet-hf-submit-btn').addEventListener('click', (event) => {
+    if (document.querySelector('#parakeet-hf-submit-btn').classList.contains('btn-disabled')) {
+      event.preventDefault();
+      return;
+    }
+    el.getData();
+  });
+
+  const updateState = () => {
+    const hasFile = document.querySelector('#parakeet-hf-file').files.length > 0;
+    const hasMedia = document.querySelector('#parakeet-hf-media').value.trim() !== '';
+    const hasKey = document.querySelector('#parakeet-hf-key').value.trim() !== '';
+    const button = document.querySelector('#parakeet-hf-submit-btn');
+    if (hasKey && (hasFile || hasMedia)) {
+      button.classList.remove('btn-disabled');
+      button.setAttribute('aria-disabled', 'false');
+    } else {
+      button.classList.add('btn-disabled');
+      button.setAttribute('aria-disabled', 'true');
+    }
+  };
+  document.querySelector('#parakeet-hf-file').addEventListener('change', updateState);
+  document.querySelector('#parakeet-hf-media').addEventListener('input', updateState);
+  document.querySelector('#parakeet-hf-key').addEventListener('input', updateState);
+}
+
+// Single synchronous multipart POST. For a URL the media is fetched client-side
+// and forwarded as a Blob (the endpoint takes a file, not a URL), so a
+// cross-origin media host without CORS will fail here with a clear message.
+async function runParakeetHF(apiKey, file, media, opts) {
+  let blob = file;
+  let filename = file ? file.name : 'audio';
+  if (!blob) {
+    let mediaResp;
+    try {
+      mediaResp = await fetch(media);
+      if (!mediaResp.ok) throw new Error('media ' + mediaResp.status);
+    } catch (e) {
+      throw new Error('media-fetch');
+    }
+    blob = await mediaResp.blob();
+    filename = media.split('/').pop() || 'audio';
+  }
+
+  const form = new FormData();
+  form.append('model', PARAKEET_HF_MODEL);
+  form.append('file', blob, filename);
+  form.append('response_format', 'verbose_json');
+  form.append('timestamp_granularities[]', 'word');
+  if (opts.language && opts.language !== 'auto') {
+    form.append('language', opts.language);
+  }
+
+  const resp = await fetch(PARAKEET_HF_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Authorization': 'Bearer ' + apiKey },
+    body: form,
+  });
+  if (!resp.ok) throw new Error(resp.status);
+
+  const json = await resp.json();
+  if (!json.words || json.words.length === 0) {
+    displayParakeetHfNoWords();
+    return;
+  }
+  parakeetHfParseData(json);
+}
+
+// Build transcript HTML from the word list (start/end in SECONDS). No speaker
+// labels — Parakeet doesn't diarize.
+function parakeetHfParseData(json) {
+  const maxWordsInPara = 100;
+  const significantGapInSeconds = 4.0;
+  const words = json.words;
+
+  let hyperTranscript = "<article>\n <section>\n  <p>\n   ";
+  let previousEndSec = 0;
+  let wordsInPara = 0;
+
+  const language = json.language || "";
+  const track = document.querySelector('#hyperplayer-vtt');
+  if (track) {
+    track.label = language;
+    track.srcLang = language;
+  }
+
+  words.forEach((element, index) => {
+    const startMs = Math.round(element.start * 1000);
+    const durMs = Math.round((element.end - element.start) * 1000);
+    wordsInPara++;
+
+    if ((previousEndSec !== 0 && (element.start - previousEndSec) > significantGapInSeconds) || wordsInPara > maxWordsInPara) {
+      const prevWord = (words[index - 1] && words[index - 1].word) || "";
+      const lastChar = prevWord.charAt(prevWord.length - 1);
+      if (lastChar === "." || lastChar === "?" || lastChar === "!") {
+        hyperTranscript += "\n  </p>\n  <p>\n   ";
+        wordsInPara = 0;
+      }
+    }
+
+    hyperTranscript += `<span data-m='${startMs}' data-d='${durMs}'>${element.word} </span>`;
+    previousEndSec = element.end;
+  });
+
+  hyperTranscript += "\n </p> \n </section>\n</article>\n ";
+  hyperTranscript = hyperTranscript.replace(/<p>\s*<\/p>\s*/g, '');
+
+  document.querySelector("#hypertranscript").innerHTML = hyperTranscript;
+  document.querySelector('#download-html').setAttribute('href', 'data:text/html,' + encodeURIComponent(hyperTranscript));
+
+  if (typeof setTranscriptionInfo === 'function' && parakeetHfTranscriptionStart !== 0) {
+    setTranscriptionInfo({ ...parakeetHfTranscriptionMeta, seconds: (Date.now() - parakeetHfTranscriptionStart) / 1000 });
+  }
+  if (typeof setTranscriptBusy === 'function') {
+    setTranscriptBusy(false);
+  }
+
+  document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+  document.dispatchEvent(new CustomEvent('hyperaudioGenerateCaptionsFromTranscript'));
+}
+
+function parakeetHfErrorHtml(message) {
+  return '<div class="vertically-centre"><img src="' + errorSvg + '" width="50" alt="error" style="margin: auto; display: block;"><br/><center>' + message + '</center></div>';
+}
+
+function displayParakeetHfError(error) {
+  if (typeof setTranscriptBusy === 'function') {
+    setTranscriptBusy(false);
+  }
+  const e = "" + (error && error.message ? error.message : error);
+  let msg = "Sorry.<br/>An unexpected error has occurred.";
+  if (e.indexOf("media-fetch") >= 0) {
+    msg = "Sorry.<br/>Couldn't fetch that media URL from the browser (it may block cross-origin requests). Try uploading the file instead.";
+  } else if (e.indexOf("401") >= 0 || e.indexOf("403") >= 0) {
+    msg = "Sorry.<br/>The HuggingFace token appears to be invalid.";
+  } else if (e.indexOf("402") >= 0) {
+    msg = "Sorry.<br/>Your HuggingFace inference quota is exhausted. Add a paid plan or try another provider.";
+  } else if (e.indexOf("400") >= 0 || e.indexOf("422") >= 0) {
+    msg = "Sorry.<br/>The request was rejected — the media may be unreadable or the model unavailable.";
+  } else if (e.indexOf("503") >= 0 || e.indexOf("500") >= 0) {
+    msg = "Sorry.<br/>HuggingFace inference is unavailable right now — try again shortly.";
+  }
+  document.querySelector('#hypertranscript').innerHTML = parakeetHfErrorHtml(msg);
+  console.error("Parakeet (HF) error:", error);
+}
+
+function displayParakeetHfNoWords() {
+  if (typeof setTranscriptBusy === 'function') {
+    setTranscriptBusy(false);
+  }
+  document.querySelector('#hypertranscript').innerHTML =
+    parakeetHfErrorHtml("Sorry.<br/>No words were detected.<br/>Please verify that the audio contains speech.");
+}

--- a/js/transcribe-prefs.js
+++ b/js/transcribe-prefs.js
@@ -1,7 +1,7 @@
 /**
  * transcribe-prefs.js
  * (C) The Hyperaudio Project
- * @version 0.8.1 — last changed in release 0.8.1
+ * @version 0.8.2 — last changed in release 0.8.2
  * @license MIT
  *
  * Remembers the Transcribe modal's choices across sessions (#390): the
@@ -20,10 +20,14 @@
   // Text/selse inputs persisted by value. Models are restored before languages
   // (Deepgram repopulates its language list from the chosen model).
   const MODEL_IDS = ['language-model', 'assemblyai-model', 'model-name-input'];
-  const VALUE_IDS = ['token', 'assemblyai-key', 'language', 'assemblyai-language'];
-  const CHECK_IDS = ['deepgram-remember-key', 'assemblyai-remember-key'];
+  const VALUE_IDS = ['token', 'assemblyai-key', 'parakeet-hf-key', 'language', 'assemblyai-language', 'parakeet-hf-language'];
+  const CHECK_IDS = ['deepgram-remember-key', 'assemblyai-remember-key', 'parakeet-hf-remember-key'];
   // A key is only persisted while its "remember" toggle is on (opt-out).
-  const REMEMBER_MAP = { 'token': 'deepgram-remember-key', 'assemblyai-key': 'assemblyai-remember-key' };
+  const REMEMBER_MAP = {
+    'token': 'deepgram-remember-key',
+    'assemblyai-key': 'assemblyai-remember-key',
+    'parakeet-hf-key': 'parakeet-hf-remember-key',
+  };
 
   const byId = (id) => document.getElementById(id);
 
@@ -83,7 +87,7 @@
     (prefs.checks ? Object.keys(prefs.checks) : []).forEach((id) => { const el = byId(id); if (el) el.checked = !!prefs.checks[id]; });
 
     // let each engine re-evaluate its TRANSCRIBE button now the key is filled in
-    ['token', 'assemblyai-key', 'assemblyai-media', 'deepgram-media'].forEach((id) => {
+    ['token', 'assemblyai-key', 'parakeet-hf-key', 'assemblyai-media', 'deepgram-media', 'parakeet-hf-media'].forEach((id) => {
       const el = byId(id);
       if (el) el.dispatchEvent(new Event('input', { bubbles: true }));
     });


### PR DESCRIPTION
Closes #307.

Adds a third **Cloud** transcription engine: NVIDIA **Parakeet TDT 0.6B v3** served through HuggingFace's inference router, called directly from the browser with the user's own HF token — no server.

### Verification (the reason #307 is unblocked)
Re-checked against the live endpoint with a real token:
- The router endpoint is CORS-open (`access-control-allow-origin: *`).
- `nvidia/parakeet-tdt-0.6b-v3` transcribes via `POST router.huggingface.co/together/v1/audio/transcriptions` with `response_format=verbose_json` + `timestamp_granularities[]=word`.
- Response shape: `{ language, duration, text, words:[{ id, word, start, end }] }` with start/end in **seconds**.
- The earlier concern from huggingface.js#2225 ("Model not supported by provider together") **did not reproduce** — appears to have been provider/billing-specific; the direct provider path works.

### Implementation
- New `js/hyperaudio-lite-editor-parakeet.js` (`parakeet-hf-service`): a single **synchronous** multipart POST (like Deepgram, not AssemblyAI's poll). Parses the word list (seconds → `data-m`/`data-d`). No speaker labels (Parakeet doesn't diarize). Clear errors for invalid token (401/403), quota (402), unreadable media/model (400/422), inference down (5xx), and cross-origin media-fetch failures.
- 25-language dropdown + Auto-detect (omits the language field).
- Reuses the eye show/hide, **remember-key opt-out** and localStorage persistence from the AssemblyAI work. Cloud group is now **AssemblyAI · Deepgram · Parakeet (HF)** (alphabetical).
- Version markers → 0.8.2.

### Notes
- Keys live in localStorage in plain text (same trust model as any bring-your-own key); covered by the per-key remember opt-out.
- URL-mode fetches the media client-side and forwards it as a Blob (the endpoint takes a file, not a URL), so a media host without CORS surfaces a clear "upload the file instead" error.
