### PR TITLE
Whisper turbo is WebGPU-only: refuse WASM up front instead of downloading twice and failing

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@ If you are creating an open source application under a license compatible with t
             <option value="tiny">Whisper (Tiny) – ~40–80 MB, fastest, least accurate</option>
             <option selected="" value="base">Whisper (Base) – ~80–150 MB</option>
             <option value="small">Whisper (Small) – ~250–490 MB</option>
-            <option value="turbo">Whisper (Large v3 Turbo) – ~560 MB, GPU recommended</option>
+            <option value="turbo">Whisper (Large v3 Turbo) – ~560 MB, needs GPU</option>
           </select>
         </div>
         <label for="whisper-language" class="form-label label-text" style="display:block; padding-top:12px">Language</label>

--- a/js/hyperaudio-lite-editor-whisper.js
+++ b/js/hyperaudio-lite-editor-whisper.js
@@ -67,6 +67,34 @@ function loadWhisperClient(modal, workerBaseUrl) {
 
   const whisperWorkerPath = workerBaseUrl + "js/whisper.worker.js?v=1.0.2";
 
+  // Turbo is WebGPU-only (#461): neither of its quantised variants loads on
+  // the WASM runtime, so without a usable GPU the worker refuses it. Grey the
+  // option out up front rather than let users pick a model that can't run.
+  // Mirrors the worker's device choice, where Firefox prefers WASM over its
+  // slower WebGPU.
+  (async () => {
+    let gpuUsable = false;
+    try {
+      gpuUsable = !/firefox/i.test(navigator.userAgent)
+        && navigator.gpu !== undefined
+        && (await navigator.gpu.requestAdapter()) !== null;
+    } catch (e) {
+      // treat as no GPU
+    }
+    if (!gpuUsable && modelNameSelectionInput !== null) {
+      const turboOption = modelNameSelectionInput.querySelector('option[value="turbo"]');
+      if (turboOption !== null) {
+        turboOption.disabled = true;
+        turboOption.textContent = "Whisper (Large v3 Turbo) – needs a GPU (unavailable in this browser)";
+      }
+      // a persisted preference may already have restored turbo — drop back to
+      // the default model rather than submit with a disabled option selected
+      if (modelNameSelectionInput.value === "turbo") {
+        modelNameSelectionInput.value = "base";
+      }
+    }
+  })();
+
   // Firefox runs Whisper on the CPU (its WebGPU is still much slower than
   // its CPU path) – workable for the smaller models, but the larger ones may
   // be slow or fail. Say so up front rather than letting users find out.
@@ -253,7 +281,14 @@ function loadWhisperClient(modal, workerBaseUrl) {
     // #transcript-editor-btn's handler no-ops when already in transcript mode.
     document.querySelector('#transcript-editor-btn')?.click();
 
-    const size = modelNameSelectionInput.value;
+    let size = modelNameSelectionInput.value;
+    // a persisted "turbo" preference can be restored after the GPU probe above
+    // disabled the option (the probe is async, the restore races it) — fall
+    // back to the default model instead of submitting one the worker refuses
+    if (modelNameSelectionInput.selectedOptions[0]?.disabled) {
+      size = "base";
+      modelNameSelectionInput.value = "base";
+    }
     const language = languageSelectionInput !== null ? languageSelectionInput.value : "";
     // English gets the slightly more accurate English-only variants; any
     // other language (or auto-detect) needs the multilingual ones. Turbo

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -119,6 +119,19 @@ async function getPipeline(model_name, devices) {
     devices = !slowWebGpu && (await hasGpuAdapter()) ? ["webgpu", "wasm"] : ["wasm"];
   }
 
+  // large-v3-turbo has no dtype variant that loads on the WASM runtime — both
+  // q4f16 and q4 fail session creation with a graph error (#461) — so a WASM
+  // attempt only downloads a doomed model (twice: once per dtype). Strip WASM
+  // from turbo's device list: with no GPU this refuses before any download,
+  // and it also ends the WASM retry path immediately when a GPU run of turbo
+  // fails mid-session (e.g. device lost after a VRAM exhaustion).
+  if (model_name.includes("large-v3-turbo")) {
+    devices = devices.filter((device) => device !== "wasm");
+    if (devices.length === 0) {
+      throw new Error("The Turbo model needs a GPU, which isn't available right now. Choose a smaller model, or reload the page to retry the GPU.");
+    }
+  }
+
   let lastError = null;
   for (const device of devices) {
     for (const dtype of pickDtypes(model_name, device)) {


### PR DESCRIPTION
Fixes #461. Stacked on #465.

## What

Neither of turbo's quantised variants (`q4f16`, `q4`) loads on the WASM runtime — both fail session creation with the `InsertedPrecisionFreeCast_` graph error (an upstream onnxruntime/transformers.js issue with those exports). So any WASM attempt downloads ~560 MB per dtype and then fails anyway — the "repeated downloading" in the original report. Three layers:

- **Worker fail-fast** (`whisper.worker.js`): WASM is stripped from turbo's device list before anything downloads. With no usable GPU, `getPipeline` refuses immediately with a clear message ("The Turbo model needs a GPU… choose a smaller model, or reload the page to retry the GPU"). This also covers the mid-session case from the report — GPU adapter lost after a VRAM exhaustion — where the WebGPU→WASM inference retry now ends instantly instead of fetching two doomed variants. And if turbo's WebGPU session creation itself fails, the dtype loop no longer falls through to pointless WASM attempts.
- **UI gating** (`hyperaudio-lite-editor-whisper.js`): a `requestAdapter()` probe on load (Firefox counts as no GPU, mirroring the worker's device choice) disables the turbo option and relabels it "needs a GPU (unavailable in this browser)", resetting the selection to Base if a persisted preference had restored turbo.
- **Submit-time guard**: the async probe races `transcribe-prefs`' restore at DOMContentLoaded, so a saved "turbo" choice could be restored after the option was disabled — submission falls back to Base whenever the selected option is disabled.

The enabled option's label in `index.html` changes from "GPU recommended" to "needs GPU", since it's now enforced.

## Testing

- Unit: 60/60 pass. E2E (Playwright): 71/71 pass.
- Manual check is one-sided on this machine (working GPU, so only the enabled path is observable); the no-GPU path follows the same `hasGpuAdapter()` logic already exercised by the worker's device selection.