### PR TITLE
Gate Parakeet's WebGPU path on shader-f16 and fail loudly on empty transcription output

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-editor-assemblyai.js?v=0.8.1"></script>
   <script src="js/hyperaudio-lite-editor-parakeet.js?v=0.8.2"></script>
   <script src="js/transcribe-prefs.js?v=0.8.2"></script>
-  <script src="js/hyperaudio-lite-editor-whisper.js?v=0.6.26"></script>
-  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.8.6"></script>
+  <script src="js/hyperaudio-lite-editor-whisper.js?v=1.0.2"></script>
+  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=1.0.2"></script>
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js?v=1.0.0"></script>
   <script src="js/transcript-to-ionosphere.js?v=0.6.18"></script>

--- a/js/hyperaudio-lite-editor-parakeet-local.js
+++ b/js/hyperaudio-lite-editor-parakeet-local.js
@@ -1,7 +1,7 @@
 /**
  * hyperaudio-lite-editor-parakeet-local.js
  * (C) The Hyperaudio Project
- * @version 0.8.6 — last changed in release 0.8.6
+ * @version 1.0.2 — last changed in release 1.0.2
  * @license MIT
  */
 
@@ -61,7 +61,7 @@ function loadParakeetClient(modal, workerBaseUrl) {
     workerBaseUrl = "./";
   }
 
-  const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=0.7.0";
+  const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=1.0.2";
 
   // On Chrome (Chromium) Parakeet runs fp16 on the GPU (WebGPU) – fast, and the
   // default. Firefox's WebGPU underperforms here and Safari's can exhaust memory

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -1,7 +1,7 @@
 /**
  * hyperaudio-lite-editor-whisper.js
  * (C) The Hyperaudio Project
- * @version 0.6.26 — last changed in release 0.6.26
+ * @version 1.0.2 — last changed in release 1.0.2
  * @license MIT
  */
 
@@ -65,7 +65,7 @@ function loadWhisperClient(modal, workerBaseUrl) {
     workerBaseUrl = "./";
   }
 
-  const whisperWorkerPath = workerBaseUrl + "js/whisper.worker.js?v=0.6.7";
+  const whisperWorkerPath = workerBaseUrl + "js/whisper.worker.js?v=1.0.2";
 
   // Firefox runs Whisper on the CPU (its WebGPU is still much slower than
   // its CPU path) – workable for the smaller models, but the larger ones may

--- a/js/parakeet.worker.js
+++ b/js/parakeet.worker.js
@@ -1,7 +1,7 @@
 /**
  * parakeet.worker.js
  * (C) The Hyperaudio Project
- * @version 0.7.0 — last changed in release 0.7.0
+ * @version 1.0.2 — last changed in release 1.0.2
  * @license MIT
  */
 
@@ -18,6 +18,7 @@ const BLANK = 8192;
 const STATE_DIM = 640;       // decoder predict-net state width
 const MAX_SYMBOLS = 10;      // max tokens emitted on a single frame
 const FRAME_SEC = 0.08;      // 8x subsampling * 10ms hop
