### PR TITLE
Boot-restore anti-flash, births start clean, copy-button and banner polish (#473)

### DIFF
--- a/__TEST__/e2e/doc-export.spec.mjs
+++ b/__TEST__/e2e/doc-export.spec.mjs
@@ -158,3 +158,12 @@ test.describe('copy to clipboard', () => {
     await expect(page.locator('#transcript-copy-btn')).toBeVisible();
   });
 });
+
+test('the copy button hides while a transcription is running (aria-busy)', async ({ page }) => {
+  await expect(page.locator('#transcript-copy-btn')).toBeVisible();
+  // setTranscriptBusy is what every engine calls around its work
+  await page.evaluate(() => setTranscriptBusy(true));
+  await expect(page.locator('#transcript-copy-btn')).toBeHidden();
+  await page.evaluate(() => setTranscriptBusy(false));
+  await expect(page.locator('#transcript-copy-btn')).toBeVisible();
+});

--- a/__TEST__/e2e/library.spec.mjs
+++ b/__TEST__/e2e/library.spec.mjs
@@ -348,3 +348,43 @@ test('boot restores the most recently EDITED project, not the last opened', asyn
   await expect(page.locator('#hypertranscript')).toContainText('LAST-EDIT');
   await expect(activeRow(page)).toHaveText('Project A');
 });
+
+test('reload never flashes the demo transcript over a saved project (#473)', async ({ page }, testInfo) => {
+  await openProject(page, testInfo, 'Project A');
+  await pollPage(page, () => localStorage.getItem('hyperaudioHasProjects') === '1');
+
+  // watch every frame from before the first page script: count frames where
+  // the demo ([Monika]) was VISIBLE; stop once the project content lands
+  await page.addInitScript(() => {
+    window.__demoFlashFrames = 0;
+    const tick = () => {
+      const el = document.querySelector('#hypertranscript');
+      if (el !== null && el.textContent.indexOf('Benvenuti') !== -1) return; // project landed
+      if (el !== null && el.textContent.indexOf('[Monika]') !== -1
+          && getComputedStyle(el).visibility !== 'hidden') {
+        window.__demoFlashFrames += 1;
+      }
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  });
+  await page.reload();
+  await expect(page.locator('#hypertranscript')).toContainText('Benvenuti');
+  expect(await page.evaluate(() => window.__demoFlashFrames)).toBe(0);
+  // the anti-flash hide is down again (reveal ran)
+  expect(await page.evaluate(() =>
+    document.documentElement.classList.contains('ha-restoring'))).toBe(false);
+});
+
+test('the has-projects hint tracks the library (#473)', async ({ page }, testInfo) => {
+  // empty library: boot self-heals the hint away
+  expect(await page.evaluate(() => localStorage.getItem('hyperaudioHasProjects'))).toBeNull();
+  await openProject(page, testInfo, 'Project A');
+  await pollPage(page, () => localStorage.getItem('hyperaudioHasProjects') === '1');
+  // deleting the last project retires the hint — no phantom hide next boot
+  await openKebab(page, 'Project A');
+  const del = page.locator('#recents-menu .recents-menu-delete');
+  await del.click();
+  await del.click();
+  await pollPage(page, () => localStorage.getItem('hyperaudioHasProjects') === null);
+});

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -574,3 +574,18 @@ test('a fresh transcription starts CLEAN: v0 committed at birth, dirty only on e
   });
   await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
 });
+
+test('the tab-guard banner is dismissible (per appearance, no persistence)', async ({ page, context }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+
+  const page2 = await context.newPage();
+  await page2.goto('/index.html');
+  await page2.waitForSelector('#hypertranscript [data-m]');
+  await expect(page2.locator('#tab-guard-banner')).toBeVisible();
+
+  await page2.click('#tab-guard-banner button[aria-label="Dismiss"]');
+  await expect(page2.locator('#tab-guard-banner')).toHaveCount(0);
+  await page2.close();
+});

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -541,3 +541,36 @@ test('two tabs edit two DIFFERENT projects, each owning its own working copy (#4
   expect(state.html[state.current]).toContain('TAB-TWO');
   await page2.close();
 });
