### PR TITLE
Export as new project: flatten edits into a fresh .hyperaudio

### DIFF
--- a/__TEST__/e2e/export-project.spec.mjs
+++ b/__TEST__/e2e/export-project.spec.mjs
@@ -1,0 +1,97 @@
+// Flattened project export (#455): the "new project (.hyperaudio)" option must
+// produce a conforming container whose media IS the edited render (struck
+// seconds genuinely absent) and whose transcript is re-timed with struck words
+// removed. Uses the tone-ladder so the media's content encodes provenance.
+// Requires network: the export modal lazy-loads mediabunny from its CDN.
+import { test, expect } from '@playwright/test';
+import { createRequire } from 'node:module';
+import { ladderWav, analyseWav, transcriptHtml } from './helpers.mjs';
+
+const require = createRequire(import.meta.url);
+const save = require('../../js/hyperaudio-save.js'); // pure layer only under node
+const JSZip = require('jszip');
+
+test('flattened .hyperaudio export: edited media, re-timed struck-free transcript', async ({ page }) => {
+  const wav = ladderWav(10); // tones: sec N = (200 + N*100) Hz
+  await page.route('**/__ladder.wav', (route) => route.fulfill({
+    body: wav, contentType: 'audio/wav',
+  }));
+  await page.goto('/index.html');
+  await page.waitForFunction(() => typeof window.getPlayableSections === 'function');
+
+  await page.evaluate(async () => {
+    const blob = await (await fetch('/__ladder.wav')).blob();
+    document.getElementById('hyperplayer').src = URL.createObjectURL(blob);
+  });
+  await page.waitForFunction(() => {
+    const p = document.getElementById('hyperplayer');
+    return p.readyState >= 1 && p.duration > 9;
+  });
+
+  // one word per second; strike seconds 3 and 7
+  const words = Array.from({ length: 10 }, (_, i) => [i * 1000, 1000, i === 3 || i === 7 ? 1 : 0]);
+  await page.evaluate((html) => {
+    document.getElementById('hypertranscript').innerHTML = html;
+  }, transcriptHtml(words));
+
+  await page.evaluate(() => {
+    const m = document.getElementById('export-modal');
+    m.checked = true;
+    m.dispatchEvent(new Event('change'));
+  });
+  await page.waitForFunction(() => document.getElementById('export-format').options.length > 0, null, { timeout: 60000 });
+  await page.selectOption('#export-format', 'wav');
+  await page.evaluate(() => {
+    // only the media file + the project container
+    for (const id of ['export-retime', 'export-vtt', 'export-srt', 'export-burn']) {
+      const c = document.getElementById(id);
+      if (c) c.checked = false;
+    }
+    const p = document.getElementById('export-project');
+    p.checked = true;
+    document.getElementById('export-name').value = 'flattened';
+  });
+
+  const first = page.waitForEvent('download');
+  await page.click('#export-start');
+  const wavDownload = await first;
+  const second = await page.waitForEvent('download');
+  await page.waitForFunction(() => document.getElementById('export-status').textContent.startsWith('Done'));
+
+  expect(wavDownload.suggestedFilename()).toBe('flattened.wav');
+  expect(second.suggestedFilename()).toBe('flattened.hyperaudio');
+
+  const fs = await import('node:fs/promises');
+  const bytes = await fs.readFile(await second.path());
+
+  // read through the app's own reader: enforces the entry whitelist and STORE
+  // on the media entry, and validates the project JSON shape
+  const res = await save.unzipProject(new Uint8Array(bytes), JSZip);
+  expect(res.recovered).toBeFalsy();
+  const project = res.project;
+
+  // container identity: fresh original-media project, format ≥ 1.3
+  expect(project.media.kind).toBe('original');
+  expect(project.media.path).toBe('media/flattened.wav');
+  expect(project.media.filename).toBe('flattened.wav');
+  expect(Math.abs(project.media.durationSeconds - 8)).toBeLessThan(0.05);
+  expect(project.media.sizeBytes).toBe(res.mediaData.byteLength ?? res.mediaData.length);
+  expect(project.texts.title).toBe('flattened');
+  // cuts are baked into the media — replaying gap removal would cut twice
+  expect(project.options.gapRemoval.enabled).toBe(false);
+  // the origin transcript does not match the rendered timeline
+  expect(project.provenance?.originalTranscript).toBeUndefined();
+
+  // transcript: 8 words, none struck, re-timed onto the edited timeline —
+  // the word originally at 4s starts at 3s once struck second 3 is cut
+  expect(project.transcript.words.length).toBe(8);
+  expect(project.transcript.words.some((w) => w.struck === true)).toBe(false);
+  const starts = project.transcript.words.map((w) => Math.round(w.start));
+  expect(starts).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+
+  // the media itself: 8 seconds, struck tones (500Hz, 900Hz) absent
+  const { duration, freqs } = analyseWav(Buffer.from(res.mediaData));
+  expect(Math.abs(duration - 8)).toBeLessThan(0.01);
+  expect(freqs).not.toContain(500);
+  expect(freqs).not.toContain(900);
+});