+const MIN_SPEECH_S = 10;     // audio at least this long is assumed to contain speech
 
 const HF = "https://huggingface.co";
 const MODELS = {
@@ -47,6 +48,12 @@ self.addEventListener("message", async (event) => {
       sessionsForceGpu = forceGpu;
     }
     const output = await transcribe(sessions, event.data.audio);
+    // A broken GPU can "complete" with no output at all (async WebGPU
+    // validation errors never reject run()) — report that as a failure
+    // rather than rendering a blank transcript as if it were done (#460).
+    if (output.words.length === 0 && event.data.audio.length >= MIN_SPEECH_S * SAMPLE_RATE) {
+      throw new Error("No words were produced — if this media contains speech, transcription failed silently. Reload the page and try again.");
+    }
     self.postMessage({ type: "result", output });
   } catch (e) {
     console.error(e);
@@ -64,13 +71,18 @@ async function releaseSessions(s) {
 
 // navigator.gpu existing does not mean a usable GPU exists (headless and
 // GPU-less machines expose the API but yield no adapter), so it must be
-// ruled out before attempting a WebGPU session, not after failing.
+// ruled out before attempting a WebGPU session, not after failing. The
+// adapter must also expose "shader-f16": the WebGPU path runs the fp16
+// encoder, and on an adapter without f16 support (seen on Linux with WebGPU
+// force-enabled over Vulkan) its pipelines fail compilation — asynchronously,
+// so run() still resolves and the encoder emits garbage (#459).
 async function hasGpuAdapter() {
   try {
     if (!self.navigator?.gpu) {
       return false;
     }
-    return (await self.navigator.gpu.requestAdapter()) !== null;
+    const adapter = await self.navigator.gpu.requestAdapter();
+    return adapter !== null && adapter.features.has("shader-f16");
   } catch (e) {
     return false;
   }
@@ -272,12 +284,22 @@ async function loadSessions(forceGpu) {
 
 // Push a short silent clip through the encoder so WebGPU shader compilation
 // (and any inference-time failure) happens now, under "Preparing model…".
+// WebGPU raises validation errors asynchronously — run() resolves even when
+// every pipeline failed to compile — so the warm-up runs inside an error
+// scope and throws on a captured error, which sends loadSessions down the
+// int8/WASM fallback instead of "succeeding" into a blank transcript (#459).
 async function warmUp(encoder) {
+  const device = ort.env.webgpu?.device;
+  device?.pushErrorScope("validation");
   const len = 100;
   await encoder.run({
     audio_signal: new ort.Tensor("float32", new Float32Array(128 * len), [1, 128, len]),
     length: new ort.Tensor("int64", BigInt64Array.from([BigInt(len)]), [1]),
   });
+  const gpuError = device ? await device.popErrorScope() : null;
+  if (gpuError) {
+    throw new Error(`WebGPU validation failed during warm-up: ${gpuError.message}`);
+  }
 }
 
 async function transcribe(s, audio) {

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -1,7 +1,7 @@
 /**
  * whisper.worker.js
  * (C) The Hyperaudio Project
- * @version 0.6.7 — last changed in release 0.6.7
+ * @version 1.0.2 — last changed in release 1.0.2
  * @license MIT
  */
 
@@ -10,6 +10,7 @@ import { pipeline } from "https://cdn.jsdelivr.net/npm/@huggingface/transformers
 const SAMPLE_RATE = 16000;
 const WINDOW_S = 300;   // transcribe in 5-minute windows to bound memory
 const OVERLAP_S = 10;   // each seam is transcribed by both windows
+const MIN_SPEECH_S = 10; // audio at least this long is assumed to contain speech
 
 let cache = { key: null, pipe: null, device: null };
 
@@ -36,15 +37,18 @@ self.addEventListener("message", async (event) => {
 
   try {
     const output = await transcribe(pipe, audio, language);
+    assertNotEmpty(output, audio);
     self.postMessage({ type: "result", output });
   } catch (e) {
     console.error(e);
     // WebGPU can pass pipeline init yet fail at inference time on some GPUs –
-    // rebuild on WASM and retry once before giving up.
+    // including "succeeding" with empty output – rebuild on WASM and retry
+    // once before giving up.
     if (cache.device === "webgpu") {
       try {
         pipe = await getPipeline(model_name, ["wasm"]);
         const output = await transcribe(pipe, audio, language);
+        assertNotEmpty(output, audio);
         self.postMessage({ type: "result", output });
         return;
       } catch (retryError) {
@@ -56,6 +60,17 @@ self.addEventListener("message", async (event) => {
     self.postMessage({ type: "error", stage: "transcribe", message: e?.message || String(e) });
   }
 });
+
+// A broken GPU can "complete" with no output at all (async WebGPU validation
+// errors never reject the run) — treat an empty result on non-trivial audio as
+// a failure rather than rendering a blank transcript as if it were done (#460).
+// Thrown from the main path it engages the WASM retry above; thrown from the
+// retry it surfaces as a transcription error.
+function assertNotEmpty(output, audio) {
+  if (output.chunks.length === 0 && audio.length >= MIN_SPEECH_S * SAMPLE_RATE) {
+    throw new Error("No words were produced — if this media contains speech, transcription failed silently. Reload the page and try again.");
+  }
+}
 
 // Preferred dtype first, then a fallback: the quantized exports of some of the
 // *_timestamped models predate the v4 ONNX runtime and fail session creation


### PR DESCRIPTION
Fixes #459, fixes #460.

## What

**#459 — blank Parakeet transcript on Linux/Vulkan.** The WebGPU path always runs the fp16 encoder, but `hasGpuAdapter()` only checked that an adapter exists. On an adapter without the `shader-f16` feature (seen with WebGPU force-enabled over Vulkan on Linux), the fp16 compute pipelines fail compilation *asynchronously* — `run()` still resolves — so the encoder emitted garbage and the run "succeeded" with an empty transcript. Two changes:

- `hasGpuAdapter()` now also requires `adapter.features.has("shader-f16")`, so unsupported adapters take the int8/WASM path from the start.
- The warm-up run is wrapped in a WebGPU validation error scope (`pushErrorScope`/`popErrorScope` on `ort.env.webgpu.device`) and throws if anything was captured, sending `loadSessions()` down the existing int8/WASM fallback for any other async pipeline-compilation failure. The device handle is optional-chained, so if a future onnxruntime stops exposing it the check degrades to a no-op.

**#460 — empty output reported as success.** Both workers now treat zero words/chunks from non-trivial audio (≥10 s, `MIN_SPEECH_S`) as a failure and post the normal transcription error instead of rendering a blank transcript as completed work. The threshold keeps short genuinely-silent clips from erroring. In the Whisper worker the guard throws inside the main try, deliberately engaging the existing WebGPU→WASM rebuild-and-retry before the error surfaces; the retry path re-checks so a still-empty result fails loudly.

## Versioning

Changed files bumped to 1.0.2; worker URLs cache-busted in both callers and the two caller `<script>` tags in `index.html`.

## Testing

- Unit: 60/60 pass. E2E (Playwright): 71/71 pass.
- Manual, Chrome on Apple silicon (exposes `shader-f16`): Parakeet still selects the GPU path — "Parakeet ready on webgpu (fp16)", 15.8 s of audio transcribed in 0.8 s — confirming the new gate doesn't over-restrict working setups.
- The failing case (RTX 3060, forced-Vulkan Chrome on Linux, #459) isn't reproducible locally; on that setup this change should yield either a working GPU run or a clean fall-through to CPU with the "Running on CPU" device label.