+
+test('a fresh transcription starts CLEAN: v0 committed at birth, dirty only on edit', async ({ page }) => {
+  await page.evaluate(() => {
+    document.querySelector('#hyperplayer').src = 'https://example.com/media/fresh.mp4';
+    document.querySelector('#hypertranscript').innerHTML =
+      '<article><section><p><span data-m="0" data-d="500">Fresh </span></p></section></article>';
+    document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+  });
+  await pollPage(page, async () => {
+    const id = window.HyperaudioSave.library.currentId();
+    if (id === null) return false;
+    try {
+      const root = await navigator.storage.getDirectory();
+      const dir = await (await root.getDirectoryHandle('work')).getDirectoryHandle(id);
+      await dir.getFileHandle('saved.json'); // v0 committed at birth
+      return true;
+    } catch (e) { return false; }
+  });
+
+  const state = await readCurrentProject(page);
+  expect(state.saved.html).toContain('Fresh');
+  expect(state.draft).toBeNull();                     // no draft at birth
+  expect(save.isEntryDirty(state.entry)).toBe(false); // clean until edited
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+
+  // the first real edit flips it dirty, as always
+  await page.evaluate(() => {
+    const span = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    span.textContent = 'Edited ';
+    span.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
+});

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -578,6 +578,14 @@ dialog::backdrop {
   transform: none;
 }
 
+/* Boot-restore anti-flash (#473): while the inline head script's class is
+   up, the demo transcript is invisible but keeps its layout — the card shows
+   briefly empty instead of showing the wrong transcript. Removed by
+   bootLibrary when the restore lands (every path), or the inline timeout. */
+html.ha-restoring #hypertranscript {
+  visibility: hidden;
+}
+
 /* Copy-transcript button (#467): pinned to the transcript card's top-right
    corner — the toolbar is crowded on mobile — position:fixed because the
    holder itself is the scroll container (same reasoning as the caption

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -1324,10 +1324,29 @@ label[data-a11y-wired]:focus-visible {
 /* Second-tab guard banner (#450): this tab edits without the working-copy
    slot; the owning tab has autosave/crash recovery. */
 #tab-guard-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
   margin: 0 16px 8px;
   padding: 8px 12px;
   border-radius: 0.5rem;
   font-size: 12px;
   background-color: oklch(var(--b2));
   color: oklch(var(--bc) / 0.8);
+}
+/* the ✕, styled like the panel notices' dismiss */
+#tab-guard-banner button {
+  margin: 0 0 0 auto;
+  padding: 0 2px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 11px;
+  line-height: 1.4;
+  cursor: pointer;
+}
+#tab-guard-banner button:hover {
+  border: none;
+  background: transparent;
+  opacity: 0.7;
 }

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -599,6 +599,9 @@ html.ha-restoring #hypertranscript {
   color: oklch(var(--bc) / 0.55);
 }
 #transcript-copy-btn:hover { color: oklch(var(--bc)); }
+/* the loader owns the card while a transcription runs (#hypertranscript
+   carries aria-busy via setTranscriptBusy) — nothing to copy, no button */
+html:has(#hypertranscript[aria-busy="true"]) #transcript-copy-btn { display: none; }
 #transcript-copy-btn[data-copied] { color: oklch(var(--su, var(--p))); }
 /* right-anchor the tooltip bubble so it opens inward, not off the card edge */
 #transcript-copy-btn.tooltip::before {

--- a/index.html
+++ b/index.html
@@ -108,7 +108,23 @@ If you are creating an open source application under a license compatible with t
     }
     
   </style>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.1.0">
