### PR TITLE
Release 0.8.7

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 0.8.6 (last changed in release 0.8.6) -->
+<!--  Hyperaudio Lite Editor - Version 0.8.7 (last changed in release 0.8.7) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="0.8.6">
+  <meta name="version" content="0.8.7">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">


### PR DESCRIPTION
Bumps the app version marker to 0.8.7.

Release contents (since v0.8.6):
- Restore `title=""` on file inputs to suppress the native "No file chosen" hover tooltip that reappeared after the #402 accessibility work (regression fix, #402).