### PR TITLE
Export length: separate min/sec boxes, explained rate caps, stable readout

### DIFF
--- a/__TEST__/e2e/export-length.spec.mjs
+++ b/__TEST__/e2e/export-length.spec.mjs
@@ -1,0 +1,93 @@
+// The export modal's target length is entered as separate minutes/seconds
+// boxes (#441): the old single m:ss text field read a bare "15" as 15
+// SECONDS, so a 16-minute video typed as "15" computed a 64x rate, slammed
+// into the 4x cap and rewrote the field to ~4:00 with no explanation.
+// Explicit unit boxes remove the guessing; impossible targets now say in the
+// readout why the rate was capped instead of snapping silently.
+import { test, expect } from '@playwright/test';
+import { ladderWav, transcriptHtml } from './helpers.mjs';
+
+const setup = async (page, seconds) => {
+  const wav = ladderWav(seconds, 8000);
+  await page.route('**/__ladder.wav', (route) => route.fulfill({ body: wav, contentType: 'audio/wav' }));
+  await page.goto('/index.html');
+  await page.waitForFunction(() => typeof window.getPlayableSections === 'function');
+  await page.evaluate(async () => {
+    const blob = await (await fetch('/__ladder.wav')).blob();
+    document.getElementById('hyperplayer').src = URL.createObjectURL(blob);
+  });
+  await page.waitForFunction((s) => {
+    const p = document.getElementById('hyperplayer');
+    return p.readyState >= 1 && p.duration > s - 1;
+  }, seconds);
+  const words = Array.from({ length: seconds }, (_, i) => [i * 1000, 1000, 0]);
+  await page.evaluate((html) => {
+    document.getElementById('hypertranscript').innerHTML = html;
+  }, transcriptHtml(words));
+  await page.evaluate(() => {
+    const m = document.getElementById('export-modal');
+    m.checked = true;
+    m.dispatchEvent(new Event('change'));
+  });
+  await page.waitForFunction(() => document.getElementById('export-format').options.length > 0, null, { timeout: 60000 });
+  await page.evaluate(() => {
+    const c = document.getElementById('export-adjust');
+    c.checked = true;
+    c.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+};
+
+const enterLength = async (page, min, sec) => {
+  await page.locator('#export-length-min').fill(String(min));
+  await page.locator('#export-length-sec').fill(String(sec));
+  await page.locator('#export-length-sec').press('Enter');
+  return page.evaluate(() => ({
+    speed: document.getElementById('export-speed').value,
+    min: document.getElementById('export-length-min').value,
+    sec: document.getElementById('export-length-sec').value,
+    readout: document.getElementById('export-adjust-readout').textContent,
+  }));
+};
+
+test('minute/second boxes drive the rate; the boxes keep the requested length', async ({ page }) => {
+  await setup(page, 60); // 1 minute of content
+
+  // enabling the adjust panel prefills the boxes with the content length
+  const initial = await page.evaluate(() => ({
+    min: document.getElementById('export-length-min').value,
+    sec: document.getElementById('export-length-sec').value,
+  }));
+  expect(initial).toEqual({ min: '1', sec: '0' });
+
+  const half = await enterLength(page, 0, 30);
+  expect(half.speed).toBe('2');
+  // the boxes keep what was typed — the readout carries the outcome
+  expect(half).toMatchObject({ min: '0', sec: '30' });
+
+  const double = await enterLength(page, 2, 0);
+  expect(double.speed).toBe('0.5');
+
+  // the original bug scenario, unit-safe now: 15 in the MINUTES box on short
+  // content caps at the 0.25x floor and says so — it can never read as 15s
+  const fifteen = await enterLength(page, 15, 0);
+  expect(fifteen.speed).toBe('0.25');
+  expect(fifteen.readout).toContain('capped at 0.25×');
+  expect(fifteen.readout).toContain('longest is 4:00');
+
+  // an over-full seconds box rolls over instead of erroring
+  const rolled = await enterLength(page, 1, 90);
+  expect(rolled.speed).toBe('0.4'); // 60s / 150s
+  expect(rolled.min).toBe('2');
+  expect(rolled.sec).toBe('30');
+});
+
+test('an impossible target explains the cap instead of snapping silently', async ({ page }) => {
+  await setup(page, 60);
+  // 60s into 6s wants 10x → capped at 4x, with the reachable floor named
+  const capped = await enterLength(page, 0, 6);
+  expect(capped.speed).toBe('4');
+  expect(capped.readout).toContain('capped at 4×');
+  expect(capped.readout).toContain('shortest is 0:15');
+  expect(capped).toMatchObject({ min: '0', sec: '6' }); // the request stands
+  expect(capped.readout).toContain('→ 0:15 at 4×');     // the outcome is shown
+});

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -1158,3 +1158,16 @@ label[data-a11y-wired]:focus-visible {
   font-weight: 700;
   font-size: 1.05rem;
 }
+
+/* The export adjust panel's number inputs (speed, target minutes/seconds)
+   drop the browser spinner buttons — the slider covers coarse speed changes
+   and the spinners just crowded the small boxes. */
+#export-adjust-panel input[type="number"]::-webkit-outer-spin-button,
+#export-adjust-panel input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+#export-adjust-panel input[type="number"] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}

--- a/index.html
+++ b/index.html
@@ -778,12 +778,18 @@ If you are creating an open source application under a license compatible with t
           <input id="export-speed" type="number" min="0.25" max="4" step="0.05" value="1" class="input input-bordered input-sm" style="width:92px" aria-label="Export speed factor" />
           <span class="label-text">×</span>
         </div>
-        <div style="display:flex; gap:10px; align-items:center; margin-top:8px">
-          <span class="label-text" style="min-width:48px">Length</span>
-          <input id="export-length" type="text" inputmode="numeric" placeholder="m:ss" class="input input-bordered input-sm" style="width:92px" aria-label="Export length" />
-          <span id="export-length-orig" class="label-text" style="opacity:0.6"></span>
+        <div style="display:flex; gap:6px; align-items:center; margin-top:8px">
+          <span class="label-text" style="min-width:48px; margin-right:4px">Length</span>
+          <input id="export-length-min" type="number" min="0" step="1" class="input input-bordered input-sm" style="width:64px" aria-label="Export length minutes" />
+          <span class="label-text">min</span>
+          <input id="export-length-sec" type="number" min="0" max="59" step="1" class="input input-bordered input-sm" style="width:64px" aria-label="Export length seconds" />
+          <span class="label-text">sec</span>
+          <span id="export-length-orig" class="label-text" style="opacity:0.6; margin-left:4px"></span>
         </div>
-        <div id="export-adjust-readout" style="font-size:85%; opacity:0.8; margin-top:8px"></div>
+        <!-- min-height reserves two lines: the text length varies (quality
+             warning, rate-cap note), and letting it wrap 1↔2 lines made the
+             modal jump about -->
+        <div id="export-adjust-readout" style="font-size:85%; opacity:0.8; margin-top:8px; min-height:3.6em; white-space:pre-line"></div>
       </div>
       <label id="export-burn-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
         <input type="checkbox" id="export-burn" class="toggle toggle-primary" />
@@ -1011,7 +1017,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/editor-main.js?v=0.8.0"></script>
   <script src="js/find-replace.js?v=0.6.29"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
-  <script src="js/media-export.js?v=0.8.6"></script>
+  <script src="js/media-export.js?v=0.9.1"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
   <script src="js/word-vtt.js?v=0.8.5"></script>
   <!-- end of caption editor additions -->

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -560,7 +560,8 @@
   const adjustPanel = document.getElementById('export-adjust-panel');
   const speedInput = document.getElementById('export-speed');
   const speedSlider = document.getElementById('export-speed-slider');
-  const lengthInput = document.getElementById('export-length');
+  const lengthMinInput = document.getElementById('export-length-min');
+  const lengthSecInput = document.getElementById('export-length-sec');
   const lengthOrigEl = document.getElementById('export-length-orig');
   const adjustReadout = document.getElementById('export-adjust-readout');
   const retimeRow = document.getElementById('export-retime-row');
@@ -617,31 +618,44 @@
     s = Math.max(0, Math.round(s));
     return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
   };
-  const parseLen = (str) => {
-    const t = String(str).trim();
-    if (t === '') return NaN;
-    if (t.includes(':')) {
-      const [m, s] = t.split(':');
-      const mm = parseInt(m, 10), ss = parseInt(s, 10);
-      return (isNaN(mm) || isNaN(ss)) ? NaN : mm * 60 + ss;
-    }
-    const n = parseFloat(t);
-    return isNaN(n) ? NaN : n;
+  // The target length is entered as SEPARATE minutes/seconds boxes (#441):
+  // the old single m:ss text field read a bare "15" as 15 seconds, so a
+  // 16-minute video typed as "15" computed a 64x rate, slammed into the 4x
+  // cap and rewrote the field to ~4:00 with no explanation. Explicit unit
+  // boxes remove the guessing entirely.
+  const setLengthBoxes = (secondsTotal) => {
+    if (lengthMinInput === null || lengthSecInput === null) return;
+    const s = Math.max(0, Math.round(secondsTotal));
+    lengthMinInput.value = String(Math.floor(s / 60));
+    lengthSecInput.value = String(s % 60);
+  };
+  const readLengthBoxes = () => {
+    if (lengthMinInput === null || lengthSecInput === null) return 0;
+    const m = parseInt(lengthMinInput.value, 10);
+    const s = parseFloat(lengthSecInput.value);
+    // an over-full seconds box (e.g. 90) just rolls over on the reformat
+    return (isNaN(m) ? 0 : Math.max(0, m)) * 60 + (isNaN(s) ? 0 : Math.max(0, s));
   };
 
-  const updateAdjustReadout = () => {
+  // Two fixed lines (white-space:pre-line + reserved min-height in the
+  // markup): the outcome on the first, any warning/cap note on the second —
+  // variable-length single-line text made the modal reflow.
+  const updateAdjustReadout = (capNote = '') => {
     if (adjustReadout === null) return;
     const rate = clampRate(parseFloat(speedInput.value));
     const len = currentContentLength() / rate;
-    const warn = (rate < 0.5 || rate > 2) ? '  ⚠ noticeable quality loss' : '';
-    adjustReadout.textContent = `→ ${fmtLen(len)} at ${+rate.toFixed(2)}×, pitch preserved${warn}`;
+    const warn = (rate < 0.5 || rate > 2) ? '⚠ noticeable quality loss' : '';
+    const second = capNote !== '' ? `⚠ ${capNote}` : warn;
+    adjustReadout.textContent =
+      `→ ${fmtLen(len)} at ${+rate.toFixed(2)}×, pitch preserved` +
+      (second !== '' ? `\n${second}` : '');
   };
   // Speed is the source of truth; mirror it to the slider and derive the length.
   const syncFromSpeed = () => {
     const rate = clampRate(parseFloat(speedInput.value));
     speedInput.value = String(+rate.toFixed(2));
     if (speedSlider !== null) speedSlider.value = String(rate);
-    if (lengthInput !== null) lengthInput.value = fmtLen(currentContentLength() / rate);
+    setLengthBoxes(currentContentLength() / rate);
     updateAdjustReadout();
   };
   const syncFromSlider = () => {
@@ -649,12 +663,31 @@
     syncFromSpeed();
   };
   const syncFromLength = () => {
-    const target = parseLen(lengthInput.value);
+    const target = readLengthBoxes();
     const content = currentContentLength();
+    // When the target can't be met, say WHY in the readout — the old silent
+    // snap to the capped value read as a glitch.
+    let note = '';
     if (target > 0 && content > 0) {
-      speedInput.value = String(+clampRate(content / target).toFixed(2));
+      const raw = content / target;
+      const rate = clampRate(raw);
+      speedInput.value = String(+rate.toFixed(2));
+      if (speedSlider !== null) speedSlider.value = String(rate);
+      if (raw > RATE_MAX) {
+        note = `capped at ${RATE_MAX}× — the shortest is ${fmtLen(content / RATE_MAX)}`;
+      } else if (raw < RATE_MIN) {
+        note = `capped at ${RATE_MIN}× — the longest is ${fmtLen(content / RATE_MIN)}`;
+      }
     }
-    syncFromSpeed();   // reformat length to the (possibly clamped) rate
+    // The boxes hold the USER'S REQUESTED length and are deliberately not
+    // rewritten here — reformatting on every change fought sequential
+    // min→sec entry (the min box's change event fires when focus moves on).
+    // The readout shows the length actually delivered; only an over-full
+    // seconds box (90 → 1:30) is normalised.
+    if (lengthSecInput !== null && parseFloat(lengthSecInput.value) >= 60) {
+      setLengthBoxes(target);
+    }
+    updateAdjustReadout(note);
   };
   const updateAdjustVisibility = () => {
     if (adjustPanel === null || adjustCheck === null || adjustRow === null) return;
@@ -904,7 +937,8 @@
     });
     speedInput.addEventListener('input', () => { syncFromSpeed(); saveExportOpts(); });
     if (speedSlider !== null) speedSlider.addEventListener('input', () => { syncFromSlider(); saveExportOpts(); });
-    lengthInput.addEventListener('change', () => { syncFromLength(); saveExportOpts(); });
+    if (lengthMinInput !== null) lengthMinInput.addEventListener('change', () => { syncFromLength(); saveExportOpts(); });
+    if (lengthSecInput !== null) lengthSecInput.addEventListener('change', () => { syncFromLength(); saveExportOpts(); });
   }
   [burnCheck, retimeCheck, vttCheck, srtCheck].forEach((el) => {
     if (el !== null) el.addEventListener('change', saveExportOpts);


### PR DESCRIPTION
Fixes the report of the export speed always jumping to 4×: the single m:ss target-length field read a bare "15" as 15 seconds, so a 16-minute video's 15-minute target computed a 64× rate, hit the 4× cap, and rewrote the field to ~4:00 unexplained.

- Separate **minutes / seconds number boxes** — units are visible, nothing to guess, gibberish impossible.
- Boxes keep the **requested** length (no mid-entry rewrites that fight min→sec tabbing); the readout shows the **delivered** length. Over-full seconds roll over (1 min 90 s → 2:30).
- Rate caps explain themselves on a dedicated second readout line ("capped at 4× — the shortest is 4:07"); the readout reserves two lines so the modal no longer reflows as text length varies.
- Spinner buttons removed from the adjust panel's number inputs; `media-export.js` cache-buster → 0.9.1.

Testing: new `export-length.spec.mjs` (box-driven rate in both directions, requested-vs-delivered semantics, seconds rollover, cap messaging); full suites green (44 unit / 66 e2e).