--- a/index.html
+++ b/index.html
@@ -858,6 +858,10 @@ If you are creating an open source application under a license compatible with t
         <input type="checkbox" id="export-srt" class="toggle toggle-primary" />
         <span class="label-text">Download SRT (.srt) captions</span>
       </label>
+      <label id="export-project-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
+        <input type="checkbox" id="export-project" class="toggle toggle-primary" />
+        <span class="label-text">Download a new project (.hyperaudio) — edits applied, struck words removed, safe to share</span>
+      </label>
       <progress id="export-progress" class="progress progress-primary w-full" value="0" max="100" style="visibility:hidden; margin-top:14px"></progress>
       <div id="export-status" aria-live="polite" style="font-size:85%; opacity:0.75; min-height:1.3em; margin-top:2px"></div>
       <div class="modal-action">
@@ -1067,7 +1071,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/editor-main.js?v=0.8.0"></script>
   <script src="js/find-replace.js?v=0.6.29"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
-  <script src="js/media-export.js?v=1.0.0"></script>
+  <script src="js/media-export.js?v=1.1.4"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
   <script src="js/word-vtt.js?v=0.8.5"></script>
   <!-- end of caption editor additions -->

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -1398,6 +1398,62 @@
     if (btn !== null) btn.classList.toggle('dirty', sessionEdited === true);
   }
 
+  // Flattened project export (#455): build a fresh .hyperaudio around a
+  // RENDERED export — the render becomes the new project's original media
+  // (relative to it nothing is "derived", spec § 1.1), the re-timed
+  // struck-free transcript its transcript. Called by the media-export modal
+  // with the artifacts it already produced; this module contributes what it
+  // owns (texts, provenance, options, the container layers). Deliberate
+  // differences from a Save/Export of the current project:
+  //   - envelope: null — this is a NEW document, not a round-trip of the
+  //     opened one, so no unknown-field preservation applies;
+  //   - hasOriginal: false — the origin transcript no longer matches the
+  //     rendered timeline, so transcript.original.json is not carried over;
+  //   - gapRemoval disabled — the cuts are baked into the media; replaying
+  //     them on the new timeline would cut twice.
+  // parts: { html, captionsVtt, media: {name, data(Blob), mimeType,
+  //          durationSeconds}, title }  →  Promise<Blob>
+  async function buildFlattenedProjectBlob(parts) {
+    const base = gather();
+    const transcript = htmlToJSON(parts.html);
+    const safeName = sanitizeMediaFilename(parts.media.name);
+    const now = nowIso();
+    const state = Object.assign({}, base, {
+      envelope: null,
+      created: now,
+      modified: now,
+      media: {
+        kind: 'original',
+        path: MEDIA_DIR + safeName,
+        url: null,
+        filename: safeName,
+        mimeType: parts.media.mimeType || (parts.media.data && parts.media.data.type) || '',
+        durationSeconds: parts.media.durationSeconds || 0,
+        sizeBytes: parts.media.data.size,
+      },
+      options: Object.assign({}, base.options, {
+        gapRemoval: Object.assign({}, base.options.gapRemoval, { enabled: false }),
+      }),
+      texts: Object.assign({}, base.texts,
+        parts.title ? { title: String(parts.title) } : {}),
+      hasOriginal: false,
+      transcript,
+      html: parts.html,
+    });
+    const project = buildProjectJson(state);
+    const valid = validateProjectJson(project);
+    if (!valid.ok) {
+      throw new Error('The flattened project failed validation: '
+        + valid.errors.map((e) => e.code).join(', '));
+    }
+    return zipProject({
+      json: serializeProjectJson(project),
+      html: parts.html,
+      captionsVtt: parts.captionsVtt || '',
+      media: { name: safeName, data: parts.media.data },
+    }, await loadJSZip(), 'blob');
+  }
+
   // Export Project (.hyperaudio): build the container and download it — the
   // ONLY path that downloads. Saving is the silent OPFS commit (saveProject);
   // export is how a portable copy leaves the browser. asSave marks the two
