### PR TITLE
Bug sweep: escaping, storage correctness, round-trip losses, style scrub, caret preservation + canonical export formatting

### DIFF
--- a/__TEST__/e2e/serialization.spec.mjs
+++ b/__TEST__/e2e/serialization.spec.mjs
@@ -1,0 +1,58 @@
+// Canonical export serialization: the HTML / interactive-transcript exports
+// must emit clean, consistently formatted markup — one span per line, two-space
+// indents, data-m before data-d, speaker class kept, runtime noise dropped —
+// instead of raw contenteditable innerHTML.
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+});
+
+test('serializeTranscriptHtml emits canonical one-span-per-line markup', async ({ page }) => {
+  const html = await page.evaluate(() =>
+    window.serializeTranscriptHtml(document.querySelector('#hypertranscript')));
+  const lines = html.split('\n');
+
+  expect(lines[0]).toBe('<article>');
+  expect(lines[1]).toBe('  <section>');
+  expect(lines[2]).toBe('    <p>');
+  expect(lines[lines.length - 2]).toBe('  </section>');
+  expect(lines[lines.length - 1]).toBe('</article>');
+
+  const spanLines = lines.filter((l) => l.includes('<span'));
+  expect(spanLines.length).toBeGreaterThan(50);
+  for (const l of spanLines) {
+    expect(l).toMatch(/^      <span data-m="\d+"( data-d="\d+")?/);   // 6-space indent, m before d
+    expect((l.match(/<span/g) || []).length).toBe(1);                 // one span per line
+    expect(l).not.toMatch(/class="(?!speaker)/);                      // no runtime classes
+  }
+  // the speaker label keeps its semantic class, after data-m/data-d
+  expect(html).toMatch(/<span data-m="\d+" data-d="0" class="speaker">\[Monika\] <\/span>/);
+});
+
+test('the HTML download reflects canonical serialization after the sanitise tick', async ({ page }) => {
+  await page.evaluate(() => {
+    document.querySelector('#hypertranscript').focus();
+    document.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
+  });
+  await page.waitForTimeout(1400); // past the 1s debounce
+  const href = await page.evaluate(() =>
+    decodeURIComponent(document.querySelector('#download-html').getAttribute('href').replace('data:text/html,', '')));
+  expect(href.split('\n')[0]).toBe('<article>');
+  expect(href).toMatch(/\n      <span data-m="\d+" data-d="\d+">/);
+  expect(href).not.toMatch(/class="unread"|class="read"/);
+});
+
+test('strikethrough survives serialization; word text is escaped', async ({ page }) => {
+  const html = await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    const spans = [...t.querySelectorAll('span[data-m]')].filter((s) => !s.classList.contains('speaker'));
+    spans[1].style.textDecoration = 'line-through';
+    spans[2].textContent = '<inaudible> ';
+    return window.serializeTranscriptHtml(t);
+  });
+  expect(html).toMatch(/style="text-decoration: line-through;">/);
+  expect(html).toMatch(/&lt;inaudible&gt; /);
+  expect(html).not.toMatch(/<inaudible>/);
+});

--- a/__TEST__/e2e/serialization.spec.mjs
+++ b/__TEST__/e2e/serialization.spec.mjs
@@ -44,6 +44,26 @@ test('the HTML download reflects canonical serialization after the sanitise tick
   expect(href).not.toMatch(/class="unread"|class="read"/);
 });
 
