### PR TITLE
Persist the transcription report: provenance carries seconds/device (format 1.3)

### DIFF
--- a/__TEST__/unit/hyperaudio-save.test.mjs
+++ b/__TEST__/unit/hyperaudio-save.test.mjs
@@ -83,6 +83,16 @@ test('buildProjectJson: provenance omitted when unknown', () => {
   assert.equal(project.provenance, undefined);
 });
 
+test('buildProjectJson: provenance seconds/device persist when captured (§ 3.5, 1.3 / #457)', () => {
+  const state = sampleState();
+  state.provenance = { ...state.provenance, seconds: 42.7, device: 'GPU (WebGPU)' };
+  const project = save.buildProjectJson(state);
+  assert.equal(project.provenance.seconds, 42.7);
+  assert.equal(project.provenance.device, 'GPU (WebGPU)');
+  // still valid against the project validator
+  assert.deepEqual(save.validateProjectJson(project), { ok: true, errors: [] });
+});
+
 test('validateProjectJson: accepts a conformant project', () => {
   const result = save.validateProjectJson(save.buildProjectJson(sampleState()));
   assert.deepEqual(result, { ok: true, errors: [] });
@@ -287,7 +297,7 @@ test('rewrites preserve unknown envelope fields, top-level and nested (§ 8.1)',
   assert.equal(project.texts.title, 'new');                    // owned fields overwritten
   assert.equal(project.options.captions.updateFromTranscript, false);
   assert.equal(project.formatVersion, save.FORMAT_VERSION);    // writers write their own version
-  assert.equal(save.FORMAT_VERSION, '1.2');
+  assert.equal(save.FORMAT_VERSION, '1.3');
   assert.equal(envelope.texts.title, 'old');                   // the input envelope is not mutated
 });
 

--- a/docs/hyperaudio-format.md
+++ b/docs/hyperaudio-format.md
@@ -71,7 +71,7 @@ products stay out.
 | MIME type | `application/vnd.hyperaudio+zip` |
 | Container | ZIP (standard PKZIP) |
 | Text encoding | UTF-8, always |
-| Current version | `1.1` |
+| Current version | `1.3` |
 
 ---
 
@@ -215,6 +215,8 @@ user; they may be an empty string / empty array.
   "engine": "deepgram",
   "model": "nova-3",
   "transcribedAt": "2026-07-10T08:55:00Z",
+  "seconds": 42.7,
+  "device": "GPU (WebGPU)",
   "originalTranscript": "transcript.original.json"
 }
 ```
@@ -224,6 +226,8 @@ user; they may be an empty string / empty array.
 | `engine` | string | Engine that produced the transcription (`deepgram`, `whisper`, `parakeet-local`, …). |
 | `model` | string | Model used, if known. |
 | `transcribedAt` | string | ISO 8601 UTC of the original transcription. |
+| `seconds` | number | Optional (1.3): wall-clock duration of the transcription run, in seconds. |
+| `device` | string | Optional (1.3): what performed the inference, as reported by the engine (e.g. `"GPU (WebGPU)"`, `"CPU"`). Meaningful for local engines; absent for cloud services. |
 | `originalTranscript` | string | Path of the file holding the original machine transcription (§ 5), if kept. |
 
 Records who/what produced the original transcription. Zero cost today,
@@ -524,7 +528,8 @@ Version history: **1.0** initial; **1.1** adds `media.kind: "link"`
 (§ 7.2.1); **1.2** adds `media.kind: "none"` (§ 7.2.2), makes writer-side
 preservation of unknown fields normative (§ 8.1), requires STORE for media
 entries on read (§ 7.1), and pins the `media.path` segment rule and the
-byte-measured size caps (§ 10.2, § 10.3).
+byte-measured size caps (§ 10.2, § 10.3); **1.3** adds the optional
+`provenance.seconds` and `provenance.device` fields (§ 3.5).
 
 Documented exception: unknown `media.kind` → the project is not normally
 loadable even within the same major; the behaviours of § 7.3 apply.

--- a/index.html
+++ b/index.html
@@ -1083,7 +1083,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=0.7.4"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.1.3"></script>
+  <script src="js/hyperaudio-save.js?v=1.1.4"></script>
   <script src="js/hyperaudio-library.js?v=1.0.0"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.1.3 — last changed in release 1.1.3
+ * @version 1.1.4 — last changed in release 1.1.4
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind
@@ -43,7 +43,7 @@
   'use strict';
 
   const FORMAT_NAME = 'hyperaudio';
-  const FORMAT_VERSION = '1.2'; // 1.2: kind "none", envelope preservation, pinned path/caps (spec § 8)
+  const FORMAT_VERSION = '1.3'; // 1.3: optional provenance.seconds/device (spec § 3.5); 1.2: kind "none", envelope preservation, pinned path/caps (spec § 8)
   const READER_MAJOR = 1;
   const CONTAINER_MIMETYPE = 'application/vnd.hyperaudio+zip';
   const FILE_EXTENSION = '.hyperaudio';
@@ -847,11 +847,11 @@
 
   // The info modal's Transcription section is project-bound (#456): rebuilt
   // here from the loaded project's STORED provenance whenever a project takes
-  // the editor (apply below, import reset in onNewTranscript). A live engine
-  // run still overwrites it with its richer rows (device, time taken) via
-  // editor-core's setTranscriptionInfo — those extras aren't persisted, so a
-  // reload shows this stored subset. DOM-built: provenance is file data,
-  // never innerHTML (spec § 10.5).
+  // the editor (apply below, import reset in onNewTranscript). Since format
+  // 1.3 the stored provenance carries the engine report's seconds/device too
+  // (#457), so a reload shows the same rows as a live run — minus rows the
+  // engine never reported. DOM-built: provenance is file data, never
+  // innerHTML (spec § 10.5).
   function renderTranscriptionInfo(provenance, language) {
     const container = document.getElementById('transcription-info');
     if (container === null) return;
@@ -859,6 +859,13 @@
     if (provenance && provenance.engine) rows.push(['Service', String(provenance.engine)]);
     if (provenance && provenance.model) rows.push(['Model', String(provenance.model)]);
     if (language) rows.push(['Language', String(language)]);
+    if (provenance && provenance.device) rows.push(['Processing', String(provenance.device)]);
+    if (provenance && typeof provenance.seconds === 'number' && Number.isFinite(provenance.seconds)) {
+      // same shape as editor-core's live setTranscriptionInfo formatting
+      const minutes = Math.floor(provenance.seconds / 60);
+      const seconds = Math.round(provenance.seconds % 60);
+      rows.push(['Time taken', minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`]);
+    }
     if (provenance && provenance.transcribedAt) {
       const at = new Date(provenance.transcribedAt);
       if (!Number.isNaN(at.getTime())) rows.push(['Transcribed', at.toLocaleString()]);
@@ -2134,6 +2141,14 @@
             model: info && info.model ? String(info.model) : '',
             transcribedAt: nowIso(),
           };