@@ -2283,6 +2339,7 @@
   window.HyperaudioSave = {
     saveProject,     // silent OPFS commit (⌘S / the navbar button)
     exportProject,   // build + download a portable .hyperaudio
+    buildFlattenedProjectBlob, // #455: fresh container around a rendered export (media-export modal)
     // export naming and any future UI read the title through here
     getProjectTitle: () => session.title || (session.mediaFile !== null ? session.mediaFile.name : '') || '',
     // the document exports (#467) read the transcript through here: the same

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -1,7 +1,7 @@
 /**
  * media-export.js
  * (C) The Hyperaudio Project
- * @version 1.0.0 — last changed in release 1.0.0
+ * @version 1.1.4 — last changed in release 1.1.4
  * @license MIT
  *
  * Media export via mediabunny (#289, #291, #292): export the loaded media as
@@ -572,6 +572,8 @@
   const vttCheck = document.getElementById('export-vtt');
   const srtRow = document.getElementById('export-srt-row');
   const srtCheck = document.getElementById('export-srt');
+  const projectRow = document.getElementById('export-project-row');
+  const projectCheck = document.getElementById('export-project');
   const burnRow = document.getElementById('export-burn-row');
   const burnCheck = document.getElementById('export-burn');
   const progressBar = document.getElementById('export-progress');
@@ -715,6 +717,13 @@
     retimeRow.style.display = show;
     if (vttRow !== null) vttRow.style.display = show;
     if (srtRow !== null) srtRow.style.display = show;
+    // the flattened project (#455) needs a transcript to flatten, and the
+    // container writer to be loaded
+    if (projectRow !== null) {
+      projectRow.style.display =
+        (show === 'flex' && window.HyperaudioSave
+          && typeof window.HyperaudioSave.buildFlattenedProjectBlob === 'function') ? 'flex' : 'none';
+    }
   };
 
   const hasTranscript = () => {
@@ -748,6 +757,7 @@
         retime: retimeCheck.checked,
         vtt: vttCheck !== null && vttCheck.checked,
         srt: srtCheck !== null && srtCheck.checked,
+        project: projectCheck !== null && projectCheck.checked,
       }));
     } catch (e) { /* storage unavailable (private mode / quota) — non-fatal */ }
   };
@@ -781,6 +791,7 @@
     retimeCheck.checked = opts.retime === true;
     if (vttCheck !== null) vttCheck.checked = opts.vtt === true;
     if (srtCheck !== null) srtCheck.checked = opts.srt === true;
+    if (projectCheck !== null) projectCheck.checked = opts.project === true;
 
     // speed / length: offer it whenever there's media; restore the toggle and
     // the last speed, defaulting to the player's current rate so a playback
@@ -853,6 +864,8 @@
       const wantRetime = retimeCheck.checked && retimeRow.style.display !== 'none';
       const wantVtt = vttCheck !== null && vttCheck.checked && vttRow.style.display !== 'none';
       const wantSrt = srtCheck !== null && srtCheck.checked && srtRow.style.display !== 'none';
+      const wantProject = projectCheck !== null && projectCheck.checked
+        && projectRow !== null && projectRow.style.display !== 'none';
       // user-chosen export name (verbatim, so the media file and the transcript's
       // <video src> always agree); light sanitise for filename safety
       const rawName = nameInput !== null ? nameInput.value.trim() : '';
@@ -908,7 +921,33 @@
         }
       }
 
