### PR TITLE
Import is a top-level FILE category; submenu items drop their verbs (#470)

### DIFF
--- a/__TEST__/e2e/doc-export.spec.mjs
+++ b/__TEST__/e2e/doc-export.spec.mjs
@@ -60,13 +60,16 @@ test.beforeEach(async ({ page }, testInfo) => {
   await expect(page.locator('#hypertranscript')).toContainText('Benvenuti');
 });
 
-test('the menu carries both items directly under Export Project', async ({ page }) => {
+test('the transcript exports sit directly under Export Project in the Export submenu (#470)', async ({ page }) => {
   const order = await page.evaluate(() =>
-    [...document.querySelectorAll('#file-exportimport-submenu ul a')].map((a) => a.id).slice(0, 5));
+    [...document.querySelectorAll('#file-export-submenu ul a')].map((a) => a.id).slice(0, 4));
   expect(order).toEqual([
-    'project-open-hyperaudio', 'project-export-hyperaudio',
+    'project-export-hyperaudio',
     'export-transcript-txt', 'export-transcript-md', 'export-transcript-docx',
   ]);
+  const importOrder = await page.evaluate(() =>
+    [...document.querySelectorAll('#file-import-submenu ul a')].map((a) => a.id).slice(0, 1));
+  expect(importOrder).toEqual(['project-open-hyperaudio']);
 });
 
 test('TXT export: speaker prefix, redacted word dropped, title-derived filename', async ({ page }, testInfo) => {

--- a/__TEST__/e2e/file-menu-submenus.spec.mjs
+++ b/__TEST__/e2e/file-menu-submenus.spec.mjs
@@ -13,33 +13,43 @@ test.beforeEach(async ({ page }) => {
 test('long lists are grouped into collapsed submenus with every action still reachable (#428)', async ({ page }) => {
   const state = await page.evaluate(() => {
     const dl = document.getElementById('file-download-submenu');
-    const ei = document.getElementById('file-exportimport-submenu');
+    const im = document.getElementById('file-import-submenu');
+    const ex = document.getElementById('file-export-submenu');
     const ids = ['download-vtt', 'download-vtt-words', 'download-srt', 'download-html', 'download-hypertranscript'];
     const forTargets = ['export-modal', 'interactive-export-modal', 'file-import-deepgram-json-dialog', 'file-import-srt-dialog', 'file-import-vtt-dialog'];
     const custom = ['export-json', 'export-ionosphere', 'import-json'];
     return {
       hasDownloadSubmenu: !!dl,
-      hasExportImportSubmenu: !!ei,
+      hasImportSubmenu: !!im,
+      hasExportSubmenu: !!ex,
       downloadStartsCollapsed: dl ? !dl.open : null,
-      exportImportStartsCollapsed: ei ? !ei.open : null,
+      importStartsCollapsed: im ? !im.open : null,
+      exportStartsCollapsed: ex ? !ex.open : null,
       idsPresent: ids.filter((id) => document.getElementById(id) === null),
       labelsPresent: forTargets.filter((t) => document.querySelector(`label[for="${t}"]`) === null),
       customPresent: custom.filter((tag) => document.querySelector(`#file-dropdown ${tag}`) === null),
-      // the download/export items now live UNDER the submenus, not at top level
+      // the download/export/import items live UNDER their submenus (#470:
+      // Import and Export are separate top-level categories)
       downloadItemsNested: !!document.querySelector('#file-download-submenu #download-vtt'),
-      exportItemsNested: !!document.querySelector('#file-exportimport-submenu export-json'),
+      exportItemsNested: !!document.querySelector('#file-export-submenu export-json'),
+      importItemsNested: !!document.querySelector('#file-import-submenu import-json'),
+      importBeforeExport: !!(im && ex && (im.compareDocumentPosition(ex) & Node.DOCUMENT_POSITION_FOLLOWING)),
     };
   });
 
   expect(state.hasDownloadSubmenu).toBe(true);
-  expect(state.hasExportImportSubmenu).toBe(true);
+  expect(state.hasImportSubmenu).toBe(true);
+  expect(state.hasExportSubmenu).toBe(true);
   expect(state.downloadStartsCollapsed).toBe(true);   // collapsed → the menu is short
-  expect(state.exportImportStartsCollapsed).toBe(true);
+  expect(state.importStartsCollapsed).toBe(true);
+  expect(state.exportStartsCollapsed).toBe(true);
   expect(state.idsPresent).toEqual([]);               // no download action lost
   expect(state.labelsPresent).toEqual([]);            // no modal/import target lost
   expect(state.customPresent).toEqual([]);            // custom-element exports/imports kept
   expect(state.downloadItemsNested).toBe(true);
   expect(state.exportItemsNested).toBe(true);
+  expect(state.importItemsNested).toBe(true);
+  expect(state.importBeforeExport).toBe(true);        // inputs above outputs (#470)
 });
 
 test('a submenu expands on click and its nested actions still fire (#428)', async ({ page }) => {

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -117,8 +117,9 @@ test('save button, import menu item, and hidden input are injected', async ({ pa
     return btn.nextElementSibling && btn.nextElementSibling.id;
   });
   expect(order).toBe('export-media-btn');
-  await expect(page.locator('#file-exportimport-submenu #project-open-hyperaudio')).toHaveText('Import Project (.hyperaudio)');
-  await expect(page.locator('#file-exportimport-submenu #project-export-hyperaudio')).toHaveText('Export Project (.hyperaudio)');
+  // labels carry no verb: the submenu category (Import/Export) does (#470)
+  await expect(page.locator('#file-import-submenu #project-open-hyperaudio')).toHaveText('Project (.hyperaudio)');
+  await expect(page.locator('#file-export-submenu #project-export-hyperaudio')).toHaveText('Project (.hyperaudio)');
   await expect(page.locator('#project-open-input')).toHaveCount(1);
 });
 

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=0.8.6"></script>
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js?v=1.0.0"></script>
-  <script src="js/transcript-to-ionosphere.js?v=0.6.18"></script>
+  <script src="js/transcript-to-ionosphere.js?v=1.1.1"></script>
   <script src="js/paragraph-timecodes.js?v=0.6.20"></script>
 
   <!-- Meta Tags required for
@@ -421,6 +421,33 @@ If you are creating an open source application under a license compatible with t
                    <details>) so the File menu stays short; ids/targets unchanged so
                    all wiring (download links, modal toggles, custom elements) still
                    works. Mirrors the Glider native File menu (#428). -->
+              <!-- Import is its own top-level category (#470): inputs sit
+                   above outputs, mirroring Upload & Transcribe / Add
+                   Transcript leading the menu. The former "Export / Import"
+                   submenu split in two; ids/targets of the items unchanged so
+                   all wiring still works. Project items (.hyperaudio) and the
+                   transcript document exports are injected at the top of
+                   their submenus by hyperaudio-save.js / transcript-doc-export.js. -->
+              <li>
+                <details id="file-import-submenu">
+                  <summary>Import</summary>
+                  <ul>
+                    <li><import-json></import-json></li>
+                    <li><label for="file-import-deepgram-json-dialog">Deepgram JSON</label></li>
+                    <li><label for="file-import-srt-dialog">SRT</label></li>
+                    <li><label for="file-import-vtt-dialog">VTT</label></li>
+                  </ul>
+                </details>
+              </li>
+              <li>
+                <details id="file-export-submenu">
+                  <summary>Export</summary>
+                  <ul>
+                    <li><export-json></export-json></li>
+                    <li><export-ionosphere></export-ionosphere></li>
+                  </ul>
+                </details>
+              </li>
               <li>
                 <details id="file-download-submenu">
                   <summary>Download as</summary>
@@ -431,19 +458,6 @@ If you are creating an open source application under a license compatible with t
                     <li><a id="download-html" href="" download="hypertranscript.html">HTML</a></li>
                     <li><label id="download-hypertranscript" for="interactive-export-modal">Interactive Transcript</label></li>
                     <li><label for="export-modal">Media (WAV / MP3 / MP4…)</label></li>
-                  </ul>
-                </details>
-              </li>
-              <li>
-                <details id="file-exportimport-submenu">
-                  <summary>Export / Import</summary>
-                  <ul>
-                    <li><export-json></export-json></li>
-                    <li><export-ionosphere></export-ionosphere></li>
-                    <li><import-json></import-json></li>
-                    <li><label for="file-import-deepgram-json-dialog">Import Deepgram JSON</label></li>
-                    <li><label for="file-import-srt-dialog">Import SRT</label></li>
-                    <li><label for="file-import-vtt-dialog">Import VTT</label></li>
                   </ul>
                 </details>
               </li>
@@ -1007,7 +1021,7 @@ If you are creating an open source application under a license compatible with t
 
   <script src="js/editor-file-menu.js?v=1.0.0"></script>
 
-  <script src="./js/hyperaudio-lite-editor-export.js?v=0.8.7" type="module"> </script>
+  <script src="./js/hyperaudio-lite-editor-export.js?v=1.1.1" type="module"> </script>
   <!-- end of localstorage additions -->
 
   <!-- caption editor additions -->
@@ -1053,10 +1067,10 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=0.7.4"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.1.0"></script>
+  <script src="js/hyperaudio-save.js?v=1.1.2"></script>
   <script src="js/hyperaudio-library.js?v=1.0.0"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
-  <script src="js/transcript-doc-export.js?v=1.1.0"></script>
+  <script src="js/transcript-doc-export.js?v=1.1.2"></script>
 
 
   <script src="js/editor-svg.js?v=0.6.12"></script>

--- a/js/hyperaudio-lite-editor-export.js
+++ b/js/hyperaudio-lite-editor-export.js
@@ -17,7 +17,7 @@ class ExportJson extends HTMLElement {
 
   connectedCallback() {
     //this.innerHTML =  `<button onclick="${this.exportJson}">export json ⬇</button>`;
-    this.innerHTML = `<a onclick="${this.exportJson}">Export Hyperaudio JSON</a>`;
+    this.innerHTML = `<a onclick="${this.exportJson}">Hyperaudio JSON</a>`;
     this.addEventListener('click', this.exportJson);
   }
 }
@@ -64,7 +64,7 @@ class ImportJson extends HTMLElement {
 
   connectedCallback() {
     //this.innerHTML =  `<button onclick="${this.importJson}">import json ⬆</button>`;
-    this.innerHTML = `<a onclick="${this.importJson}">Import Hyperaudio JSON</a>`;
+    this.innerHTML = `<a onclick="${this.importJson}">Hyperaudio JSON</a>`;
     this.addEventListener('click', this.importJson);
   }
 }

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -1943,18 +1943,25 @@
       '<hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-25 dark:border-neutral-200" />'
       + '');
     // The navbar Save button covers saving (#449, a silent OPFS commit since
-    // #456), so the menu carries no Save item; opening a project lives with
-    // the other imports, and Export Project is the explicit way to take a
-    // portable .hyperaudio out of the browser — the only save-ish download.
-    const importList = document.querySelector('#file-exportimport-submenu ul');
+    // #456), so the menu carries no Save item. The project items lead their
+    // top-level submenus (#470: Import and Export are separate categories);
+    // Export Project is the explicit way to take a portable .hyperaudio out
+    // of the browser — the only save-ish download.
+    const importList = document.querySelector('#file-import-submenu ul');
     if (importList !== null) {
       importList.insertAdjacentHTML('afterbegin',
-        '<li><a id="project-open-hyperaudio">Import Project (.hyperaudio)</a></li>'
-        + '<li><a id="project-export-hyperaudio">Export Project (.hyperaudio)</a></li>');
+        '<li><a id="project-open-hyperaudio">Project (.hyperaudio)</a></li>');
     } else {
       dropdown.insertAdjacentHTML('beforeend',
-        '<li><a id="project-open-hyperaudio">Import Project (.hyperaudio)</a></li>'
-        + '<li><a id="project-export-hyperaudio">Export Project (.hyperaudio)</a></li>');
+        '<li><a id="project-open-hyperaudio">Project (.hyperaudio)</a></li>');
+    }
+    const exportList = document.querySelector('#file-export-submenu ul');
+    if (exportList !== null) {
+      exportList.insertAdjacentHTML('afterbegin',
+        '<li><a id="project-export-hyperaudio">Project (.hyperaudio)</a></li>');
+    } else {
+      dropdown.insertAdjacentHTML('beforeend',
+        '<li><a id="project-export-hyperaudio">Project (.hyperaudio)</a></li>');
     }
     document.querySelector('#project-export-hyperaudio').addEventListener('click', () => {
       exportProject().catch((e) => projectAlert('Exporting the project failed: ' + e.message));

--- a/js/transcript-doc-export.js
+++ b/js/transcript-doc-export.js
@@ -199,14 +199,14 @@
     // after hyperaudio-save.js, so its DOMContentLoaded wiring (and menu
     // injection) has already run.
     const markup =
-      '<li><a id="export-transcript-txt">Export Transcript (.txt)</a></li>'
-      + '<li><a id="export-transcript-md">Export Transcript (.md)</a></li>'
-      + '<li><a id="export-transcript-docx">Export Transcript (.docx)</a></li>';
+      '<li><a id="export-transcript-txt">Transcript (.txt)</a></li>'
+      + '<li><a id="export-transcript-md">Transcript (.md)</a></li>'
+      + '<li><a id="export-transcript-docx">Transcript (.docx)</a></li>';
     const projectExport = document.getElementById('project-export-hyperaudio');
     if (projectExport !== null && projectExport.closest('li') !== null) {
       projectExport.closest('li').insertAdjacentHTML('afterend', markup);
     } else {
-      const submenu = document.querySelector('#file-exportimport-submenu ul');
+      const submenu = document.querySelector('#file-export-submenu ul');
       if (submenu === null) return;
       submenu.insertAdjacentHTML('afterbegin', markup);
     }

--- a/js/transcript-to-ionosphere.js
+++ b/js/transcript-to-ionosphere.js
@@ -245,7 +245,7 @@
     }
 
     connectedCallback() {
-      this.innerHTML = '<a>Export ionosphere (AT Protocol) JSON</a>';
+      this.innerHTML = '<a>Ionosphere (AT Protocol) JSON</a>';
       this.addEventListener('click', this.exportIonosphere);
     }
   }


### PR DESCRIPTION
Closes #470. The single "Export / Import" submenu splits into separate top-level **Import** and **Export** categories, inputs above outputs (Import first, mirroring Upload & Transcribe / Add Transcript leading the menu), "Download as" unchanged below.

With the category carrying the verb, every item drops its own: Import → Project (.hyperaudio) · Hyperaudio JSON · Deepgram JSON · SRT · VTT; Export → Project (.hyperaudio) · Transcript (.txt/.md/.docx) · Hyperaudio JSON · Ionosphere (AT Protocol) JSON. Ids and label-for targets unchanged — all wiring (download links, modal toggles, custom elements, runtime injections) holds. The #428 submenu guard now asserts the split explicitly: both submenus present and collapsed, no action lost, Import before Export.

Tests: 73 unit / 79 e2e green.