+test('HTML→JSON→HTML round trip preserves every word, incl. zero-duration and no-data-d (#408)', async ({ page }) => {
+  const r = await page.evaluate(() => {
+    const html = `<article><section>
+      <p><span data-m="1000" data-d="0" class="speaker">[A] </span>
+         <span data-m="1000" data-d="500">one </span>
+         <span data-m="1600">nodur </span>
+         <span data-m="2000" data-d="0">zerolast </span></p>
+      <p><span data-m="5000" data-d="0" class="speaker">[B] </span>
+         <span data-m="5000" data-d="400">two </span></p>
+    </section></article>`;
+    const json = htmlToJSON(html);
+    const back = jsonToHTML(json);
+    return { jsonWords: json.words.map((w) => w.text), back };
+  });
+  expect(r.jsonWords).toEqual(['one', 'nodur', 'zerolast', 'two']);
+  for (const w of ['one ', 'nodur ', 'zerolast ', 'two ']) {
+    expect(r.back).toContain(`>${w}</span>`);
+  }
+});
+
 test('strikethrough survives serialization; word text is escaped', async ({ page }) => {
   const html = await page.evaluate(() => {
     const t = document.querySelector('#hypertranscript');

--- a/__TEST__/e2e/span-merge.spec.mjs
+++ b/__TEST__/e2e/span-merge.spec.mjs
@@ -202,6 +202,61 @@ test('the caret survives join/split normalization on the debounced pass', async 
   expect(await page.evaluate(() => getSelection().anchorNode.nodeValue)).toContain('HyperaudioLite');
 });
 
+test('a non-collapsed selection survives a rewrite on the debounced pass', async ({ page }) => {
+  await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    t.focus();
+    const spans = [...t.querySelectorAll('span[data-m]')].filter((s) => !s.classList.contains('speaker'));
+    spans[1].textContent = spans[1].textContent.replace(/\s+$/, '');  // pending join elsewhere
+    const makes = spans.find((s) => s.textContent.trim() === 'makes');
+    const sel = getSelection();
+    const r = document.createRange();
+    r.setStart(makes.firstChild, 0);
+    r.setEnd(makes.firstChild, 5);                                    // "makes" selected
+    sel.removeAllRanges();
+    sel.addRange(r);
+    document.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
+  });
+  await page.waitForTimeout(1400);
+  expect(await page.evaluate(() => getSelection().toString())).toBe('makes');
+});
+
+test('merge and split in the same pass still re-index wordArr (net-zero span count)', async ({ page }) => {
+  const r = await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    const spans = [...t.querySelectorAll('span[data-m]')].filter((s) => !s.classList.contains('speaker'));
+    spans[5].textContent = spans[5].textContent.replace(/\s+$/, '');                        // join: −1 span
+    spans[8].textContent = spans[8].textContent.trim().replace(/^(..)/, '$1 ') + ' ';       // split: +1 span
+    t.dispatchEvent(new Event('blur'));
+    const domNodes = [...t.querySelectorAll('span[data-m]')];
+    const arrNodes = window.hyperaudioInstance.wordArr.map((w) => w.n);
+    return {
+      sameLength: domNodes.length === arrNodes.length,
+      allLive: arrNodes.every((n) => domNodes.includes(n)),
+      allIndexed: domNodes.every((n) => arrNodes.includes(n)),
+    };
+  });
+  expect(r).toEqual({ sameLength: true, allLive: true, allIndexed: true });
+});
+
+test('normalization is skipped during IME composition and runs after it ends', async ({ page }) => {
+  const r = await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    t.focus();
+    const spans = [...t.querySelectorAll('span[data-m]')].filter((s) => !s.classList.contains('speaker'));
+    const a = spans[10];
+    a.textContent = a.textContent.replace(/\s+$/, '');                // pending join
+    document.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    t.dispatchEvent(new Event('blur'));
+    const untouchedWhileComposing = a.isConnected && !/\s$/.test(a.textContent);
+    document.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+    t.dispatchEvent(new Event('blur'));
+    const mergedAfter = !a.isConnected || /\s$/.test(a.textContent);
+    return { untouchedWhileComposing, mergedAfter };
+  });
+  expect(r).toEqual({ untouchedWhileComposing: true, mergedAfter: true });
+});
+
 test('a clean transcript is untouched on blur (no spurious merges)', async ({ page }) => {
   const { before, after } = await page.evaluate(() => {
     const t = document.querySelector('#hypertranscript');

--- a/__TEST__/e2e/span-merge.spec.mjs
+++ b/__TEST__/e2e/span-merge.spec.mjs
@@ -166,6 +166,42 @@ test('contenteditable style pollution is scrubbed; functional styles survive (#4
   });
 });
 
+test('the caret survives join/split normalization on the debounced pass', async ({ page }) => {
+  // The repairs rewrite text nodes, which used to throw the caret to the start
+  // of the affected word mid-edit. It's now saved as a character offset and
+  // re-resolved after the pass.
+  const abs = () => page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    const sel = getSelection();
+    if (!sel.rangeCount) return null;
+    const r = sel.getRangeAt(0);
+    const pre = document.createRange();
+    pre.selectNodeContents(t);
+    pre.setEnd(r.startContainer, r.startOffset);
+    return pre.toString().length;
+  });
+
+  await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    t.focus();
+    const spans = [...t.querySelectorAll('span[data-m]')].filter((s) => !s.classList.contains('speaker'));
+    const a = spans[1];
+    a.textContent = a.textContent.replace(/\s+$/, '');   // join: user deleted the boundary space
+    const sel = getSelection();
+    const r = document.createRange();
+    r.setStart(a.firstChild, a.firstChild.length);       // caret at the join point
+    r.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(r);
+    document.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
+  });
+  const before = await abs();
+  await page.waitForTimeout(1400);                       // debounced sanitise fires
+  expect(await abs()).toBe(before);
+  // and the merge actually happened (caret preserved on the merged span)
+  expect(await page.evaluate(() => getSelection().anchorNode.nodeValue)).toContain('HyperaudioLite');
+});
+
 test('a clean transcript is untouched on blur (no spurious merges)', async ({ page }) => {
   const { before, after } = await page.evaluate(() => {
     const t = document.querySelector('#hypertranscript');

--- a/__TEST__/e2e/span-merge.spec.mjs
+++ b/__TEST__/e2e/span-merge.spec.mjs
@@ -134,6 +134,38 @@ test('typing a speaker name gets labelled as a speaker, not split as words (#416
   expect(r.wordD).toBe(r.orig.d);
 });
 
+test('contenteditable style pollution is scrubbed; functional styles survive (#415)', async ({ page }) => {
+  const r = await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    const spans = [...t.querySelectorAll('span[data-m]')].filter((s) => !s.classList.contains('speaker'));
+    // WebKit-style pollution: font-size on a word, a style-only wrapper span
+    spans[1].setAttribute('style', 'font-size: 13pt;');
+    spans[1].insertAdjacentHTML('afterend', '<span style="font-size: 13pt;"> </span>');
+    // functional styles that MUST survive: a struck word, a hidden speaker
+    spans[2].style.textDecoration = 'line-through';
+    spans[2].style.fontSize = '13pt';                    // struck + polluted
+    const speaker = t.querySelector('span.speaker');
+    if (speaker) speaker.style.display = 'none';
+    t.dispatchEvent(new Event('blur'));
+    return {
+      pollutedGone: !spans[1].hasAttribute('style'),
+      wrapperGone: t.querySelector('span[style*="font-size"]:not([data-m])') === null,
+      struckKept: spans[2].style.textDecoration.includes('line-through'),
+      struckPollutionGone: spans[2].style.fontSize === '',
+      speakerDisplayKept: speaker ? speaker.style.display === 'none' : true,
+      textIntact: spans[1].textContent.length > 0,
+    };
+  });
+  expect(r).toEqual({
+    pollutedGone: true,
+    wrapperGone: true,
+    struckKept: true,
+    struckPollutionGone: true,
+    speakerDisplayKept: true,
+    textIntact: true,
+  });
+});
+
 test('a clean transcript is untouched on blur (no spurious merges)', async ({ page }) => {
   const { before, after } = await page.evaluate(() => {
     const t = document.querySelector('#hypertranscript');

--- a/__TEST__/e2e/storage.spec.mjs
+++ b/__TEST__/e2e/storage.spec.mjs
@@ -1,0 +1,76 @@
+// Storage picker regression net (#410): saved projects are referenced by KEY
+// STRING, not by storage.key(i) position — positional indices shift whenever
+// any other module writes a key (the transcribe prefs do so on every toggle),
+// which loaded the wrong entry or threw. Also: corrupted entries must not kill
+// the click handler, and filenames must render as text, not markup.
+import { test, expect } from '@playwright/test';
+
+const seed = (page) => page.evaluate(() => {
+  localStorage.clear();
+  const entry = (text) => JSON.stringify({
+    hypertranscript: `<article><section><p><span data-m="0" data-d="500">${text} </span></p></section></article>`,
+    video: 'https://example.com/a.mp3',
+    summary: 's', topics: [],
+  });
+  localStorage.setItem('alpha.hyperaudio', entry('ALPHA'));
+  localStorage.setItem('beta.hyperaudio', entry('BETA'));
+  loadLocalStorageOptions();
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+});
+
+test('clicking a file loads that file even after other keys shift the order (#410)', async ({ page }) => {
+  await seed(page);
+  // shift the key landscape AFTER the list rendered — this is what the
+  // prefs/export modules do at arbitrary times
+  await page.evaluate(() => {
+    localStorage.setItem('aaa-unrelated', 'x');
+    localStorage.removeItem('aaa-unrelated');
+    localStorage.setItem('hyperaudioTranscribePrefs', '{"serviceMode":"local"}');
+  });
+  await page.evaluate(() => {
+    [...document.querySelectorAll('.file-item')].find((a) => a.textContent === 'beta').click();
+  });
+  await page.waitForTimeout(300);
+  const loaded = await page.evaluate(() => document.querySelector('#hypertranscript').textContent);
+  expect(loaded).toContain('BETA');
+  expect(loaded).not.toContain('ALPHA');
+});
+
+test('a corrupted entry does not throw and the picker keeps working (#410)', async ({ page }) => {
+  await seed(page);
+  const errors = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  await page.evaluate(() => {
+    localStorage.setItem('broken.hyperaudio', '{not json');
+    loadLocalStorageOptions();
+  });
+  await page.evaluate(() => {
+    [...document.querySelectorAll('.file-item')].find((a) => a.textContent === 'broken').click();
+  });
+  await page.evaluate(() => {
+    [...document.querySelectorAll('.file-item')].find((a) => a.textContent === 'alpha').click();
+  });
+  await page.waitForTimeout(300);
+  expect(errors).toEqual([]);
+  expect(await page.evaluate(() => document.querySelector('#hypertranscript').textContent)).toContain('ALPHA');
+});
+
+test('a filename containing markup renders as text (#410)', async ({ page }) => {
+  await seed(page);
+  await page.evaluate(() => {
+    localStorage.setItem('<img src=x onerror=window.__xss=1>.hyperaudio', localStorage.getItem('alpha.hyperaudio'));
+    loadLocalStorageOptions();
+  });
+  const r = await page.evaluate(() => ({
+    xss: window.__xss === 1,
+    itemTexts: [...document.querySelectorAll('.file-item')].map((a) => a.textContent),
+    imgInPicker: document.querySelector('#file-picker img') !== null,
+  }));
+  expect(r.xss).toBe(false);
+  expect(r.imgInPicker).toBe(false);
+  expect(r.itemTexts).toContain('<img src=x onerror=window.__xss=1>');
+});

--- a/__TEST__/unit/html-json-converter.test.mjs
+++ b/__TEST__/unit/html-json-converter.test.mjs
@@ -1,0 +1,50 @@
+// Unit tests for jsonToHTML's escaping (#406): word text and speaker names from
+// (possibly third-party) transcript JSON must not become live markup — raw
+// interpolation meant "<inaudible>" vanished as a bogus tag and a hostile
+// payload executed when the HTML landed in innerHTML. htmlToJSON needs a DOM
+// (DOMParser), so the decode half of the round trip is covered in e2e; the
+// serialization half is pure string and lives here.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { jsonToHTML } = require('../../js/html-json-converter.js');
+
+test('word text is escaped: <inaudible> and & survive as text, not markup (#406)', () => {
+  const html = jsonToHTML({
+    words: [
+      { start: 1.0, end: 1.5, text: '<inaudible>' },
+      { start: 1.6, end: 2.0, text: 'AT&T' },
+    ],
+  });
+  assert.match(html, /&lt;inaudible&gt; /);
+  assert.match(html, /AT&amp;T /);
+  assert.doesNotMatch(html, /<inaudible>/);
+});
+
+test('speaker names are escaped, including quotes (#406)', () => {
+  const html = jsonToHTML({
+    words: [{ start: 1.0, end: 1.5, text: 'hello' }],
+    paragraphs: [{ speaker: 'Q&A "host" <b>', start: 0.5, end: 2.0 }],
+  });
+  assert.match(html, /\[Q&amp;A &quot;host&quot; &lt;b&gt;\] /);
+  assert.doesNotMatch(html, /<b>/);
+});
+
+test('an XSS payload in transcript JSON is neutralised (#406)', () => {
+  const html = jsonToHTML({
+    words: [{ start: 0, end: 1, text: '<img src=x onerror=alert(1)>' }],
+  });
+  assert.doesNotMatch(html, /<img/);
+  assert.match(html, /&lt;img src=x onerror=alert\(1\)&gt;/);
+});
+
+test('clean text is untouched', () => {
+  const html = jsonToHTML({
+    words: [{ start: 4.76, end: 5.28, text: 'Testing' }],
+    paragraphs: [{ speaker: 'Alice', start: 4.76, end: 5.28 }],
+  });
+  assert.match(html, /<span data-m="4760" data-d="0" class="speaker">\[Alice\] <\/span>/);
+  assert.match(html, /<span data-m="4760" data-d="520">Testing <\/span>/);
+});

--- a/__TEST__/unit/html-json-converter.test.mjs
+++ b/__TEST__/unit/html-json-converter.test.mjs
@@ -40,6 +40,41 @@ test('an XSS payload in transcript JSON is neutralised (#406)', () => {
   assert.match(html, /&lt;img src=x onerror=alert\(1\)&gt;/);
 });
 
+test('a zero-duration last word is not dropped by its own paragraph range (#408)', () => {
+  const html = jsonToHTML({
+    words: [
+      { start: 1.0, end: 1.5, text: 'first' },
+      { start: 2.0, end: 2.0, text: 'last' },      // end == start == paragraph.end
+    ],
+    paragraphs: [{ speaker: 'A', start: 1.0, end: 2.0 }],
+  });
+  expect_word(html, 'last');
+});
+
+test('gap and trailing words are assigned to a paragraph, never dropped (#408)', () => {
+  const html = jsonToHTML({
+    words: [
+      { start: 0.5, end: 0.8, text: 'early' },     // before the first paragraph
+      { start: 12.0, end: 12.5, text: 'gapword' }, // between paragraph ranges
+      { start: 25.0, end: 25.5, text: 'trailing' },// after the last paragraph end
+      { start: 1.5, end: 2.0, text: 'inP1' },
+      { start: 16.0, end: 16.5, text: 'inP2' },
+    ],
+    paragraphs: [
+      { speaker: 'A', start: 1.0, end: 10.0 },
+      { speaker: 'B', start: 15.0, end: 20.0 },
+    ],
+  });
+  for (const w of ['early', 'gapword', 'trailing', 'inP1', 'inP2']) expect_word(html, w);
+  // placement: early -> P1 (before B's speaker label), trailing -> P2
+  assert.ok(html.indexOf('early') < html.indexOf('[B]'), 'early lands in the first paragraph');
+  assert.ok(html.indexOf('trailing') > html.indexOf('[B]'), 'trailing lands in the last paragraph');
+});
+
+function expect_word(html, word) {
+  assert.ok(html.includes(`>${word} </span>`) || html.includes(`>${word}</span>`), `word "${word}" survives`);
+}
+
 test('clean text is untouched', () => {
   const html = jsonToHTML({
     words: [{ start: 4.76, end: 5.28, text: 'Testing' }],

--- a/__TEST__/unit/word-vtt.test.mjs
+++ b/__TEST__/unit/word-vtt.test.mjs
@@ -74,3 +74,21 @@ test('generateWordVtt: header, cue timing, inline per-word timestamps', () => {
 test('generateWordVtt: no words yields just the header', () => {
   assert.equal(generateWordVtt({ source: mockRoot([]) }), 'WEBVTT\n');
 });
+
+test('generateWordVtt: cue text is escaped so <tags> and & survive parsing (#409)', () => {
+  const root = mockRoot([
+    { m: 1000, d: 300, t: '<inaudible>' },
+    { m: 1400, d: 300, t: 'AT&T' },
+  ]);
+  const vtt = generateWordVtt({ source: root });
+  // words become entities, not markup…
+  assert.match(vtt, /<00:00:01\.000>&lt;inaudible&gt; <00:00:01\.400>AT&amp;T\n/);
+  // …while the timestamp tags themselves stay raw
+  assert.match(vtt, /<00:00:01\.000>/);
+  assert.doesNotMatch(vtt, /<inaudible>/);
+});
+
+test('buildWordChunks stays raw for the burn-in renderer (no escaping)', () => {
+  const chunks = require('../../js/word-vtt.js').buildWordChunks({ source: mockRoot([{ m: 0, d: 100, t: '<laughs>' }]) });
+  assert.equal(chunks[0][0].text, '<laughs>');
+});

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.26"></script>
   <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.7.0"></script>
   <script src="js/word-alignment.js"></script>
-  <script src="js/html-json-converter.js?v=0.6.18"></script>
+  <script src="js/html-json-converter.js?v=0.8.5"></script>
   <script src="js/transcript-to-ionosphere.js?v=0.6.18"></script>
   <script src="js/paragraph-timecodes.js?v=0.6.20"></script>
 
@@ -963,7 +963,8 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite.js?v=2.6.2"></script>
   <script src="js/hyperaudio-lite-extension.js?v=0.7.2"></script>
   <script src="js/caption.js?v=0.7.1"></script>
-  <script src="js/editor-core.js?v=0.8.4"></script>
+  <script src="js/transcript-serializer.js?v=0.8.5"></script>
+  <script src="js/editor-core.js?v=0.8.5"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1046,7 +1047,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/find-replace.js?v=0.6.29"></script>
   <script src="js/media-export.js?v=0.8.0"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
-  <script src="js/word-vtt.js?v=0.8.0"></script>
+  <script src="js/word-vtt.js?v=0.8.5"></script>
   <!-- end of caption editor additions -->
 
   <!-- responsive small-screen UI toggles (#349) -->

--- a/index.html
+++ b/index.html
@@ -1012,7 +1012,7 @@ If you are creating an open source application under a license compatible with t
   </div>
  
 
-  <script src="./js/hyperaudio-lite-editor-storage.js?v=0.8.3"></script>
+  <script src="./js/hyperaudio-lite-editor-storage.js?v=0.8.5"></script>
 
   <script src="js/editor-file-menu.js?v=0.6.12"></script>
 

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -123,7 +123,9 @@
         // function replacements so a literal $ in the transcript/filename isn't
         // treated as a replacement pattern
         const html = hyperaudioTemplate
-          .replace('{hypertranscript}', () => getTranscriptData())
+          .replace('{hypertranscript}', () => (typeof serializeTranscriptHtml === 'function'
+            ? serializeTranscriptHtml(document.querySelector('#hypertranscript'))
+            : getTranscriptData()))
           .replace('{sourcemedia}', () => mediaSrc)
           .replace('{sourcevtt}', () => (track !== null ? track.src : ''));
         const blob = new Blob([html], { type: 'text/html' });
@@ -215,6 +217,27 @@
     span.replaceWith(frag);
   }
 
+  // Scrub contenteditable artifacts (#415): WebKit injects inline styles
+  // (font-size etc.) on paste/splits, plus style-only wrapper spans with no
+  // data-m — all of which persisted into exports and confused downstream
+  // consumers. Only two inline styles are FUNCTIONAL on transcript spans:
+  // line-through (the strikeout/cut model) and display on speaker labels (the
+  // Speakers toggle). Preserve those, drop everything else, and unwrap
+  // non-data-m wrapper spans so their text folds back into the flow.
+  function scrubEditingArtifacts(root) {
+    root.querySelectorAll('span[style]').forEach((span) => {
+      const display = span.classList.contains('speaker') ? span.style.display : '';
+      const struck = (span.style.textDecoration || '').includes('line-through');
+      span.removeAttribute('style');
+      if (display) span.style.display = display;
+      if (struck) span.style.textDecoration = 'line-through';
+    });
+    root.querySelectorAll('span:not([data-m])').forEach((span) => {
+      if (span.classList.contains('speaker')) return;
+      span.replaceWith(...span.childNodes);
+    });
+  }
+
   // Spans containing a bracket belong to the SPEAKER machinery, not word
   // normalization (#416): "[Maria] The " must survive until sanitise's speaker
   // pass extracts the label — splitting it first turns "[Maria] " into a plain
@@ -300,6 +323,8 @@
         }
       }
     }
+    // artifact hygiene runs regardless of the timing-repair switch (#415)
+    scrubEditingArtifacts(root);
     if (!WORD_SPLIT_TIMING) return;
     // disjoint conditions, in order: reflow (internal space + no trailing),
     // merge (no internal + no trailing), split (internal space + trailing).
@@ -527,7 +552,13 @@
           }
         }
 
-        let hypertranscript = rootnode.innerHTML.replace(/ class=".*?"/g, '');
+        // Canonical serialization (transcript-serializer.js): one span per
+        // line, two-space indents, data-m before data-d, runtime noise
+        // dropped. Replaces the old raw-innerHTML + strip-all-classes regex —
+        // which also (wrongly) removed the semantic speaker class.
+        let hypertranscript = typeof serializeTranscriptHtml === 'function'
+          ? serializeTranscriptHtml(rootnode)
+          : rootnode.innerHTML.replace(/ class=".*?"/g, '');
         document.querySelector('#download-html').setAttribute('href', 'data:text/html,'+encodeURIComponent(hypertranscript));
 
         if (isTranscriptFocused === true && updateCaptionsFromTranscript === true) {

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -217,6 +217,45 @@
     span.replaceWith(frag);
   }
 
+  // --- Caret preservation across normalization -------------------------------
+  // The span repairs rewrite text nodes (textContent =, replaceWith), which
+  // destroys the browser's selection anchor — mid-edit the caret jumped to the
+  // start of the joined/split word. All the passes preserve the transcript's
+  // character CONTENT though, so the caret can be saved as an absolute
+  // character offset and re-resolved onto whatever nodes exist afterwards.
+  function saveCaretOffset(root) {
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return null;
+    const range = sel.getRangeAt(0);
+    if (!root.contains(range.startContainer)) return null;
+    const pre = document.createRange();
+    pre.selectNodeContents(root);
+    pre.setEnd(range.startContainer, range.startOffset);
+    return pre.toString().length;
+  }
+
+  function restoreCaretOffset(root, chars) {
+    const sel = window.getSelection();
+    const range = document.createRange();
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let node;
+    let remaining = chars;
+    while ((node = walker.nextNode())) {
+      if (remaining <= node.nodeValue.length) {
+        range.setStart(node, remaining);
+        range.collapse(true);
+        sel.removeAllRanges();
+        sel.addRange(range);
+        return;
+      }
+      remaining -= node.nodeValue.length;
+    }
+    range.selectNodeContents(root);   // past the end — clamp to the end
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }
+
   // Scrub contenteditable artifacts (#415): WebKit injects inline styles
   // (font-size etc.) on paste/splits, plus style-only wrapper spans with no
   // data-m — all of which persisted into exports and confused downstream
@@ -265,6 +304,7 @@
   // space. Move the post-space fragment to the front of the next word span,
   // reconstituting the word with each span's ORIGINAL data-m/data-d intact.
   function reflowLeakedFragments(root) {
+    let changed = false;
     const spans = Array.from(root.querySelectorAll('span[data-m]'));
     for (let i = 0; i < spans.length; i++) {
       const span = spans[i];
@@ -279,13 +319,16 @@
       const cut = txt.lastIndexOf(' ');
       span.textContent = txt.slice(0, cut).replace(/\s+$/, '') + ' ';
       next.textContent = txt.slice(cut + 1) + next.textContent;
+      changed = true;
     }
+    return changed;
   }
 
   // Merge spans JOINED by deleting the space between two words — the inverse of
   // splitWordSpan (#394): a span with no trailing space, followed by a word
   // span, is glued back into one (start of first, end of last); chains for 3+.
   function mergeJoinedSpans(root) {
+    let changed = false;
     const spans = Array.from(root.querySelectorAll('span[data-m]'));
     for (let i = 0; i < spans.length; i++) {
       const span = spans[i];
@@ -302,8 +345,10 @@
         span.setAttribute('data-d', String(Math.max(0, (nm + nd) - m)));
         span.textContent = span.textContent + next.textContent;
         next.remove();
+        changed = true;
       }
     }
+    return changed;
   }
 
   // Run the span repairs on `root` and, if the set of word spans changed
@@ -326,14 +371,26 @@
     // artifact hygiene runs regardless of the timing-repair switch (#415)
     scrubEditingArtifacts(root);
     if (!WORD_SPLIT_TIMING) return;
+    // The repairs rewrite text nodes, which would throw the caret to the start
+    // of the affected word mid-edit — save it as a character offset first and
+    // re-resolve after, but only when the transcript actually has focus (on
+    // blur there is nothing to preserve) and a rewrite actually happened.
+    const hasFocus = document.activeElement === root;
+    const caret = hasFocus ? saveCaretOffset(root) : null;
     // disjoint conditions, in order: reflow (internal space + no trailing),
     // merge (no internal + no trailing), split (internal space + trailing).
     const countBefore = root.querySelectorAll('span[data-m]').length;
-    reflowLeakedFragments(root);
-    mergeJoinedSpans(root);
+    let rewrote = reflowLeakedFragments(root);
+    rewrote = mergeJoinedSpans(root) || rewrote;
     const spans = root.querySelectorAll('span[data-m]');
     for (let i = 0; i < spans.length; i++) {
-      if (!isSpeakerText(spans[i]) && /\S\s+\S/.test(spans[i].textContent)) splitWordSpan(spans[i]);
+      if (!isSpeakerText(spans[i]) && /\S\s+\S/.test(spans[i].textContent)) {
+        splitWordSpan(spans[i]);
+        rewrote = true;
+      }
+    }
+    if (caret !== null && rewrote) {
+      restoreCaretOffset(root, caret);
     }
     const inst = window.hyperaudioInstance;
     if (inst && typeof inst.setupTranscriptWords === 'function'

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -183,6 +183,13 @@
   // mid-edit too (#394).
   const WORD_SPLIT_TIMING = true;
 
+  // Skip normalization while an IME composition is in flight — rewriting the
+  // text nodes under an active composition (CJK etc.) breaks it. The skipped
+  // pass simply happens on the next keyup/blur.
+  let imeComposing = false;
+  document.addEventListener('compositionstart', () => { imeComposing = true; });
+  document.addEventListener('compositionend', () => { imeComposing = false; });
+
   // Estimate syllables from contiguous vowel groups (Latin-script heuristic);
   // floored at 1 so every part carries weight.
   function estimateSyllables(token) {
@@ -223,35 +230,54 @@
   // start of the joined/split word. All the passes preserve the transcript's
   // character CONTENT though, so the caret can be saved as an absolute
   // character offset and re-resolved onto whatever nodes exist afterwards.
+  // Both endpoints are saved so a non-collapsed SELECTION (e.g. words selected
+  // for striking) survives too, not just a caret.
   function saveCaretOffset(root) {
     const sel = window.getSelection();
     if (!sel || sel.rangeCount === 0) return null;
     const range = sel.getRangeAt(0);
-    if (!root.contains(range.startContainer)) return null;
-    const pre = document.createRange();
-    pre.selectNodeContents(root);
-    pre.setEnd(range.startContainer, range.startOffset);
-    return pre.toString().length;
+    if (!root.contains(range.startContainer) || !root.contains(range.endContainer)) return null;
+    const measure = (container, offset) => {
+      const pre = document.createRange();
+      pre.selectNodeContents(root);
+      pre.setEnd(container, offset);
+      return pre.toString().length;
+    };
+    return {
+      start: measure(range.startContainer, range.startOffset),
+      end: range.collapsed ? null : measure(range.endContainer, range.endOffset),
+    };
   }
 
-  function restoreCaretOffset(root, chars) {
-    const sel = window.getSelection();
-    const range = document.createRange();
+  // Resolve an absolute character offset back to a (text node, offset) pair;
+  // clamps past-the-end to the final position.
+  function resolveCharOffset(root, chars) {
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
     let node;
+    let last = null;
     let remaining = chars;
     while ((node = walker.nextNode())) {
       if (remaining <= node.nodeValue.length) {
-        range.setStart(node, remaining);
-        range.collapse(true);
-        sel.removeAllRanges();
-        sel.addRange(range);
-        return;
+        return { node, offset: remaining };
       }
       remaining -= node.nodeValue.length;
+      last = node;
     }
-    range.selectNodeContents(root);   // past the end — clamp to the end
-    range.collapse(false);
+    return last ? { node: last, offset: last.nodeValue.length } : null;
+  }
+
+  function restoreCaretOffset(root, saved) {
+    const start = resolveCharOffset(root, saved.start);
+    if (start === null) return;
+    const sel = window.getSelection();
+    const range = document.createRange();
+    range.setStart(start.node, start.offset);
+    if (saved.end !== null) {
+      const end = resolveCharOffset(root, saved.end);
+      if (end !== null) range.setEnd(end.node, end.offset);
+    } else {
+      range.collapse(true);
+    }
     sel.removeAllRanges();
     sel.addRange(range);
   }
@@ -357,7 +383,7 @@
   // between existing nodes, so it never changes the count. Called from both the
   // blur handler and the debounced sanitise pass.
   function normalizeTranscriptSpans(root) {
-    if (!root) return;
+    if (!root || imeComposing) return;
     // nbsp -> normal space (#339)
     if (root.textContent.indexOf(' ') !== -1) {
       const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
@@ -379,22 +405,26 @@
     const caret = hasFocus ? saveCaretOffset(root) : null;
     // disjoint conditions, in order: reflow (internal space + no trailing),
     // merge (no internal + no trailing), split (internal space + trailing).
-    const countBefore = root.querySelectorAll('span[data-m]').length;
-    let rewrote = reflowLeakedFragments(root);
-    rewrote = mergeJoinedSpans(root) || rewrote;
+    const reflowed = reflowLeakedFragments(root);
+    let merged = mergeJoinedSpans(root);
+    let split = false;
     const spans = root.querySelectorAll('span[data-m]');
     for (let i = 0; i < spans.length; i++) {
       if (!isSpeakerText(spans[i]) && /\S\s+\S/.test(spans[i].textContent)) {
         splitWordSpan(spans[i]);
-        rewrote = true;
+        split = true;
       }
     }
-    if (caret !== null && rewrote) {
+    if (caret !== null && (reflowed || merged || split)) {
       restoreCaretOffset(root, caret);
     }
+    // Re-index whenever merge or split FIRED — not on a span-count comparison:
+    // a merge (−1) plus a split (+1) in the same pass nets zero yet leaves
+    // wordArr holding removed nodes and missing new ones. Reflow keeps the
+    // span elements themselves, so it needs no re-index.
     const inst = window.hyperaudioInstance;
     if (inst && typeof inst.setupTranscriptWords === 'function'
-        && root.querySelectorAll('span[data-m]').length !== countBefore) {
+        && (merged || split)) {
       inst.setupTranscriptWords();
       if (typeof inst.updateTranscriptVisualState === 'function') {
         const player = document.querySelector('#hyperplayer');

--- a/js/html-json-converter.js
+++ b/js/html-json-converter.js
@@ -95,7 +95,27 @@ function jsonToHTML(jsonData) {
   if (paragraphs.length > 0) {
     // ===== MULTI-PARAGRAPH CASE =====
     // Generate separate <p> tags based on paragraph data
-    
+
+    // Assign EVERY word to a paragraph — never drop (#408). The old half-open
+    // range filter (start >= pStart && start < pEnd) silently deleted words:
+    // a zero-duration last word (end == start) failed its own paragraph's
+    // range, and diarizer paragraph times that don't exactly bracket word
+    // times left gap/trailing words unmatched. Rule: a word belongs to the
+    // last paragraph that has started by the word's start time; words before
+    // the first paragraph go to the first.
+    const assignedWords = paragraphs.map(() => []);
+    words.forEach(word => {
+      let idx = 0;
+      let bestStart = -Infinity;
+      paragraphs.forEach((p, i) => {
+        if (word.start >= p.start && p.start >= bestStart) {
+          idx = i;
+          bestStart = p.start;
+        }
+      });
+      assignedWords[idx].push(word);
+    });
+
     paragraphs.forEach((paragraph, paragraphIndex) => {
       html += '  <p>\n';
       
@@ -108,14 +128,8 @@ function jsonToHTML(jsonData) {
         html += `    <span data-m="${speakerTime}" data-d="0" class="speaker">[${escapeHTMLText(paragraph.speaker)}] </span>\n`;
       }
       
-      // Find all words that belong to this paragraph
-      // Words belong to a paragraph if their start time is within the paragraph's time range
-      const paragraphStart = paragraph.start;
-      const paragraphEnd = paragraph.end;
-      
-      const paragraphWords = words.filter(word => 
-        word.start >= paragraphStart && word.start < paragraphEnd
-      );
+      // Words pre-assigned above — every word renders exactly once
+      const paragraphWords = assignedWords[paragraphIndex];
       
       // One span per line (indented) for readability. A word flagged
       // space:false has no trailing space and is kept adjacent to the next
@@ -208,17 +222,19 @@ function htmlToJSON(html) {
   const doc = parser.parseFromString(html, 'text/html');
   
   // ===== EXTRACT WORDS =====
-  // Find all spans with timing data that are NOT speaker labels
+  // Find all spans with timing data that are NOT speaker labels. data-d is
+  // OPTIONAL in the hyperaudio format (caption.js handles its absence), so the
+  // selector must not require it (#408) — a missing/invalid duration reads as 0.
   const words = [];
-  const wordSpans = doc.querySelectorAll('span[data-m][data-d]:not(.speaker)');
-  
+  const wordSpans = doc.querySelectorAll('span[data-m]:not(.speaker)');
+
   wordSpans.forEach(span => {
     const raw = span.textContent;
     const text = raw.trim();
     if (text) {
       // Parse timing attributes
       const startMs = parseInt(span.getAttribute('data-m'));
-      const durationMs = parseInt(span.getAttribute('data-d'));
+      const durationMs = parseInt(span.getAttribute('data-d')) || 0;
       const endMs = startMs + durationMs;
 
       // Convert from milliseconds to seconds
@@ -258,17 +274,18 @@ function htmlToJSON(html) {
       }
     }
     
-    // Find all word spans in this paragraph (excluding speaker)
-    const paragraphWordSpans = pElement.querySelectorAll('span[data-m][data-d]:not(.speaker)');
-    
+    // Find all word spans in this paragraph (excluding speaker); data-d
+    // optional here too (#408)
+    const paragraphWordSpans = pElement.querySelectorAll('span[data-m]:not(.speaker)');
+
     if (paragraphWordSpans.length > 0) {
       // Get start time from first word and end time from last word
       const firstSpan = paragraphWordSpans[0];
       const lastSpan = paragraphWordSpans[paragraphWordSpans.length - 1];
-      
+
       const startMs = parseInt(firstSpan.getAttribute('data-m'));
       const lastStartMs = parseInt(lastSpan.getAttribute('data-m'));
-      const lastDurationMs = parseInt(lastSpan.getAttribute('data-d'));
+      const lastDurationMs = parseInt(lastSpan.getAttribute('data-d')) || 0;
       const endMs = lastStartMs + lastDurationMs;
       
       // Create paragraph object

--- a/js/html-json-converter.js
+++ b/js/html-json-converter.js
@@ -71,6 +71,20 @@
  *     <span data-m="4760" data-d="520">Testing </span>
  *   </p></section></article>
  */
+
+// Escape text destined for markup (#406): word text and speaker names come
+// from transcripts (possibly third-party JSON) and may contain "<inaudible>",
+// "AT&T", or hostile payloads — interpolated raw they become live markup when
+// the result lands in innerHTML (stored XSS), and round-trips corrupt.
+// htmlToJSON reads textContent, which decodes entities, so the mirror is free.
+function escapeHTMLText(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 function jsonToHTML(jsonData) {
   const words = jsonData.words || [];
   const paragraphs = jsonData.paragraphs || [];
@@ -91,7 +105,7 @@ function jsonToHTML(jsonData) {
         const speakerTime = Math.round(paragraph.start * 1000);
         
         // Speaker span has zero duration (data-d="0")
-        html += `    <span data-m="${speakerTime}" data-d="0" class="speaker">[${paragraph.speaker}] </span>\n`;
+        html += `    <span data-m="${speakerTime}" data-d="0" class="speaker">[${escapeHTMLText(paragraph.speaker)}] </span>\n`;
       }
       
       // Find all words that belong to this paragraph
@@ -116,7 +130,7 @@ function jsonToHTML(jsonData) {
         const trail = word.space === false ? '' : ' ';
         const gluedToPrev = wordIndex > 0 && paragraphWords[wordIndex - 1].space === false;
         const lead = wordIndex === 0 ? '    ' : gluedToPrev ? '' : '\n    ';
-        html += `${lead}<span data-m="${startMs}" data-d="${durationMs}">${word.text}${trail}</span>`;
+        html += `${lead}<span data-m="${startMs}" data-d="${durationMs}">${escapeHTMLText(word.text)}${trail}</span>`;
       });
       html += '\n';
       
@@ -135,7 +149,7 @@ function jsonToHTML(jsonData) {
       const trail = word.space === false ? '' : ' ';
       const gluedToPrev = wordIndex > 0 && words[wordIndex - 1].space === false;
       const lead = wordIndex === 0 ? '    ' : gluedToPrev ? '' : '\n    ';
-      html += `${lead}<span data-m="${startMs}" data-d="${durationMs}">${word.text}${trail}</span>`;
+      html += `${lead}<span data-m="${startMs}" data-d="${durationMs}">${escapeHTMLText(word.text)}${trail}</span>`;
     });
     html += '\n';
     

--- a/js/hyperaudio-lite-editor-storage.js
+++ b/js/hyperaudio-lite-editor-storage.js
@@ -340,19 +340,36 @@ function saveHyperTranscriptToLocalStorage(
   }
 }
 
+// Escape text/keys interpolated into picker markup (#410) — a saved filename
+// containing < or " must not break (or script) the list.
+function escapeStorageMarkup(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 function loadLocalStorageOptions(storage = window.localStorage) {
 
   let fileSelect = document.querySelector("#load-localstorage-filename");
   let filePicker = document.querySelector("#file-picker");
-  
+
   fileSelect.innerHTML = '<option value="default">Select file…</option>';
   filePicker.innerHTML = "";
 
+  // Entries are referenced by their KEY STRING, never by storage.key(i)
+  // position (#410): key order is implementation-defined and shifts whenever
+  // ANY key is written — and other modules write keys at arbitrary times
+  // (prefs on every toggle) — so a positional index resolved at click time
+  // could load a different entry than the one listed.
   for (let i = 0; i < storage.length; i++) {
     if (storage.key(i).indexOf(fileExtension) > 0) {
-      let filename = storage.key(i).substring(0,storage.key(i).lastIndexOf(fileExtension));
-      fileSelect.insertAdjacentHTML("beforeend", `<option value=${i}>${filename}</option>`);
-      filePicker.insertAdjacentHTML("beforeend", `<li><a class="file-item" title="..." data-index=${i}>${filename}</a></li>`);
+      const key = storage.key(i);
+      const filename = escapeStorageMarkup(key.substring(0, key.lastIndexOf(fileExtension)));
+      const keyAttr = escapeStorageMarkup(key);
+      fileSelect.insertAdjacentHTML("beforeend", `<option value="${keyAttr}">${filename}</option>`);
+      filePicker.insertAdjacentHTML("beforeend", `<li><a class="file-item" title="..." data-key="${keyAttr}">${filename}</a></li>`);
     }
   }
 
@@ -377,7 +394,7 @@ function setFileSelectListeners() {
 }
 
 function fileSelectHandleClick(event) {
-  loadHyperTranscriptFromLocalStorage(event.target.getAttribute("data-index"));
+  loadHyperTranscriptFromLocalStorage(event.target.getAttribute("data-key"));
 
   let files = document.querySelectorAll('.file-item');
 
@@ -391,28 +408,46 @@ function fileSelectHandleClick(event) {
 }
 
 function fileSelectHandleHover(event) {
-  loadSummaryFromLocalStorage(event.target.getAttribute("data-index"), event.target);
+  loadSummaryFromLocalStorage(event.target.getAttribute("data-key"), event.target);
   event.preventDefault();
   return false;
 }
 
-function loadHyperTranscriptFromLocalStorage(fileindex, storage = window.localStorage){
-  let hypertranscriptstorage = JSON.parse(storage.getItem(storage.key(fileindex)));
-
-  if (hypertranscriptstorage) {
-
-    lastFilename = storage.key(fileindex).substring(0,storage.key(fileindex).lastIndexOf(fileExtension));
-    renderTranscript(hypertranscriptstorage, lastFilename);
-    
-    document.querySelector('#save-localstorage-filename').value = lastFilename;
+// Read an entry by its key string. A corrupted value must not throw out of the
+// click handler (that permanently broke the picker), and an entry missing the
+// expected fields must not half-populate the editor (renderTranscript reads
+// .video and .hypertranscript unguarded) — so parse defensively and validate.
+function readTranscriptEntry(fileKey, storage) {
+  if (!fileKey) return null;
+  try {
+    return JSON.parse(storage.getItem(fileKey));
+  } catch (e) {
+    console.warn(`Could not parse saved transcript "${fileKey}":`, e);
+    return null;
   }
 }
 
-function loadSummaryFromLocalStorage(fileindex, target, storage = window.localStorage){
-  
-  let hypertranscriptstorage = JSON.parse(storage.getItem(storage.key(fileindex)));
+function loadHyperTranscriptFromLocalStorage(fileKey, storage = window.localStorage){
+  let hypertranscriptstorage = readTranscriptEntry(fileKey, storage);
 
-  if (hypertranscriptstorage) {
-    target.setAttribute("title", hypertranscriptstorage.summary + "\n\nTopics: " + getTopicsString(hypertranscriptstorage.topics)); 
+  if (hypertranscriptstorage
+      && typeof hypertranscriptstorage.hypertranscript === 'string'
+      && typeof hypertranscriptstorage.video === 'string') {
+
+    lastFilename = fileKey.substring(0, fileKey.lastIndexOf(fileExtension));
+    renderTranscript(hypertranscriptstorage, lastFilename);
+
+    document.querySelector('#save-localstorage-filename').value = lastFilename;
+  } else if (hypertranscriptstorage) {
+    console.warn(`Saved entry "${fileKey}" is missing transcript/video fields — not loading.`);
+  }
+}
+
+function loadSummaryFromLocalStorage(fileKey, target, storage = window.localStorage){
+
+  let hypertranscriptstorage = readTranscriptEntry(fileKey, storage);
+
+  if (hypertranscriptstorage && hypertranscriptstorage.summary !== undefined) {
+    target.setAttribute("title", hypertranscriptstorage.summary + "\n\nTopics: " + getTopicsString(hypertranscriptstorage.topics));
   }
 }

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -185,7 +185,11 @@
       if (p.querySelector('[data-m]') === null) p.remove();
     });
     clone.normalize();
-    return clone.innerHTML;
+    // canonical formatting (one span per line, data-m before data-d) so the
+    // retimed transcript exports as clean as the plain HTML export
+    return typeof window.serializeTranscriptHtml === 'function'
+      ? window.serializeTranscriptHtml(clone)
+      : clone.innerHTML;
   };
 
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms));

--- a/js/transcript-serializer.js
+++ b/js/transcript-serializer.js
@@ -1,0 +1,100 @@
+/**
+ * transcript-serializer.js
+ * (C) The Hyperaudio Project
+ * @version 0.8.5 — last changed in release 0.8.5
+ * @license MIT
+ *
+ * Canonical transcript serialization for the HTML and interactive-transcript
+ * exports. The live DOM accumulates editing noise (runtime classes, WebKit
+ * inline styles, arbitrary attribute order), so exports built from raw
+ * innerHTML shipped that noise verbatim. This walks the transcript and emits
+ * clean, consistently formatted markup instead:
+ *
+ *   <article>
+ *     <section>
+ *       <p>
+ *         <span data-m="640" data-d="80">The </span>
+ *         <span data-m="960" data-d="1040" class="speaker">[Monika] </span>
+ *       </p>
+ *     </section>
+ *   </article>
+ *
+ * — one span per line, two-space indents, data-m before data-d, class only
+ * for speaker labels, style only for strikethrough (the two functional bits
+ * of state, cf. #415). Text is re-escaped from textContent, so words like
+ * "<inaudible>" survive as text (#406/#409 companion).
+ *
+ * Loaded as a plain <script>; exposes `serializeTranscriptHtml` as a global.
+ */
+
+(function () {
+  const escapeText = (t) =>
+    t.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const escapeAttr = (t) => escapeText(t).replace(/"/g, '&quot;');
+
+  // One span, canonical shape: data-m, data-d, speaker class, strike style.
+  function spanLine(span) {
+    const m = span.getAttribute('data-m');
+    const d = span.getAttribute('data-d');
+    let attrs = '';
+    if (m !== null) attrs += ` data-m="${escapeAttr(m)}"`;
+    if (d !== null) attrs += ` data-d="${escapeAttr(d)}"`;
+    if (span.classList.contains('speaker')) attrs += ' class="speaker"';
+    if (((span.style && span.style.textDecoration) || '').includes('line-through')) {
+      attrs += ' style="text-decoration: line-through;"';
+    }
+    return `<span${attrs}>${escapeText(span.textContent)}</span>`;
+  }
+
+  function serializeParagraph(p, indent) {
+    const inner = indent + '  ';
+    const lines = [indent + '<p>'];
+    p.childNodes.forEach((node) => {
+      if (node.nodeType === Node.ELEMENT_NODE && node.tagName === 'SPAN' && node.hasAttribute('data-m')) {
+        lines.push(inner + spanLine(node));
+      } else if (node.nodeType === Node.TEXT_NODE && node.nodeValue.trim() !== '') {
+        // stray text between spans — keep it (escaped) rather than lose words
+        lines.push(inner + escapeText(node.nodeValue.trim()) + ' ');
+      } else if (node.nodeType === Node.ELEMENT_NODE && node.textContent.trim() !== '') {
+        // unexpected wrapper (e.g. residual mark/span): flatten to its text
+        lines.push(inner + escapeText(node.textContent.trim()) + ' ');
+      }
+    });
+    lines.push(indent + '</p>');
+    return lines;
+  }
+
+  /**
+   * Serialize a transcript root (the #hypertranscript element, a clone of it,
+   * or an <article>) to canonical, indented HTML. Falls back to innerHTML if
+   * there are no timed spans (e.g. loader markup), so callers can use it
+   * unconditionally.
+   */
+  function serializeTranscriptHtml(root) {
+    if (!root || root.querySelector === undefined) return '';
+    if (root.querySelector('span[data-m]') === null) {
+      return root.innerHTML || '';
+    }
+    const paragraphs = root.querySelectorAll('p');
+    const lines = ['<article>', '  <section>'];
+    if (paragraphs.length > 0) {
+      paragraphs.forEach((p) => {
+        if (p.querySelector('span[data-m]') === null) return; // skip empty/UI paragraphs
+        lines.push(...serializeParagraph(p, '    '));
+      });
+    } else {
+      // no <p> structure — treat every timed span as one paragraph's content
+      const pseudo = { childNodes: root.querySelectorAll('span[data-m]') };
+      lines.push(...serializeParagraph(pseudo, '    '));
+    }
+    lines.push('  </section>', '</article>');
+    return lines.join('\n');
+  }
+
+  if (typeof window !== 'undefined') {
+    window.serializeTranscriptHtml = serializeTranscriptHtml;
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { serializeTranscriptHtml };
+  }
+})();

--- a/js/word-vtt.js
+++ b/js/word-vtt.js
@@ -1,7 +1,7 @@
 /**
  * word-vtt.js
  * (C) The Hyperaudio Project
- * @version 0.8.0 — last changed in release 0.8.0
+ * @version 0.8.5 — last changed in release 0.8.5
  * @license MIT
  *
  * Word-level ("karaoke") WebVTT export (#387, part 1).
@@ -120,6 +120,14 @@
    * @param {string|Element} [options.source='#hypertranscript'] transcript root
    * @returns {string} a WebVTT document (just the header if there are no words)
    */
+  // WebVTT cue text is parsed for tags, so raw word text must be escaped
+  // (#409): "<inaudible>" would read as a malformed tag and swallow the word,
+  // and a bare "&" starts an entity. Serialization-only — buildWordChunks
+  // stays raw for the burn-in renderer, which draws text, not markup.
+  function escapeVttText(text) {
+    return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
   function generateWordVtt(options) {
     const chunks = buildWordChunks(options);
     let vtt = 'WEBVTT\n';
@@ -127,7 +135,7 @@
       const start = chunk[0].start;
       const end = chunk[chunk.length - 1].end;
       const line = chunk
-        .map((w) => `<${formatTimestamp(w.start)}>${w.text}`)
+        .map((w) => `<${formatTimestamp(w.start)}>${escapeVttText(w.text)}`)
         .join(' ');
       vtt += `\n${formatTimestamp(start)} --> ${formatTimestamp(end)}\n${line}\n`;
     });
@@ -165,6 +173,6 @@
   }
 
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { generateWordVtt, buildWordChunks, formatTimestamp, readWords, chunkWords };
+    module.exports = { generateWordVtt, buildWordChunks, formatTimestamp, readWords, chunkWords, escapeVttText };
   }
 })();


### PR DESCRIPTION
Fixes five bugs from the recent review batch, plus canonical export formatting and caret preservation during editing.

- **#409 — word-vtt:** cue text is escaped so `<inaudible>` / `AT&T` survive WebVTT parsing; `buildWordChunks` stays raw for the burn-in renderer.
- **#406 — converter escaping:** `jsonToHTML` escapes speaker names and word text at all three interpolation sites — closes a stored XSS via third-party transcript JSON and stops `<inaudible>` vanishing on round-trip.
- **#415 — style scrub:** normalization now strips WebKit's injected inline styles and unwraps style-only wrapper spans, preserving the two functional styles (strikeout `line-through`, speaker `display`).
- **#410 — storage:** saved projects referenced by key string instead of `storage.key(i)` position (which shifted whenever any module wrote a key — the prefs do so on every toggle); `JSON.parse` guarded; entries validated before rendering; filenames escaped.
- **#408 — round-trip:** `jsonToHTML` assigns every word to a paragraph (zero-duration last words, gap and trailing words previously deleted silently); `htmlToJSON` accepts spans without the optional `data-d`.
- **Canonical export serialization** (new `js/transcript-serializer.js`): the HTML download, interactive-transcript dialog, and export modal's re-timed transcript all emit one-span-per-line, two-space-indented markup with `data-m` before `data-d` — replacing raw contenteditable `innerHTML` (and the old strip-all-classes regex that wrongly removed the semantic `speaker` class).
- **Caret preservation:** the join/split/reflow repairs rewrite text nodes, which threw the cursor to the start of the affected word mid-edit — the selection (both endpoints) is now saved as character offsets and restored after the pass. Hardened by self-review: non-collapsed selections survive, the wordArr re-index keys on merge/split firing (a net-zero merge+split previously skipped it), and normalization skips during IME composition.

Tests: +17 new across unit and e2e (escaping, storage order-shift/corruption/markup-name, serialization format, round-trip, style scrub, caret/selection/IME/re-index). Full suite 36 e2e + 15 unit passing.

Closes #406, #408, #409, #410, #415.
