### PR TITLE
Release the local-transcription model memory after two minutes idle

### DIFF
--- a/js/parakeet.worker.js
+++ b/js/parakeet.worker.js
@@ -33,10 +33,36 @@ const CACHE_NAME = "parakeet-models-v1";
 let sessions = null;        // { mel, encoder, decoder, vocab, device }
 let sessionsForceGpu = null; // the forceGpu flag the current sessions were built with
 
+// The sessions hold the (GPU) model memory — ~1.2 GB for the fp16 encoder —
+// and keeping them alive makes a follow-up transcription skip model setup.
+// But the common flow is transcribe once, then edit for a long time, and the
+// model squats on that memory the whole while (#463). Middle ground: free the
+// sessions after a couple of idle minutes. The model bytes stay in Cache
+// Storage, so a later transcription repeats only session creation and shader
+// warm-up, not the download.
+const IDLE_RELEASE_MS = 2 * 60 * 1000;
+let idleTimer = null;
+
+function scheduleIdleRelease() {
+  clearTimeout(idleTimer);
+  idleTimer = setTimeout(async () => {
+    if (sessions === null) {
+      return;
+    }
+    // detach before the awaited release so a request landing mid-release
+    // rebuilds fresh sessions instead of grabbing dying ones
+    const releasing = sessions;
+    sessions = null;
+    await releaseSessions(releasing);
+    console.log("Parakeet: model sessions released after idle — next transcription reloads from cache");
+  }, IDLE_RELEASE_MS);
+}
+
 self.addEventListener("message", async (event) => {
   if (event.data?.type !== "INFERENCE_REQUEST") {
     return;
   }
+  clearTimeout(idleTimer);
   const forceGpu = event.data.forceGpu === true;
   try {
     // Rebuild if the GPU opt-in changed since the sessions were created, so the
@@ -59,6 +85,8 @@ self.addEventListener("message", async (event) => {
     console.error(e);
     const stage = sessions === null ? "load" : "transcribe";
     self.postMessage({ type: "error", stage, message: e?.message || String(e) });
+  } finally {
+    scheduleIdleRelease();
   }
 });
 

--- a/js/whisper.worker.js
+++ b/js/whisper.worker.js
@@ -14,50 +14,84 @@ const MIN_SPEECH_S = 10; // audio at least this long is assumed to contain speec
 
 let cache = { key: null, pipe: null, device: null };
 
+// The cached pipeline holds the model's (GPU) memory, and keeping it alive
+// makes a follow-up transcription skip model setup. But the common flow is
+// transcribe once, then edit for a long time, with the model squatting on
+// that memory the whole while (#463). Middle ground: dispose it after a
+// couple of idle minutes. The model bytes stay in the browser cache, so a
+// later transcription repeats only session creation and warm-up, not the
+// download.
+const IDLE_RELEASE_MS = 2 * 60 * 1000;
+let idleTimer = null;
+
+function scheduleIdleRelease() {
+  clearTimeout(idleTimer);
+  idleTimer = setTimeout(async () => {
+    if (cache.pipe === null) {
+      return;
+    }
+    // detach before the awaited dispose so a request landing mid-dispose
+    // rebuilds a fresh pipeline instead of grabbing a dying one
+    const releasing = cache.pipe;
+    cache = { key: null, pipe: null, device: null };
+    try {
+      await releasing.dispose();
+    } catch (e) {
+      console.warn("Failed to dispose idle pipeline:", e);
+    }
+    console.log("Whisper: model released after idle — next transcription reloads from cache");
+  }, IDLE_RELEASE_MS);
+}
+
 self.addEventListener("message", async (event) => {
   const { type, audio, model_name } = event.data;
 
   if (type !== "INFERENCE_REQUEST") {
     return;
   }
-
-  // a language hint stops multilingual models re-detecting the language per
-  // 30s chunk (which can drift into translating instead of transcribing).
-  // English-only models reject the option, so it only applies to multilingual.
-  const language = (event.data.language && !model_name.includes(".en")) ? event.data.language : null;
-
-  let pipe;
-  try {
-    pipe = await getPipeline(model_name);
-  } catch (e) {
-    console.error(e);
-    self.postMessage({ type: "error", stage: "load", message: e?.message || String(e) });
-    return;
-  }
+  clearTimeout(idleTimer);
 
   try {
-    const output = await transcribe(pipe, audio, language);
-    assertNotEmpty(output, audio);
-    self.postMessage({ type: "result", output });
-  } catch (e) {
-    console.error(e);
-    // WebGPU can pass pipeline init yet fail at inference time on some GPUs –
-    // including "succeeding" with empty output – rebuild on WASM and retry
-    // once before giving up.
-    if (cache.device === "webgpu") {
-      try {
-        pipe = await getPipeline(model_name, ["wasm"]);
-        const output = await transcribe(pipe, audio, language);
-        assertNotEmpty(output, audio);
-        self.postMessage({ type: "result", output });
-        return;
-      } catch (retryError) {
-        console.error(retryError);
-        self.postMessage({ type: "error", stage: "transcribe", message: retryError?.message || String(retryError) });
-        return;
-      }
+    // a language hint stops multilingual models re-detecting the language per
+    // 30s chunk (which can drift into translating instead of transcribing).
+    // English-only models reject the option, so it only applies to multilingual.
+    const language = (event.data.language && !model_name.includes(".en")) ? event.data.language : null;
+
+    let pipe;
+    try {
+      pipe = await getPipeline(model_name);
+    } catch (e) {
+      console.error(e);
+      self.postMessage({ type: "error", stage: "load", message: e?.message || String(e) });
+      return;
     }
-    self.postMessage({ type: "error", stage: "transcribe", message: e?.message || String(e) });
+
+    try {
+      const output = await transcribe(pipe, audio, language);
+      assertNotEmpty(output, audio);
+      self.postMessage({ type: "result", output });
+    } catch (e) {
+      console.error(e);
+      // WebGPU can pass pipeline init yet fail at inference time on some GPUs –
+      // including "succeeding" with empty output – rebuild on WASM and retry
+      // once before giving up.
+      if (cache.device === "webgpu") {
+        try {
+          pipe = await getPipeline(model_name, ["wasm"]);
+          const output = await transcribe(pipe, audio, language);
+          assertNotEmpty(output, audio);
+          self.postMessage({ type: "result", output });
+          return;
+        } catch (retryError) {
+          console.error(retryError);
+          self.postMessage({ type: "error", stage: "transcribe", message: retryError?.message || String(retryError) });
+          return;
+        }
+      }
+      self.postMessage({ type: "error", stage: "transcribe", message: e?.message || String(e) });
+    }
+  } finally {
+    scheduleIdleRelease();
   }
 });
 


### PR DESCRIPTION
Fixes #463. Stacked on #466.

## What

Both local workers (Parakeet and Whisper) kept their inference sessions alive for the worker's lifetime so a follow-up transcription skips model setup — at the cost of squatting on the model's GPU memory (~1.2 GB for Parakeet's fp16 encoder) the whole time the user edits. The common flow is transcribe once, then edit for a long while, so:

- After a request completes (result or error), a 2-minute idle timer starts; when it fires, the Parakeet worker releases its ONNX sessions and the Whisper worker disposes its pipeline. Any new request cancels the timer.
- The model bytes stay in Cache Storage, so a later transcription repeats only session creation and shader warm-up — not the download.
- The sessions/pipeline are detached from module state *before* the awaited release, so a request landing mid-release rebuilds fresh handles instead of grabbing dying ones.
- The release is logged to the console so the behaviour is diagnosable in reports.

While profiling #462 on macOS, the "held until tab close" behaviour this addresses was confirmed directly: the Chrome GPU process's footprint retains the model until the tab reloads, and releasing the sessions returns it to baseline.

## Testing

Unit: 60/60 pass. E2E (Playwright): 71/71 pass.