### PR TITLE
Interactive transcript export: missing-media fallback, Recents media reference, attribution footer

### DIFF
--- a/__TEST__/e2e/interactive-export-filename.spec.mjs
+++ b/__TEST__/e2e/interactive-export-filename.spec.mjs
@@ -94,3 +94,28 @@ test('a fresh remote URL wins over a stale stamped local reference', async ({ pa
   });
   expect(await openExportModalValue(page)).toBe('https://example.com/fresh/remote.mp3');
 });
+
+test('the exported page includes the missing-media fallback and the typed reference', async ({ page }) => {
+  await loadLocalMedia(page, 'clip.mp4', 'video/mp4');
+  await openExportModalValue(page);
+  // the template fetch resolves asynchronously after load — retry until the
+  // download is built from the real template
+  let text = '';
+  for (let i = 0; i < 10 && !text.includes('<video'); i++) {
+    const downloadPromise = page.waitForEvent('download');
+    await page.evaluate(() => {
+      const m = document.getElementById('interactive-export-modal');
+      m.checked = true; m.dispatchEvent(new Event('change'));
+    });
+    await page.click('#interactive-export-download');
+    const download = await downloadPromise;
+    text = await (await import('node:fs/promises')).readFile(await download.path(), 'utf8');
+    if (!text.includes('<video')) await page.waitForTimeout(300);
+  }
+  expect(text).toMatch(/<video[^>]*src="clip\.mp4"/);
+  // a page moved away from its media explains itself instead of a dead player
+  expect(text).toContain('media-missing-note');
+  expect(text).toContain('same folder as the media file');
+  // attribution footer links back to the editor
+  expect(text).toMatch(/<a href="https:\/\/hyperaudio\.github\.io\/hyperaudio-lite-editor\/"[^>]*>Made with Hyperaudio<\/a>/);
+});

--- a/__TEST__/e2e/storage.spec.mjs
+++ b/__TEST__/e2e/storage.spec.mjs
@@ -422,6 +422,85 @@ test('edits autosave (debounced) to the active entry and bump its updated stamp 
   expect(after.meta.updated).toBeGreaterThan(before.updated);
 });
 