+          // Optional fields (spec § 3.5, format 1.3) — persisted so the info
+          // modal's Time taken / Processing rows survive a reload (#457).
+          if (info && typeof info.seconds === 'number' && Number.isFinite(info.seconds)) {
+            session.provenance.seconds = Math.round(info.seconds * 10) / 10;
+          }
+          if (info && info.device) {
+            session.provenance.device = String(info.device);
+          }
           session.provenanceAt = Date.now();
           session.language = info && info.language ? String(info.language) : session.language;
         } catch (e) { /* provenance is best-effort */ }


### PR DESCRIPTION
Fixes #457, fixes #378.

## What

The engines report processing time and device through `setTranscriptionInfo`, but only engine/model/timestamp were captured into `provenance` — so the info modal's **Time taken** and **Processing** rows vanished on any reload or project switch (#457 item 1; the persistence half of #378).

- The `setTranscriptionInfo` wrapper now also captures `seconds` (rounded to 0.1 s) and `device` into the session provenance; the writer persists them into `hyperaudio.json` unchanged.
- `renderTranscriptionInfo` renders both back from stored provenance with the same formatting as the live report, so a reopened project shows the same rows as a fresh run.
- Format surface: the two fields are optional additions, so `FORMAT_VERSION` bumps to **1.3** per § 8's minor-bump rule; § 3.5 documents them and the version history gains a 1.3 entry. Readers ignore unknown fields — older editors and other implementations are unaffected (writer parity for Glider-side implementations can follow at leisure). Also corrects the spec's stale "Current version" row (said 1.1; the writer has emitted 1.2 since the envelope-preservation work).

## Items 2–3 of #457

Neither reproduces against current code: all five engines stamp their report metadata **before** the file/URL branch, and `hyperaudio-lite-editor-parakeet.js` has called `setTranscriptionInfo` from its parse path since it landed (unchanged since July). Verified live: a URL transcription shows the full report. Both look like observations against an intermediate state of the #456 branch.

## Testing

- Unit: 74/74 (new test: provenance `seconds`/`device` round-trip and validate; the § 8.1 test's `FORMAT_VERSION` pin updated 1.2 → 1.3). E2E: 84/84.
- Manual, Chrome: URL-transcribed a clip with Whisper tiny → all five rows live; full page reload → boot-restored project still shows `Processing: GPU (WebGPU)` and `Time taken: 5s` from stored provenance.