-      // 3. hand the browser each file, spaced out so Safari doesn't drop all but
+      // 3. flattened project container (#455): a fresh .hyperaudio in which the
+      // render IS the original media, with the re-timed struck-free transcript
+      // and matching captions. Cuts are genuinely absent from the media and
+      // struck words unrecoverable — the safe-to-share artifact the format
+      // doc's § 1.1 caveat points to.
+      if (wantProject) {
+        setStatus('Building project container…');
+        const projHtml = buildRetimedTranscriptHtml(sections, rate);
+        if (projHtml !== null) {
+          const projSubs = genRetimedCaptions(sections, rate);
+          const projDur = keptDuration(sections) / rate; // Infinity when metadata never loaded
+          const projBlob = await window.HyperaudioSave.buildFlattenedProjectBlob({
+            html: projHtml,
+            captionsVtt: projSubs && projSubs.vtt ? projSubs.vtt : '',
+            media: {
+              name: mediaName,
+              data: blob,
+              mimeType: fmt.mime,
+              durationSeconds: Number.isFinite(projDur) ? Math.round(projDur * 1000) / 1000 : 0,
+            },
+            title: baseName,
+          });
+          outputs.push({ blob: projBlob, name: `${baseName}.hyperaudio` });
+        }
+      }
+
+      // 4. hand the browser each file, spaced out so Safari doesn't drop all but
       // the last of a multi-file download
       for (let i = 0; i < outputs.length; i++) {
         downloadBlob(outputs[i].blob, outputs[i].name);
@@ -942,7 +981,7 @@
     if (lengthMinInput !== null) lengthMinInput.addEventListener('change', () => { syncFromLength(); saveExportOpts(); });
     if (lengthSecInput !== null) lengthSecInput.addEventListener('change', () => { syncFromLength(); saveExportOpts(); });
   }
-  [burnCheck, retimeCheck, vttCheck, srtCheck].forEach((el) => {
+  [burnCheck, retimeCheck, vttCheck, srtCheck, projectCheck].forEach((el) => {
     if (el !== null) el.addEventListener('change', saveExportOpts);
   });
   startBtn.addEventListener('click', runExport);


### PR DESCRIPTION
Fixes #455. Stacked on #475.

## What

A new toggle in the media-export modal — **"Download a new project (.hyperaudio) — edits applied, struck words removed, safe to share"** — adds one output to the export: a fresh `.hyperaudio` in which the rendered media IS the new project's original media, the transcript is the re-timed struck-free one (the same code path the re-timed sidecars already use), and captions are re-timed to match. Cuts are genuinely absent from the media and struck words unrecoverable — the safe-to-share artifact `docs/hyperaudio-format.md` § 1.1's privacy caveat points to.

This is spec-clean: relative to the new project nothing is "derived", so the output is an ordinary conforming container (media `kind: "original"`).

## Semantics

- Fresh document: `envelope: null` (not a round-trip of the opened project); no `transcript.original.json` — the origin no longer matches the rendered timeline.
- `gapRemoval` disabled in the new project: the cuts are baked into the media, replaying them would cut twice.
- Provenance (engine/model/transcribedAt/seconds/device) carries over; title and all filenames follow the modal's "Save as" name; the option honours the Entire/Edited choice and any speed adjustment, like every other output; it appears only when there's a transcript. The toggle persists with the other export options.
- Deliberately NOT included (the issue's "future minor could note lineage"): a provenance lineage marker — kept the format surface minimal; easy follow-up if wanted.

## How

- `hyperaudio-save.js` gains `HyperaudioSave.buildFlattenedProjectBlob(parts)` — it owns session texts/provenance and the FORMAT/CONTAINER layers, and validates the resulting JSON before zipping.
- `media-export.js` builds the render artifacts (re-timed HTML, VTT, blob, duration) and queues the container into its normal multi-file download flow.

## Testing

- Unit: 74/74. E2E: 85/85, including a new spec (`export-project.spec.mjs`): exports a tone-ladder WAV with two struck seconds plus the container, reads the `.hyperaudio` back through the app's own `unzipProject` (entry whitelist + STORE enforced), and asserts the media is exactly the kept 8 s with the struck tones absent, the transcript is re-timed with no `struck` flags, `gapRemoval` is off, and the project JSON validates.