### PR TITLE
Preserve struck words in the HTML/JSON round-trip (#403 Phase A)

### DIFF
--- a/__TEST__/unit/html-json-converter.test.mjs
+++ b/__TEST__/unit/html-json-converter.test.mjs
@@ -83,3 +83,18 @@ test('clean text is untouched', () => {
   assert.match(html, /<span data-m="4760" data-d="0" class="speaker">\[Alice\] <\/span>/);
   assert.match(html, /<span data-m="4760" data-d="520">Testing <\/span>/);
 });
+
+test('struck words serialize with line-through and stay escaped (#403)', () => {
+  // The converter used to drop redactions in both directions, silently
+  // resurrecting every cut through a JSON round trip. The strike attribute
+  // must also compose with #406's escaping — both landed on this line.
+  const html = jsonToHTML({
+    words: [
+      { start: 1.0, end: 1.5, text: 'keep' },
+      { start: 1.6, end: 2.0, text: '<cut>', struck: true },
+    ],
+  });
+  assert.match(html, /<span data-m="1600" data-d="400" style="text-decoration: line-through;">&lt;cut&gt; <\/span>/);
+  // the default (unstruck) word carries no style attribute
+  assert.match(html, /<span data-m="1000" data-d="500">keep <\/span>/);
+});

--- a/js/editor-audio-cut.js
+++ b/js/editor-audio-cut.js
@@ -57,6 +57,34 @@
   document.querySelector('#remove-gaps-threshold').addEventListener('input', applyGapSettings);
   document.querySelector('#remove-gaps-buffer').addEventListener('input', applyGapSettings);
 
+  // Read/apply for the project save module (js/hyperaudio-save.js): the gap
+  // settings are module-locals here, and a loaded .hyperaudio project must be
+  // able to restore them. Applying goes through the UI controls so the dialog
+  // stays in sync, then reuses the normal applyGapSettings() path.
+  window.getGapRemovalSettings = function () {
+    return {
+      enabled: removeGapsEnabled,
+      thresholdMs: Math.round(gapThreshold * 1000),
+      bufferMs: Math.round(gapBuffer * 1000),
+    };
+  };
+  window.applyGapRemovalSettings = function (settings) {
+    if (!settings || typeof settings !== 'object') return;
+    const enabledEl = document.querySelector('#remove-gaps-enabled');
+    const thresholdEl = document.querySelector('#remove-gaps-threshold');
+    const bufferEl = document.querySelector('#remove-gaps-buffer');
+    if (typeof settings.enabled === 'boolean' && enabledEl) {
+      enabledEl.checked = settings.enabled;
+    }
+    if (Number.isFinite(settings.thresholdMs) && settings.thresholdMs > 0 && thresholdEl) {
+      thresholdEl.value = String(settings.thresholdMs);
+    }
+    if (Number.isFinite(settings.bufferMs) && settings.bufferMs >= 0 && bufferEl) {
+      bufferEl.value = String(settings.bufferMs);
+    }
+    applyGapSettings();
+  };
+
   function updateRemoveGapsBtnState() {
     const dot = document.querySelector('#remove-gaps-active-dot');
     if (!dot) return;

--- a/js/html-json-converter.js
+++ b/js/html-json-converter.js
@@ -22,6 +22,9 @@
  *   ]
  * }
  * - Times in SECONDS (floating point)
+ * - A redacted (struck-out) word carries "struck": true; the default (false)
+ *   is not serialized. In HTML a redaction is the inline style
+ *   text-decoration: line-through on the word span (see editor-audio-cut.js).
  * 
  * HTML (Legacy format):
  * <article><section>
@@ -142,9 +145,10 @@ function jsonToHTML(jsonData) {
         const endMs = Math.round(word.end * 1000);
         const durationMs = endMs - startMs;
         const trail = word.space === false ? '' : ' ';
+        const strike = word.struck === true ? ' style="text-decoration: line-through;"' : '';
         const gluedToPrev = wordIndex > 0 && paragraphWords[wordIndex - 1].space === false;
         const lead = wordIndex === 0 ? '    ' : gluedToPrev ? '' : '\n    ';
-        html += `${lead}<span data-m="${startMs}" data-d="${durationMs}">${escapeHTMLText(word.text)}${trail}</span>`;
+        html += `${lead}<span data-m="${startMs}" data-d="${durationMs}"${strike}>${escapeHTMLText(word.text)}${trail}</span>`;
       });
       html += '\n';
       
@@ -161,9 +165,10 @@ function jsonToHTML(jsonData) {
       const endMs = Math.round(word.end * 1000);
       const durationMs = endMs - startMs;
       const trail = word.space === false ? '' : ' ';
+      const strike = word.struck === true ? ' style="text-decoration: line-through;"' : '';
       const gluedToPrev = wordIndex > 0 && words[wordIndex - 1].space === false;
       const lead = wordIndex === 0 ? '    ' : gluedToPrev ? '' : '\n    ';
-      html += `${lead}<span data-m="${startMs}" data-d="${durationMs}">${escapeHTMLText(word.text)}${trail}</span>`;
+      html += `${lead}<span data-m="${startMs}" data-d="${durationMs}"${strike}>${escapeHTMLText(word.text)}${trail}</span>`;
     });
     html += '\n';
     
@@ -250,6 +255,13 @@ function htmlToJSON(html) {
       // Omitted (the common case) means a space follows.
       if (!/\s$/.test(raw)) {
         word.space = false;
+      }
+
+      // Preserve redactions: the editor marks a struck-out word with the
+      // inline style text-decoration: line-through (editor-audio-cut.js).
+      // Omitted (the common case) means not struck.
+      if (/line-through/.test(span.getAttribute('style') || '')) {
+        word.struck = true;
       }
 
       words.push(word);


### PR DESCRIPTION
First slice of the #403 Phase A sequence — cherry-picked from #404 so this data-integrity fix lands independently of the storage work.

The HTML↔JSON converter dropped redactions (inline line-through) in both directions, so any JSON export/import silently resurrected every cut. Words now carry `struck: true` (default not serialized), and `editor-audio-cut.js` exposes `getGapRemovalSettings`/`applyGapRemovalSettings` so a loaded project can restore gap-removal state through the normal UI path.

Conflict resolved against `main`: #406's escaping landed on the same serializer line after this branched — the resolution composes both (strike attribute + escaped text), and a new unit test pins exactly that composition.

Tests: 45 unit / 70 e2e green.