+   <!-- Boot-restore anti-flash (#473): when the synchronous hint says a
+        project exists, hide the static demo transcript BEFORE first paint —
+        the OPFS restore is async and will replace it. hyperaudio-save.js
+        reveals when the restore lands; the timeout fails safe so a script
+        error can never leave the transcript hidden. Crawlers have clean
+        storage, so their first paint is unchanged. -->
+   <script>
+     try {
+       if (localStorage.getItem('hyperaudioHasProjects') === '1') {
+         document.documentElement.classList.add('ha-restoring');
+         setTimeout(function () {
+           document.documentElement.classList.remove('ha-restoring');
+         }, 4000);
+       }
+     } catch (e) { /* private mode: no hint, no hide */ }
+   </script>
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.1.1">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1067,7 +1083,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=0.7.4"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.1.1"></script>
+  <script src="js/hyperaudio-save.js?v=1.1.2"></script>
   <script src="js/hyperaudio-library.js?v=1.0.0"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.1.2">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.1.3">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1083,7 +1083,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=0.7.4"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.1.3"></script>
+  <script src="js/hyperaudio-save.js?v=1.1.4"></script>
   <script src="js/hyperaudio-library.js?v=1.0.0"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -1083,7 +1083,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=0.7.4"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.1.2"></script>
+  <script src="js/hyperaudio-save.js?v=1.1.3"></script>
   <script src="js/hyperaudio-library.js?v=1.0.0"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.1.1">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.1.2">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -537,8 +537,31 @@
     } else {
       lib = await run();
     }
+    syncProjectsHint(lib);
     notifyLibraryChanged(false);
     return lib;
+  }
+
+  // Synchronous boot hint (#473): OPFS can only be probed async, so the next
+  // page load needs a sync signal that a project will replace the demo —
+  // the inline head script hides the transcript on it before first paint.
+  // Maintained here at the single write choke point; re-synced at boot so a
+  // cleared localStorage heals after one flash.
+  function syncProjectsHint(lib) {
+    try {
+      if (lib.projects.length > 0) {
+        localStorage.setItem('hyperaudioHasProjects', '1');
+      } else {
+        localStorage.removeItem('hyperaudioHasProjects');
+      }
+    } catch (e) { /* private mode */ }
+  }
+
+  // Reveal the transcript hidden by the inline anti-flash script (#473).
+  // Called on EVERY bootLibrary exit — restored, empty library, or failed
+  // restore falling back to the demo.
+  function revealTranscript() {
+    document.documentElement.classList.remove('ha-restoring');
   }
 
   // The panel (hyperaudio-library.js) re-renders on this event; the channel
@@ -1894,6 +1917,7 @@
 
   async function bootLibrary() {
     if (!opfsAvailable) {
+      revealTranscript();
       notifyLibraryChanged(false);
       return;
     }
@@ -1906,6 +1930,7 @@
     try {
       await migrateSingleSlotWork();
       const lib = await readLibrary();
+      syncProjectsHint(lib); // self-heal a cleared/stale hint (#473)
       // Most recently edited first; a corrupt head entry falls through to the
       // next rather than abandoning the boot (the demo stays for none).
       for (const entry of sortLibraryEntries(lib.projects)) {
@@ -1913,6 +1938,8 @@
       }
     } catch (e) {
       console.warn('hyperaudio-save: boot restore failed, leaving demo', e);
+    } finally {
+      revealTranscript(); // never leave the anti-flash hide up (#473)
     }
     notifyLibraryChanged(false);
   }

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -1050,6 +1050,24 @@
     });
   }
 
+  // Every project birth — transcription, import, opened file, delete-undo
+  // re-home — commits its initial state as saved.json and starts CLEAN: v0
+  // is the material the project was born from (the immutable origin already
+  // preserves the as-transcribed baseline at the format level). The dirty
+  // dot means "edited since the last committed state", never "you haven't
+  // performed a first Save".
+  function commitInitialState(id) {
+    snapshotChain = snapshotChain.then(async () => {
+      try {
+        const state = await writeStateFile(id, SAVED_FILE);
+        await touchLibraryEntry(id, state, { saved: true });
+      } catch (e) {
+        console.warn('hyperaudio-save: committing the new project failed', e);
+      }
+    });
+    return snapshotChain;
+  }
+
   // Land the outgoing project's pending draft in its own directory before the
   // editor DOM changes hands (#456: switching loses nothing — the draft keeps
   // the edits, the dirty state stays honest). Await-ing the chain also lets
@@ -1201,7 +1219,10 @@
     session.pendingReconcile = null;
     session.title = '';
     session.envelope = null; // a fresh document has no envelope to preserve