+test('a Recents load restores the media reference for the interactive export (#426)', async ({ page }) => {
+  await seed(page);
+  // a local-media doc: video is the indexeddb: marker, the blob is cached
+  // under meta.mediaKey, and meta.mediaRef holds the original filename
+  await page.evaluate(() => new Promise((resolve) => {
+    const open = indexedDB.open('hyperaudioMedia', 1);
+    open.onupgradeneeded = () => open.result.createObjectStore('media');
+    open.onsuccess = () => {
+      const tx = open.result.transaction('media', 'readwrite');
+      tx.objectStore('media').put('data:audio/mp3;base64,AAAA', 'm-key');
+      tx.oncomplete = () => resolve();
+    };
+  }));
+  await page.evaluate(() => {
+    localStorage.setItem('hyperaudio:doc:localdoc', JSON.stringify({
+      hypertranscript: '<article><section><p><span data-m="0" data-d="500">LOCAL </span></p></section></article>',
+      video: 'indexeddb:', summary: '', topics: [],
+      meta: { name: 'my doc', mediaKey: 'm-key', mediaRef: 'clip.mp4', updated: 5000 },
+    }));
+    loadLocalStorageOptions();
+    [...document.querySelectorAll('.file-item')].find((a) => a.textContent === 'my doc').click();
+  });
+  await page.waitForTimeout(400);
+  const r = await page.evaluate(() => {
+    const modal = document.getElementById('interactive-export-modal');
+    modal.checked = true;
+    modal.dispatchEvent(new Event('change'));
+    return {
+      stamped: document.getElementById('hyperplayer').dataset.mediaRef,
+      dialogValue: document.getElementById('interactive-media-filename').value,
+      playerSrc: document.getElementById('hyperplayer').src,
+    };
+  });
+  expect(r.stamped).toBe('clip.mp4');
+  expect(r.dialogValue).toBe('clip.mp4');
+  expect(r.playerSrc.startsWith('data:')).toBe(true); // the cached media loaded
+
+  // autosave must carry the reference through the meta rebuild
+  await page.evaluate(() => {
+    const span = document.querySelector('#hypertranscript span[data-m]');
+    span.textContent = 'LOCAL-EDIT ';
+    span.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await page.waitForTimeout(2600);
+  expect(await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('hyperaudio:doc:localdoc')).meta.mediaRef)).toBe('clip.mp4');
+});
+
+test('a pre-mediaRef entry whose name is still the media filename backfills the reference (#426)', async ({ page }) => {
+  await seed(page);
+  await page.evaluate(() => {
+    localStorage.setItem('hyperaudio:doc:old', JSON.stringify({
+      hypertranscript: '<article><section><p><span data-m="0" data-d="500">OLD </span></p></section></article>',
+      video: 'indexeddb:', summary: '', topics: [],
+      meta: { name: 'clapper-march-13.mp4', mediaKey: 'nope', updated: 5000 }, // no mediaRef
+    }));
+    loadLocalStorageOptions();
+    [...document.querySelectorAll('.file-item')].find((a) => a.textContent === 'clapper-march-13.mp4').click();
+  });
+  await page.waitForTimeout(300);
+  const r = await page.evaluate(() => {
+    const modal = document.getElementById('interactive-export-modal');
+    modal.checked = true;
+    modal.dispatchEvent(new Event('change'));
+    return document.getElementById('interactive-media-filename').value;
+  });
+  expect(r).toBe('clapper-march-13.mp4');
+});
+
+test('an entry predating mediaRef clears the stamp instead of offering stale media (#426)', async ({ page }) => {
+  await seed(page);
+  await page.evaluate(() => {
+    document.getElementById('hyperplayer').dataset.mediaRef = 'stale-previous.mp4';
+    [...document.querySelectorAll('.file-item')].find((a) => a.textContent === 'alpha').click();
+  });
+  await page.waitForTimeout(300);
+  expect(await page.evaluate(() => document.getElementById('hyperplayer').dataset.mediaRef)).toBeUndefined();
+});
+
 test('a filename containing markup renders as text (#410)', async ({ page }) => {
   await seed(page);
   await page.evaluate(() => {

--- a/hyperaudio-template.html
+++ b/hyperaudio-template.html
@@ -62,7 +62,37 @@
     <div id="hypertranscript" class="hyperaudio-transcript">
 {hypertranscript}
     </div>
+
+    <footer style="max-width:34rem; margin:16px auto 24px; text-align:center; font-size:0.85rem; color:#a2a2a2;">
+      <a href="https://hyperaudio.github.io/hyperaudio-lite-editor/" style="color:inherit; text-decoration:underline;">Made with Hyperaudio</a>
+    </footer>
   </main>
+
+  <script>
+  // If the media can't be found — most often because this page was moved away
+  // from its media file — explain how to fix it instead of showing a dead
+  // player. The media is referenced by RELATIVE path on purpose: the page and
+  // its media travel (and upload) together; an absolute local path would break
+  // the moment either is shared or hosted.
+  (function () {
+    var player = document.getElementById('hyperplayer');
+    if (!player) return;
+    player.addEventListener('error', function () {
+      if (document.getElementById('media-missing-note')) return;
+      var ref = player.getAttribute('src') || 'the media file';
+      var note = document.createElement('div');
+      note.id = 'media-missing-note';
+      note.setAttribute('role', 'alert');
+      note.style.cssText = 'max-width:420px; margin:0 auto 24px; padding:14px 18px; ' +
+        'border:1px solid #e5b5b5; border-radius:10px; background:#fdf3f3; color:#7a2e2e; ' +
+        'font-size:0.95rem; line-height:1.5;';
+      note.textContent = 'Couldn’t load “' + ref + '”. Keep this page in the ' +
+        'same folder as the media file — or, if the media is hosted online, edit this ' +
+        'file’s video src to its full URL.';
+      player.insertAdjacentElement('afterend', note);
+    });
+  })();
+  </script>
 
   <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/hyperaudio-lite.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/hyperaudio-lite-extension.js"></script>

--- a/index.html
+++ b/index.html
@@ -817,7 +817,7 @@ If you are creating an open source application under a license compatible with t
       <label class="label-text" for="interactive-media-filename">Media file or URL</label>
       <input id="interactive-media-filename" type="text" class="input input-bordered w-full" placeholder="e.g. my-video.mp4" style="margin-top:4px" />
       <div style="font-size:85%; opacity:0.75; margin-top:8px">
-        The page links to your media by this path and loads the Hyperaudio Lite player so words stay clickable. For a local file, save the downloaded HTML in the same folder as the media file so it can be found.
+        The page links to your media by this path and loads the Hyperaudio Lite player so words stay clickable. For a local file, keep the downloaded HTML in the same folder as the media file — they travel (and upload to a server) as a pair. If the media is hosted online, or will be, use its full URL here instead.
       </div>
       <div class="modal-action">
         <button id="interactive-export-download" class="btn btn-primary">Download</button>
@@ -970,14 +970,14 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-extension.js?v=0.7.2"></script>
   <script src="js/caption.js?v=0.8.6"></script>
   <script src="js/transcript-serializer.js?v=0.8.5"></script>
-  <script src="js/editor-core.js?v=0.8.11"></script>
+  <script src="js/editor-core.js?v=0.9.1"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
   <import-srt></import-srt>
   <import-vtt></import-vtt>
   
-  <script src="./js/hyperaudio-lite-editor-storage.js?v=0.9.0"></script>
+  <script src="./js/hyperaudio-lite-editor-storage.js?v=0.9.1"></script>
 
   <script src="js/editor-file-menu.js?v=0.9.0"></script>
 

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -77,7 +77,7 @@
   window.document.addEventListener('hyperaudioGenerateCaptionsFromTranscript', hyperaudioGenerateCaptionsFromTranscript, false);
   let hyperaudioTemplate = "";
 
-  fetch('hyperaudio-template.html')
+  fetch('hyperaudio-template.html?v=0.9.1') // bump with the template — an unversioned fetch served stale copies from the browser cache
   .then(function(response) {
       // When the page is loaded convert it to text
       return response.text()

--- a/js/hyperaudio-lite-editor-storage.js
+++ b/js/hyperaudio-lite-editor-storage.js
@@ -237,11 +237,27 @@ function renderTranscript(
   // file, so a stale cue from the old transcript can't stay painted (#356/#287).
   resetCaptionTrack(videoDomId, vttId);
 
-  // Drop any media reference stamped by a previous local/remote load so the
-  // interactive-transcript export can't offer it for this Recents entry (a remote
-  // http src is read from the player directly; a local one falls back to empty).
+  // Re-stamp the media reference from the entry itself so the interactive-
+  // transcript export can offer it (meta.mediaRef, saved with the doc).
+  // Backfill for entries saved before that field existed: an auto-added
+  // entry's NAME defaults to the media filename, so a name that still looks
+  // like one IS the reference (the next autosave then persists it). A doc
+  // renamed to something without a media extension clears the stamp instead —
+  // offering stale previously-loaded media would be worse than offering none.
   const loadedVideo = document.getElementById(videoDomId);
-  if (loadedVideo) delete loadedVideo.dataset.mediaRef;
+  if (loadedVideo) {
+    const meta = hypertranscriptstorage.meta || {};
+    let storedRef = (typeof meta.mediaRef === 'string') ? meta.mediaRef : '';
+    if (storedRef === '' && typeof meta.name === 'string' &&
+        /\.(mp4|webm|ogv|ogg|mov|m4v|mkv|mp3|m4a|wav|aac|flac|opus)$/i.test(meta.name.trim())) {
+      storedRef = meta.name.trim();
+    }
+    if (storedRef !== '') {
+      loadedVideo.dataset.mediaRef = storedRef;
+    } else {
+      delete loadedVideo.dataset.mediaRef;
+    }
+  }
 
   let hypertranscriptElement = document.getElementById(hypertranscriptDomId);
 
@@ -260,7 +276,14 @@ function renderTranscript(
   if (hypertranscriptstorage['video'].startsWith("http") === true) {
     document.getElementById(videoDomId).src = hypertranscriptstorage['video'];
   } else {
-    //load from indexedDB
+    // load from indexedDB — clearing the previous (e.g. demo, or prior doc's
+    // remote) src FIRST: it would otherwise linger until the blob arrives, or
+    // forever if the cached media is missing, and an http src outranks this
+    // doc's own media reference in guessMediaSrc (the interactive export
+    // would offer the WRONG media).
+    const playerEl = document.getElementById(videoDomId);
+    playerEl.removeAttribute('src');
+    playerEl.load();
     getMedia(MEDIA_DATABASE, MEDIA_STORE, mediaKey);
   }
 
@@ -347,6 +370,13 @@ function getMedia(databaseName, objectStoreName, id) {
     getRequest.onsuccess = function() {
 
       const base64String = getRequest.result; // Base64 string
+
+      // no cached media under this key (deleted, or never saved) — leave the
+      // player alone rather than setting src to the string "undefined"
+      if (base64String === undefined) {
+        console.warn("No cached media found for:", id);
+        return;
+      }
 
       /* The following commented lines should work (but don't) for a more elegant solution */
       /*const binaryString = atob(base64String.split(',')[1]); // Binary data string
@@ -467,6 +497,14 @@ function saveHyperTranscriptToLocalStorage(
 
   let video = document.getElementById(videoDomId).src;
 
+  // The media reference the interactive-transcript export offers for this doc
+  // (#430/#426): a remote src as-is, else the stamped local filename
+  // (dataset.mediaRef). A Recents load re-stamps from the saved value, and an
+  // older entry may predate this field — fall back to the previous save's.
+  const liveMediaRef = /^https?:/i.test(video)
+    ? video
+    : (document.getElementById(videoDomId).dataset.mediaRef || '');
+
   // A doc loaded from Recents carries a base64 data: URL as its src (getMedia
   // sets it directly). Never serialise that payload into the localStorage JSON
   // — the media already lives in IndexedDB under meta.mediaKey. Store a marker
@@ -489,6 +527,7 @@ function saveHyperTranscriptToLocalStorage(
     created: prevMeta.created || now,
     updated: now,
     starred: prevMeta.starred === true, // meta is rebuilt — carry the star through
+    mediaRef: liveMediaRef || prevMeta.mediaRef || undefined, // undefined drops from the JSON
   };
 
   // if media url begins with blob it means it's locally cached only for the session


### PR DESCRIPTION
- Exported pages (both export paths share the template) show an explanatory note when their media can't be found, instead of a dead player, and carry a "Made with Hyperaudio" footer linking the editor.
- Entries store `meta.mediaRef`; Recents loads re-stamp it so the FILE-menu interactive export prepopulates. Pre-fix entries backfill from a media-filename-shaped name. Loads clear the player's stale http src before IndexedDB fetch — it used to outrank the doc's own reference and could offer the WRONG media (the intro demo or a prior doc's URL).
- `getMedia` hardened against missing blobs; template fetch gains a cache-buster; dialog copy sharpened (keep page+media together; full URL when hosted).

Testing: 44 unit / 68 e2e green, including new coverage for the fallback note, footer, mediaRef round-trip incl. autosave, the name backfill, and the stale-src case.

Known issue (tracked separately): one real-world report of the dialog still prepopulating empty from a Recents doc after these fixes — not reproduced by the suite.