### PR TITLE
Document exports (TXT / Markdown / DOCX) and copy-to-clipboard (#467)

### DIFF
--- a/__TEST__/e2e/doc-export.spec.mjs
+++ b/__TEST__/e2e/doc-export.spec.mjs
@@ -1,0 +1,106 @@
+// Transcript document exports (#467): the TXT/MD menu items drive the shipped
+// editor end to end — a project with a speaker and a redacted word exports to
+// clean rendered documents named from the project title.
+import { test, expect } from '@playwright/test';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import { ladderWav } from './helpers.mjs';
+
+const require = createRequire(import.meta.url);
+const save = require('../../js/hyperaudio-save.js');
+const JSZip = require('jszip');
+
+async function buildFixture() {
+  const state = {
+    generatorVersion: 'e2e',
+    created: '2026-07-10T09:00:00Z',
+    modified: '2026-07-10T11:30:00Z',
+    media: {
+      kind: 'original', path: 'media/tone.wav', url: null, filename: 'tone.wav',
+      mimeType: 'audio/wav', durationSeconds: 2, sizeBytes: 0,
+    },
+    options: {
+      gapRemoval: { enabled: false, thresholdMs: 500, bufferMs: 100 },
+      updateCaptionsFromTranscript: true,
+      view: { showSpeakers: true, showTimecodes: false },
+    },
+    texts: { title: 'Doc Export Project', language: 'it', summary: '', topics: [] },
+    hasOriginal: false,
+    transcript: {
+      words: [
+        { start: 0.32, end: 0.84, text: 'Benvenuti' },
+        { start: 0.84, end: 1.02, text: 'ehm', struck: true },
+        { start: 1.1, end: 1.5, text: 'a' },
+      ],
+      paragraphs: [{ speaker: 'Maria', start: 0.32, end: 1.5 }],
+    },
+  };
+  return save.zipProject({
+    json: save.serializeProjectJson(save.buildProjectJson(state)),
+    html: '<article><section><p><span data-m="320" data-d="520">Benvenuti </span></p></section></article>',
+    media: { name: 'tone.wav', data: ladderWav(2) },
+  }, JSZip, 'nodebuffer');
+}
+
+async function exportVia(page, itemId, testInfo, saveName) {
+  const downloadPromise = page.waitForEvent('download');
+  await page.evaluate((id) => document.getElementById(id).click(), itemId);
+  const download = await downloadPromise;
+  const outPath = testInfo.outputPath(saveName);
+  await download.saveAs(outPath);
+  return { name: download.suggestedFilename(), text: fs.readFileSync(outPath, 'utf8') };
+}
+
+test.beforeEach(async ({ page }, testInfo) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  const fixturePath = testInfo.outputPath('fixture.hyperaudio');
+  fs.writeFileSync(fixturePath, await buildFixture());
+  await page.setInputFiles('#project-open-input', fixturePath);
+  await expect(page.locator('#hypertranscript')).toContainText('Benvenuti');
+});
+
+test('the menu carries both items directly under Export Project', async ({ page }) => {
+  const order = await page.evaluate(() =>
+    [...document.querySelectorAll('#file-exportimport-submenu ul a')].map((a) => a.id).slice(0, 5));
+  expect(order).toEqual([
+    'project-open-hyperaudio', 'project-export-hyperaudio',
+    'export-transcript-txt', 'export-transcript-md', 'export-transcript-docx',
+  ]);
+});
+
+test('TXT export: speaker prefix, redacted word dropped, title-derived filename', async ({ page }, testInfo) => {
+  const out = await exportVia(page, 'export-transcript-txt', testInfo, 'out.txt');
+  expect(out.name).toBe('Doc Export Project.txt');
+  expect(out.text).toBe('Maria: Benvenuti a\n'); // "ehm" is struck: it must not survive
+});
+
+test('MD export: bold speaker, same redaction semantics', async ({ page }, testInfo) => {
+  const out = await exportVia(page, 'export-transcript-md', testInfo, 'out.md');
+  expect(out.name).toBe('Doc Export Project.md');
+  expect(out.text).toBe('**Maria:** Benvenuti a\n');
+});
+
+test('DOCX export: a valid package with bold speaker run, redaction dropped', async ({ page }, testInfo) => {
+  const downloadPromise = page.waitForEvent('download');
+  await page.evaluate(() => document.getElementById('export-transcript-docx').click());
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe('Doc Export Project.docx');
+  const outPath = testInfo.outputPath('out.docx');
+  await download.saveAs(outPath);
+  const zip = await JSZip.loadAsync(fs.readFileSync(outPath));
+  const docXml = await zip.file('word/document.xml').async('string');
+  expect(docXml).toContain('<w:t xml:space="preserve">Maria: </w:t>');
+  expect(docXml).toContain('Benvenuti a');
+  expect(docXml).not.toContain('ehm');
+});
+
+test('exports follow edits: a new word appears, a newly struck word disappears', async ({ page }, testInfo) => {
+  await page.evaluate(() => {
+    const span = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    span.textContent = 'Willkommen ';
+    span.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  const out = await exportVia(page, 'export-transcript-txt', testInfo, 'edited.txt');
+  expect(out.text).toBe('Maria: Willkommen a\n');
+});

--- a/__TEST__/e2e/doc-export.spec.mjs
+++ b/__TEST__/e2e/doc-export.spec.mjs
@@ -104,3 +104,54 @@ test('exports follow edits: a new word appears, a newly struck word disappears',
   const out = await exportVia(page, 'export-transcript-txt', testInfo, 'edited.txt');
   expect(out.text).toBe('Maria: Willkommen a\n');
 });
+
+test.describe('copy to clipboard', () => {
+  test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+
+  test('the button copies BOTH flavours, whole transcript, redaction dropped', async ({ page }) => {
+    await page.click('#transcript-copy-btn');
+    // feedback: checkmark state + polite announcement
+    await expect(page.locator('#transcript-copy-btn[data-copied]')).toBeVisible();
+    await expect(page.locator('#transcript-copy-status')).toHaveText('Transcript copied to clipboard.');
+
+    const flavours = await page.evaluate(async () => {
+      const items = await navigator.clipboard.read();
+      const out = {};
+      for (const item of items) {
+        for (const type of item.types) {
+          out[type] = await (await item.getType(type)).text();
+        }
+      }
+      return out;
+    });
+    expect(flavours['text/plain']).toBe('Maria: Benvenuti a\n');            // the TXT rendering
+    expect(flavours['text/html']).toContain('<b>Maria:</b> Benvenuti a');   // the rich rendering
+    expect(flavours['text/html']).not.toContain('ehm');                     // redaction holds in both
+
+    // the checkmark reverts to the copy glyph
+    await expect(page.locator('#transcript-copy-btn:not([data-copied])')).toBeVisible({ timeout: 3000 });
+  });
+
+  test('a live selection does not narrow the copy (whole-transcript contract)', async ({ page }) => {
+    await page.evaluate(() => {
+      const word = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+      const range = document.createRange();
+      range.selectNodeContents(word);
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+    await page.click('#transcript-copy-btn');
+    await expect(page.locator('#transcript-copy-btn[data-copied]')).toBeVisible();
+    const plain = await page.evaluate(() => navigator.clipboard.readText());
+    expect(plain).toBe('Maria: Benvenuti a\n'); // everything, not the selected word
+  });
+
+  test('the button yields the corner to caption mode and returns', async ({ page }) => {
+    await expect(page.locator('#transcript-copy-btn')).toBeVisible();
+    await page.click('#caption-editor-btn');
+    await expect(page.locator('#transcript-copy-btn')).toBeHidden();
+    await page.click('#transcript-editor-btn');
+    await expect(page.locator('#transcript-copy-btn')).toBeVisible();
+  });
+});

--- a/__TEST__/unit/transcript-doc-export.test.mjs
+++ b/__TEST__/unit/transcript-doc-export.test.mjs
@@ -121,3 +121,19 @@ test('docx: empty transcript still yields a valid document with one empty paragr
   const xml = doc.docxDocumentXml({ words: [], paragraphs: [] });
   assert.match(xml, /<w:body><w:p\/><\/w:body>/);
 });
+
+/* ---------- Clipboard HTML ---------- */
+
+test('clipboard html: conservative <p>/<b> markup, redaction and escaping shared', () => {
+  const out = doc.renderClipboardHtml(sampleTranscript());
+  assert.equal(out,
+    '<p><b>Maria:</b> Benvenuti a Hyperaudio</p>\n<p><b>Luca:</b> Grazie</p>');
+});
+
+test('clipboard html: word text is HTML-escaped, no injected markup', () => {
+  const out = doc.renderClipboardHtml({
+    words: [{ start: 0, end: 1, text: '<img src=x>' }],
+    paragraphs: [{ speaker: 'A&B', start: 0, end: 2 }],
+  });
+  assert.equal(out, '<p><b>A&amp;B:</b> &lt;img src=x&gt;</p>');
+});

--- a/__TEST__/unit/transcript-doc-export.test.mjs
+++ b/__TEST__/unit/transcript-doc-export.test.mjs
@@ -1,0 +1,123 @@
+// Unit tests for the transcript document exports (#467): the pure TXT and
+// Markdown renderers over the words/paragraphs model. Rendered semantics:
+// struck (redacted) words dropped, speakers as prefixes, paragraphs as
+// blank-line-separated blocks.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const doc = require('../../js/transcript-doc-export.js');
+
+function sampleTranscript() {
+  return {
+    words: [
+      { start: 0.32, end: 0.84, text: 'Benvenuti' },
+      { start: 0.84, end: 1.02, text: 'ehm', struck: true },
+      { start: 1.1, end: 1.3, text: 'a' },
+      { start: 1.4, end: 1.9, text: 'Hyperaudio' },
+      { start: 6.6, end: 7.0, text: 'Grazie' },
+      { start: 7.1, end: 7.4, text: 'mille', struck: true },
+    ],
+    paragraphs: [
+      { speaker: 'Maria', start: 0.32, end: 6.5 },
+      { speaker: 'Luca', start: 6.6, end: 8.0 },
+    ],
+  };
+}
+
+/* ---------- TXT ---------- */
+
+test('txt: speaker prefixes, paragraphs blank-line separated, struck words dropped', () => {
+  assert.equal(doc.renderTxt(sampleTranscript()),
+    'Maria: Benvenuti a Hyperaudio\n\nLuca: Grazie\n');
+});
+
+test('txt: no paragraphs → one unprefixed block', () => {
+  const out = doc.renderTxt({ words: [
+    { start: 0, end: 1, text: 'just' },
+    { start: 1, end: 2, text: 'words' },
+  ], paragraphs: [] });
+  assert.equal(out, 'just words\n');
+});
+
+test('txt: space:false joins without a gap (dropping struck neighbours stays clean)', () => {
+  const out = doc.renderTxt({ words: [
+    { start: 0, end: 1, text: 'draft' },
+    { start: 1, end: 2, text: 'y', space: false },
+    { start: 2, end: 3, text: 'REDACTED', struck: true },
+    { start: 3, end: 4, text: '-note' },
+  ], paragraphs: [] });
+  assert.equal(out, 'draft y-note\n');
+});
+
+test('txt: empty and all-struck transcripts render to an empty string', () => {
+  assert.equal(doc.renderTxt({ words: [], paragraphs: [] }), '');
+  assert.equal(doc.renderTxt({ words: [{ start: 0, end: 1, text: 'x', struck: true }], paragraphs: [] }), '');
+});
+
+test('txt: a paragraph whose every word is struck disappears entirely', () => {
+  const out = doc.renderTxt({
+    words: [
+      { start: 0, end: 1, text: 'kept' },
+      { start: 5, end: 6, text: 'gone', struck: true },
+    ],
+    paragraphs: [
+      { speaker: 'A', start: 0, end: 4 },
+      { speaker: 'B', start: 5, end: 8 },
+    ],
+  });
+  assert.equal(out, 'A: kept\n'); // no dangling "B:" prefix
+});
+
+/* ---------- Markdown ---------- */
+
+test('md: bold speaker prefixes, same structure and redaction semantics', () => {
+  assert.equal(doc.renderMarkdown(sampleTranscript()),
+    '**Maria:** Benvenuti a Hyperaudio\n\n**Luca:** Grazie\n');
+});
+
+test('md: inline-construct characters in words and speaker names are escaped', () => {
+  const out = doc.renderMarkdown({
+    words: [{ start: 0, end: 1, text: '*laughs*' }, { start: 1, end: 2, text: '[sighs]' }],
+    paragraphs: [{ speaker: 'M_C*', start: 0, end: 4 }],
+  });
+  assert.equal(out, '**M\\_C\\*:** \\*laughs\\* \\[sighs\\]\n');
+});
+
+test('md: empty transcript renders to an empty string', () => {
+  assert.equal(doc.renderMarkdown({ words: [], paragraphs: [] }), '');
+});
+
+/* ---------- DOCX ---------- */
+
+const JSZip = require('jszip');
+
+test('docx: package round-trips with bold speaker runs, struck words dropped', async () => {
+  const out = await doc.buildDocx(sampleTranscript(), JSZip, 'nodebuffer');
+  const zip = await JSZip.loadAsync(out);
+  const types = await zip.file('[Content_Types].xml').async('string');
+  assert.match(types, /wordprocessingml\.document\.main\+xml/);
+  const rels = await zip.file('_rels/.rels').async('string');
+  assert.match(rels, /Target="word\/document\.xml"/);
+  const docXml = await zip.file('word/document.xml').async('string');
+  assert.match(docXml, /<w:r><w:rPr><w:b\/><\/w:rPr><w:t xml:space="preserve">Maria: <\/w:t><\/w:r>/);
+  assert.match(docXml, /<w:t xml:space="preserve">Benvenuti a Hyperaudio<\/w:t>/);
+  assert.ok(!docXml.includes('ehm')); // redacted: must not survive
+  assert.match(docXml, /Luca: /);
+});
+
+test('docx: word text is XML-escaped', () => {
+  const xml = doc.docxDocumentXml({
+    words: [{ start: 0, end: 1, text: 'a<b>&"c"' }],
+    paragraphs: [{ speaker: 'R&D', start: 0, end: 2 }],
+  });
+  assert.ok(xml.includes('a&lt;b&gt;&amp;"c"')); // & < > escaped; quotes fine in text nodes
+  assert.ok(xml.includes('R&amp;D: '));
+  assert.ok(!xml.includes('<b>'));
+});
+
+test('docx: empty transcript still yields a valid document with one empty paragraph', () => {
+  const xml = doc.docxDocumentXml({ words: [], paragraphs: [] });
+  assert.match(xml, /<w:body><w:p\/><\/w:body>/);
+});

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -578,6 +578,43 @@ dialog::backdrop {
   transform: none;
 }
 
+/* Copy-transcript button (#467): pinned to the transcript card's top-right
+   corner — the toolbar is crowded on mobile — position:fixed because the
+   holder itself is the scroll container (same reasoning as the caption
+   editor's Regenerate float). Offsets mirror .transcript-holder's edges;
+   hidden in caption mode by the view-switch wiring. */
+#transcript-copy-btn {
+  position: fixed;
+  top: 88px;              /* holder top (78px) + 10px inset */
+  right: 28px;            /* holder right (16px) + 12px inset */
+  z-index: 20;            /* above content, below the drawer (45) and navbar (60) */
+  color: oklch(var(--bc) / 0.55);
+}
+#transcript-copy-btn:hover { color: oklch(var(--bc)); }
+#transcript-copy-btn[data-copied] { color: oklch(var(--su, var(--p))); }
+/* right-anchor the tooltip bubble so it opens inward, not off the card edge */
+#transcript-copy-btn.tooltip::before {
+  left: auto;
+  right: 0;
+  transform: none;
+}
+@media screen and (max-width: 948px) {
+  #transcript-copy-btn {
+    top: calc(var(--nav-h) + var(--player-h) + 10px);
+    right: 12px;
+    transition: top 0.25s ease; /* follows the video collapse like the holder */
+  }
+}
+/* screen-reader-only live region for the copy announcement */
+#transcript-copy-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
 /* Search: highlight only the matched substring. searchPhrase wraps the match in
    <mark class="search-mark"> and also tags the word .search-match — neutralise
    the vendored whole-word background so just the mark shows, tinted with a much

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@ If you are creating an open source application under a license compatible with t
     }
     
   </style>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.0.0">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.1.2">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1056,7 +1056,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-save.js?v=1.1.1"></script>
   <script src="js/hyperaudio-library.js?v=1.0.0"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
-  <script src="js/transcript-doc-export.js?v=1.1.1"></script>
+  <script src="js/transcript-doc-export.js?v=1.1.2"></script>
 
 
   <script src="js/editor-svg.js?v=0.6.12"></script>

--- a/index.html
+++ b/index.html
@@ -1053,8 +1053,10 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=0.7.4"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.0.1"></script>
+  <script src="js/hyperaudio-save.js?v=1.1.1"></script>
   <script src="js/hyperaudio-library.js?v=1.0.0"></script>
+  <!-- transcript document exports: TXT / Markdown (#467) -->
+  <script src="js/transcript-doc-export.js?v=1.1.1"></script>
 
 
   <script src="js/editor-svg.js?v=0.6.12"></script>

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2210,6 +2210,10 @@
     exportProject,   // build + download a portable .hyperaudio
     // export naming and any future UI read the title through here
     getProjectTitle: () => session.title || (session.mediaFile !== null ? session.mediaFile.name : '') || '',
+    // the document exports (#467) read the transcript through here: the same
+    // speaker-preserving, caption-mode-aware gather the save path uses
+    getTranscriptJson: () => htmlToJSON(getEditorHtml()),
+    loadJSZip, // shared vendored-zip loader (the .docx export packages with it)
     openFromFile,
     autosaveNow: writeDraft,
     isDirty,

--- a/js/transcript-doc-export.js
+++ b/js/transcript-doc-export.js
@@ -1,0 +1,218 @@
+/*
+ * ============================================================================
+ * TRANSCRIPT DOCUMENT EXPORTS (#467) — TXT and Markdown
+ * ============================================================================
+ *
+ * Rendered document exports of the transcript, added to the FILE →
+ * Export / Import submenu. RENDERED means the semantics of the format doc's
+ * § 1.1 privacy caveat (share rendered exports, not project files):
+ *
+ *   - struck (redacted) words are DROPPED — a redacted word must not survive
+ *     into a shared document, matching the media-export semantics;
+ *   - speakers come from the paragraph model and become prefixes
+ *     ("Maria: …" in TXT, "**Maria:**" in Markdown);
+ *   - paragraphs become paragraphs (blank-line separated).
+ *
+ * One shared serializer over the words/paragraphs model with a thin renderer
+ * per format; the pure layer is exported for node --test. The transcript
+ * comes from HyperaudioSave.getTranscriptJson(), the same speaker-preserving,
+ * caption-mode-aware gather the save path uses. Export filenames come from
+ * the project title, like the .hyperaudio export.
+ */
+
+(function () {
+  'use strict';
+
+  /* ==========================================================================
+   * Pure renderers (node-testable)
+   * ======================================================================== */
+
+  // Assign words to paragraphs the same way the editor builds its DOM from
+  // JSON: a word belongs to the paragraph whose [start, end) contains its
+  // start; with no paragraphs everything is one block. Struck words are
+  // dropped here so every renderer inherits the redaction semantics.
+  function paragraphsWithWords(transcript) {
+    const words = ((transcript && transcript.words) || []).filter((w) => w.struck !== true);
+    const paragraphs = (transcript && transcript.paragraphs && transcript.paragraphs.length > 0)
+      ? transcript.paragraphs
+      : [{ start: -Infinity, end: Infinity, speaker: null }];
+    return paragraphs
+      .map((p) => ({
+        speaker: p.speaker || null,
+        words: words.filter((w) => w.start >= p.start && w.start < p.end),
+      }))
+      .filter((p) => p.words.length > 0);
+  }
+
+  // Words carry their own trailing-space flag (space: false = none), so
+  // dropping struck words never leaves double spaces behind.
+  function joinWords(words) {
+    return words.map((w) => w.text + (w.space === false ? '' : ' ')).join('').trim();
+  }
+
+  function renderTxt(transcript) {
+    const blocks = paragraphsWithWords(transcript)
+      .map((p) => (p.speaker ? p.speaker + ': ' : '') + joinWords(p.words));
+    return blocks.length > 0 ? blocks.join('\n\n') + '\n' : '';
+  }
+
+  // Escape the inline constructs a transcript word could accidentally
+  // trigger ("*laughs*" must not italicise); full CommonMark escaping is
+  // overkill for natural speech.
+  function escapeMd(text) {
+    return String(text).replace(/([\\`*_[\]])/g, '\\$1');
+  }
+
+  function renderMarkdown(transcript) {
+    const blocks = paragraphsWithWords(transcript)
+      .map((p) => {
+        const text = joinWords(p.words.map((w) => ({
+          text: escapeMd(w.text),
+          space: w.space,
+        })));
+        return (p.speaker ? '**' + escapeMd(p.speaker) + ':** ' : '') + text;
+      });
+    return blocks.length > 0 ? blocks.join('\n\n') + '\n' : '';
+  }
+
+  /* ==========================================================================
+   * DOCX (#467): a .docx is a zip of XML parts — the vendored JSZip builds
+   * it, no new dependency. Three parts make a minimal valid package:
+   * [Content_Types].xml, _rels/.rels, and word/document.xml with one w:p per
+   * paragraph (bold run for the speaker prefix, normal run for the text).
+   * Opens natively in Word, Pages, LibreOffice and Google Docs. NOT the
+   * legacy binary .doc, and not the HTML-named-.doc trick.
+   * ======================================================================== */
+
+  function escapeXml(text) {
+    return String(text)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  // The document part. xml:space="preserve" keeps the speaker prefix's
+  // trailing space; word text is XML-escaped (it is user/file data).
+  function docxDocumentXml(transcript) {
+    const paragraphs = paragraphsWithWords(transcript).map((p) => {
+      const runs = [];
+      if (p.speaker) {
+        runs.push('<w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">'
+          + escapeXml(p.speaker + ': ') + '</w:t></w:r>');
+      }
+      runs.push('<w:r><w:t xml:space="preserve">' + escapeXml(joinWords(p.words)) + '</w:t></w:r>');
+      return '<w:p>' + runs.join('') + '</w:p>';
+    });
+    if (paragraphs.length === 0) paragraphs.push('<w:p/>');
+    return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+      + '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+      + '<w:body>' + paragraphs.join('') + '</w:body></w:document>';
+  }
+
+  const DOCX_CONTENT_TYPES = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+    + '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+    + '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+    + '<Default Extension="xml" ContentType="application/xml"/>'
+    + '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>'
+    + '</Types>';
+
+  const DOCX_RELS = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+    + '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    + '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>'
+    + '</Relationships>';
+
+  // Assemble the package (JSZip implementation injected — node-testable,
+  // same pattern as the container layer in hyperaudio-save.js).
+  function buildDocx(transcript, JSZipImpl, outType) {
+    const zip = new JSZipImpl();
+    zip.file('[Content_Types].xml', DOCX_CONTENT_TYPES);
+    zip.file('_rels/.rels', DOCX_RELS);
+    zip.file('word/document.xml', docxDocumentXml(transcript));
+    return zip.generateAsync({ type: outType || 'uint8array', compression: 'DEFLATE' });
+  }
+
+  /* ==========================================================================
+   * Exports for node --test, then browser-only code.
+   * ======================================================================== */
+
+  const pure = {
+    paragraphsWithWords, joinWords, escapeMd, renderTxt, renderMarkdown,
+    escapeXml, docxDocumentXml, buildDocx,
+  };
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = pure;
+  }
+  if (typeof document === 'undefined') {
+    return; // node context: pure layer only
+  }
+
+  /* ==========================================================================
+   * UI — menu items in FILE → Export / Import, download wiring
+   * ======================================================================== */
+
+  function currentTranscript() {
+    if (window.HyperaudioSave && typeof window.HyperaudioSave.getTranscriptJson === 'function') {
+      return window.HyperaudioSave.getTranscriptJson();
+    }
+    // fallback: the live DOM keeps its speaker classes
+    const el = document.querySelector('#hypertranscript');
+    return el !== null && typeof htmlToJSON === 'function'
+      ? htmlToJSON(el.innerHTML)
+      : { words: [], paragraphs: [] };
+  }
+
+  // Same title→filename rule as the .hyperaudio export.
+  function exportFilename(extension) {
+    const title = ((window.HyperaudioSave && window.HyperaudioSave.getProjectTitle()) || 'transcript')
+      .replace(/[\\/:*?"<>|]+/g, '-').trim() || 'transcript';
+    return title + extension;
+  }
+
+  function triggerDownload(data, extension, mime) {
+    const blob = data instanceof Blob ? data : new Blob([data], { type: mime });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = exportFilename(extension);
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 60000);
+  }
+
+  function boot() {
+    // Sit directly under Export Project (.hyperaudio); this script loads
+    // after hyperaudio-save.js, so its DOMContentLoaded wiring (and menu
+    // injection) has already run.
+    const markup =
+      '<li><a id="export-transcript-txt">Export Transcript (.txt)</a></li>'
+      + '<li><a id="export-transcript-md">Export Transcript (.md)</a></li>'
+      + '<li><a id="export-transcript-docx">Export Transcript (.docx)</a></li>';
+    const projectExport = document.getElementById('project-export-hyperaudio');
+    if (projectExport !== null && projectExport.closest('li') !== null) {
+      projectExport.closest('li').insertAdjacentHTML('afterend', markup);
+    } else {
+      const submenu = document.querySelector('#file-exportimport-submenu ul');
+      if (submenu === null) return;
+      submenu.insertAdjacentHTML('afterbegin', markup);
+    }
+
+    document.getElementById('export-transcript-txt').addEventListener('click', () => {
+      triggerDownload(renderTxt(currentTranscript()), '.txt', 'text/plain');
+    });
+    document.getElementById('export-transcript-md').addEventListener('click', () => {
+      triggerDownload(renderMarkdown(currentTranscript()), '.md', 'text/markdown');
+    });
+    document.getElementById('export-transcript-docx').addEventListener('click', async () => {
+      const loader = window.HyperaudioSave && window.HyperaudioSave.loadJSZip;
+      if (typeof loader !== 'function') return;
+      const blob = await buildDocx(currentTranscript(), await loader(), 'blob');
+      triggerDownload(blob, '.docx',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot);
+  } else {
+    boot();
+  }
+})();

--- a/js/transcript-doc-export.js
+++ b/js/transcript-doc-export.js
@@ -76,6 +76,20 @@
   }
 
   /* ==========================================================================
+   * Clipboard HTML (#467): the rich flavour for the copy button. Deliberately
+   * conservative markup — plain <p> and <b> only — because paste targets
+   * apply their own defaults, and minimal markup pastes cleanly everywhere.
+   * ======================================================================== */
+
+  function renderClipboardHtml(transcript) {
+    return paragraphsWithWords(transcript)
+      .map((p) => '<p>'
+        + (p.speaker ? '<b>' + escapeXml(p.speaker) + ':</b> ' : '')
+        + escapeXml(joinWords(p.words)) + '</p>')
+      .join('\n');
+  }
+
+  /* ==========================================================================
    * DOCX (#467): a .docx is a zip of XML parts — the vendored JSZip builds
    * it, no new dependency. Three parts make a minimal valid package:
    * [Content_Types].xml, _rels/.rels, and word/document.xml with one w:p per
@@ -137,7 +151,7 @@
 
   const pure = {
     paragraphsWithWords, joinWords, escapeMd, renderTxt, renderMarkdown,
-    escapeXml, docxDocumentXml, buildDocx,
+    escapeXml, docxDocumentXml, buildDocx, renderClipboardHtml,
   };
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = pure;
@@ -210,9 +224,99 @@
     });
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', boot);
-  } else {
+  /* ==========================================================================
+   * Copy-transcript button (#467): pinned to the transcript card's top-right
+   * corner (the top toolbar is crowded on mobile and lower resolutions).
+   *
+   * Contract: ALWAYS copies the WHOLE rendered transcript, selection or not.
+   * A selection-sensitive button is a trap (contenteditable selections
+   * survive focus loss), and selection copying already has an owner — native
+   * ⌘C, which must stay verbatim because it doubles as an editing operation.
+   * ⌘C = editing copy, verbatim; this button = publishing copy, rendered
+   * clean (struck words dropped, speaker prefixes).
+   *
+   * Both clipboard flavours ride one ClipboardItem — text/plain (the TXT
+   * rendering) and text/html — so Docs/Word/Notion paste formatted while
+   * terminals and plain editors get clean text; ⇧⌘V forces plain anywhere.
+   * The strings are built synchronously in the click gesture (Safari-safe).
+   * ======================================================================== */
+
+  const COPY_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>';
+  const CHECK_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>';
+
+  let copyResetTimer = null;
+
+  async function copyTranscript(btn, statusEl) {
+    const transcript = currentTranscript();
+    const plain = renderTxt(transcript);
+    const html = renderClipboardHtml(transcript);
+    try {
+      if (navigator.clipboard && typeof ClipboardItem !== 'undefined'
+          && typeof navigator.clipboard.write === 'function') {
+        await navigator.clipboard.write([new ClipboardItem({
+          'text/plain': new Blob([plain], { type: 'text/plain' }),
+          'text/html': new Blob([html], { type: 'text/html' }),
+        })]);
+      } else if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+        await navigator.clipboard.writeText(plain); // older engines: plain only
+      } else {
+        return;
+      }
+    } catch (e) {
+      console.warn('transcript-doc-export: clipboard write failed', e);
+      return;
+    }
+    // clipboard writes are invisible — flip to a checkmark and announce
+    btn.dataset.copied = '1';
+    btn.innerHTML = CHECK_SVG;
+    statusEl.textContent = '';
+    statusEl.textContent = 'Transcript copied to clipboard.';
+    clearTimeout(copyResetTimer);
+    copyResetTimer = setTimeout(() => {
+      delete btn.dataset.copied;
+      btn.innerHTML = COPY_SVG;
+    }, 1500);
+  }
+
+  function bootCopyButton() {
+    const statusEl = document.createElement('div');
+    statusEl.id = 'transcript-copy-status';
+    statusEl.setAttribute('role', 'status');
+    statusEl.setAttribute('aria-live', 'polite');
+    document.body.appendChild(statusEl);
+
+    const btn = document.createElement('button');
+    btn.id = 'transcript-copy-btn';
+    btn.type = 'button';
+    btn.className = 'btn btn-square btn-ghost btn-sm tooltip';
+    btn.setAttribute('data-tip', 'Copy transcript');
+    btn.setAttribute('aria-label', 'Copy transcript');
+    btn.innerHTML = COPY_SVG;
+    btn.addEventListener('click', () => { copyTranscript(btn, statusEl); });
+    document.body.appendChild(btn);
+
+    // The caption editor owns that corner in caption mode (its Regenerate
+    // button floats there), and "copy transcript" is a transcript-mode act —
+    // hide/show with the view switch. The engines force transcript view by
+    // clicking #transcript-editor-btn, so this covers programmatic switches.
+    const captionBtn = document.getElementById('caption-editor-btn');
+    const transcriptBtn = document.getElementById('transcript-editor-btn');
+    if (captionBtn !== null) {
+      captionBtn.addEventListener('click', () => { btn.style.display = 'none'; });
+    }
+    if (transcriptBtn !== null) {
+      transcriptBtn.addEventListener('click', () => { btn.style.display = ''; });
+    }
+  }
+
+  function bootAll() {
     boot();
+    bootCopyButton();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bootAll);
+  } else {
+    bootAll();
   }
 })();


### PR DESCRIPTION
Closes #467. Fills the "just give me the words" gap: every existing export served machines or players, not documents.

## One serializer, four renderers

`js/transcript-doc-export.js` — a shared serializer over the words/paragraphs model (pure layer node-tested), with a thin renderer per output. All four inherit the RENDERED semantics of the format doc's § 1.1 privacy caveat: **struck (redacted) words are dropped at the serializer** — a paragraph whose every word is struck disappears entirely, prefix included — speakers become prefixes, per-word space flags keep joins clean across dropped neighbours.

- **TXT** — `Maria: …`, blank-line paragraphs.
- **Markdown** — `**Maria:**`, inline constructs escaped (a spoken `*laughs*` can't italicise).
- **DOCX** — minimal three-part OOXML package zipped with the vendored JSZip (no new dependency): bold speaker runs, `xml:space="preserve"`, XML-escaped text. Opens natively in **Word (verified)**, Pages, LibreOffice, Google Docs. Not legacy `.doc`, not the HTML-named-`.doc` trick.
- **Clipboard** — a copy button pinned to the transcript card's top-right (the toolbar is crowded on mobile; fixed-positioned since the holder scrolls, per the Regenerate precedent; yields the corner in caption mode). **Always the whole rendered transcript** — ⌘C stays verbatim for editing, the button is the publishing copy — with one `ClipboardItem` carrying `text/plain` (byte-identical to the TXT export) and conservative `text/html`, so rich targets paste formatted and plain targets stay clean. Checkmark + `aria-live` feedback.

Menu items sit directly under **Export Project (.hyperaudio)**; filenames derive from the project title like the `.hyperaudio` export. `HyperaudioSave` grows two accessors: `getTranscriptJson()` (the same speaker-preserving, caption-mode-aware gather the save path uses) and `loadJSZip` (shared vendor loader).

## Tests

73 unit / 79 e2e green. E2e reads the flavours back from the real clipboard (granted permissions), proves the whole-document contract against a live selection, verifies the DOCX package contents, and pins the redaction contract on every output.