-    sessionEdited = true;    // a fresh transcription IS undownloaded work
+    // With OPFS the birth is committed below and the project starts CLEAN;
+    // without it nothing persists, so the session stays marked edited and
+    // the quit guard keeps protecting the on-screen work.
+    sessionEdited = session.projectId === null;
     identityGeneration += 1; // new document
     updateSaveIndicator();
     // Provenance is only this project's if the engine reported it moments ago
@@ -1219,7 +1240,8 @@
       await writeOriginOnce(htmlToJSON(getEditorHtml()));
       await resolveMediaFile();
       await writeMediaOnce();
-      await writeDraft(); // a fresh transcription is an unsaved draft
+      await commitInitialState(session.projectId); // v0: as transcribed/imported
+      updateSaveIndicator();
     }
   }
 
@@ -1561,19 +1583,10 @@
     } finally {
       suppressCapture = false;
     }
-    // The opened file IS the saved state: seed saved.json, no draft — the
-    // fresh entry starts clean.
+    // The opened file IS the saved state: commit it, no draft — the fresh
+    // entry starts clean.
     if (opfsAvailable && session.projectId !== null) {
-      const id = session.projectId;
-      snapshotChain = snapshotChain.then(async () => {
-        try {
-          const state = await writeStateFile(id, SAVED_FILE);
-          await touchLibraryEntry(id, state, { saved: true });
-        } catch (e) {
-          console.warn('hyperaudio-save: seeding the opened project failed', e);
-        }
-      });
-      await snapshotChain;
+      await commitInitialState(session.projectId);
     }
 
     if (loaded.warnings.length > 0) {
@@ -1846,7 +1859,10 @@
     await acquireProjectLock(id);
     await writeOriginToProjectDir();
     await writeMediaOnce();
-    await writeDraft(); // re-homed work is an unsaved draft until Saved
+    // a rebirth: the on-screen content IS the new baseline — commit it clean
+    await commitInitialState(id);
+    sessionEdited = false;
+    updateSaveIndicator();
     if (starred === true) await setProjectStarred(id, true);
     return id;
   }

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2176,7 +2176,17 @@
     const el = document.createElement('div');
     el.id = 'tab-guard-banner';
     el.setAttribute('role', 'status');
-    el.textContent = 'This project is open in another tab — autosave and crash recovery are active there. You can still edit and save here, or switch to a different project.';
+    const text = document.createElement('span');
+    text.textContent = 'This project is open in another tab — autosave and crash recovery are active there. You can still edit and save here, or switch to a different project.';
+    // Dismissible per appearance: the condition is real, so no persistence —
+    // contesting the same (or another) project later shows it again.
+    const dismiss = document.createElement('button');
+    dismiss.type = 'button';
+    dismiss.setAttribute('aria-label', 'Dismiss');
+    dismiss.textContent = '✕';
+    dismiss.addEventListener('click', () => { el.remove(); });
+    el.appendChild(text);
+    el.appendChild(dismiss);
     anchor.appendChild(el);
   }
 


### PR DESCRIPTION
Closes #473, plus three refinements from the same pass:

- **No demo flash on reload** (#473): a synchronous `hyperaudioHasProjects` hint (maintained at the library-write choke point, re-synced at boot) lets a tiny inline head script hide the demo transcript before first paint when a project restore is pending; `bootLibrary` reveals on every exit path, with a timeout fail-safe. Crawlers have clean storage, so their first paint is unchanged. Proven by a frame-by-frame rAF watcher: zero visible-demo frames across a reload.
- **Every project birth commits v0 and starts clean**: transcription, import, opened file and delete-undo re-home all commit their initial state as `saved.json` through one shared `commitInitialState()` — the dirty dot now means exactly "edited since the last committed state". (Births were inconsistent: opened files started clean, transcriptions started dirty.) No-OPFS browsers keep dirty-at-birth since nothing persists there.
- **Copy button hides while transcribing**: one `html:has(#hypertranscript[aria-busy])` rule keyed on `setTranscriptBusy`.
- **The tab-guard banner is dismissible**: the panel notices' ✕, per appearance, no persistence; promotion still removes it automatically.

Tests: 73 unit / 84 e2e green (includes the 1.1.2 merge).