### PR TITLE
Interactive transcript template: remove the Twitter sharer and its scripts (#444)

### DIFF
--- a/hyperaudio-template.html
+++ b/hyperaudio-template.html
@@ -7,7 +7,6 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/css/hyperaudio-lite-player.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/css/share-this.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>
-  <script src="https://platform.twitter.com/widgets.js"></script>
   <style>
     body {
       margin: 0;
@@ -97,11 +96,10 @@
   <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/hyperaudio-lite.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/hyperaudio-lite-extension.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/share-this.js"></script>
-  <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/share-this-twitter.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/share-this-clipboard.js"></script>
   <script>
   ShareThis({
-      sharers: [ ShareThisViaTwitter, ShareThisViaClipboard ],
+      sharers: [ ShareThisViaClipboard ],
       selector: "article"
   }).init();
 

--- a/index.html
+++ b/index.html
@@ -997,7 +997,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-extension.js?v=0.7.2"></script>
   <script src="js/caption.js?v=0.8.6"></script>
   <script src="js/transcript-serializer.js?v=0.8.5"></script>
-  <script src="js/editor-core.js?v=0.9.1"></script>
+  <script src="js/editor-core.js?v=1.1.1"></script>
 
 
   <import-deepgram-json></import-deepgram-json>

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -77,7 +77,7 @@
   window.document.addEventListener('hyperaudioGenerateCaptionsFromTranscript', hyperaudioGenerateCaptionsFromTranscript, false);
   let hyperaudioTemplate = "";
 
-  fetch('hyperaudio-template.html?v=0.9.1') // bump with the template — an unversioned fetch served stale copies from the browser cache
+  fetch('hyperaudio-template.html?v=1.1.1') // bump with the template — an unversioned fetch served stale copies from the browser cache
   .then(function(response) {
       // When the page is loaded convert it to text
       return response.text()


### PR DESCRIPTION
Closes #444. The exported interactive transcript page loses all three pieces of Twitter wiring — `platform.twitter.com/widgets.js`, the CDN `share-this-twitter.js`, and `ShareThisViaTwitter` in the `ShareThis` init. `ShareThisViaClipboard` stays, so select-to-share still offers copy on published transcripts. Two fewer third-party scripts in every page published from the editor; the template's fetch cache-buster bumps alongside per its own comment.

Tests: 73 unit / 79 e2e green (including the interactive-export spec that builds from the real template).