### PR TITLE
Phantom dirty dot fixes, view-switch relayout, gaps retitle

### DIFF
--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -347,6 +347,15 @@ test('a fresh transcription births CLEAN: the engine caption pass is not an edit
   await page.waitForTimeout(2000); // and it stays clean once the birth settles
   await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
 
+  // focus traffic is not an edit: focus into the transcript and away again —
+  // the same sequence an app switch replays on window refocus — stays clean
+  await page.evaluate(() => {
+    document.getElementById('hypertranscript').focus();
+    document.getElementById('project-save-btn').focus();
+  });
+  await page.waitForTimeout(300);
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+
   // a LATER caption regeneration (user-driven) is a real edit again
   await page.evaluate(() => {
     document.dispatchEvent(new CustomEvent('hyperaudioGenerateCaptionsFromTranscript'));

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -331,6 +331,29 @@ test('edit tracking survives the caption-mode round trip (#448 delegation)', asy
   expect(after.draft.html).toContain('POST-ROUNDTRIP');
 });
 
+test('a fresh transcription births CLEAN: the engine caption pass is not an edit', async ({ page }) => {
+  // simulate exactly what every engine does when a transcription lands:
+  // render the transcript, fire hyperaudioInit, then the caption event
+  await page.evaluate(() => {
+    document.getElementById('hypertranscript').innerHTML =
+      '<article><section><p><span data-m="0" data-d="500">Fresh </span><span data-m="500" data-d="500">words </span></p></section></article>';
+    document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+    document.dispatchEvent(new CustomEvent('hyperaudioGenerateCaptionsFromTranscript'));
+  });
+  await awaitLibraryEntry(page);
+  // the birth commit gathers AFTER the captions are generated, so the
+  // committed v0 matches the screen — the Save button must be clean
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+  await page.waitForTimeout(2000); // and it stays clean once the birth settles
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+
+  // a LATER caption regeneration (user-driven) is a real edit again
+  await page.evaluate(() => {
+    document.dispatchEvent(new CustomEvent('hyperaudioGenerateCaptionsFromTranscript'));
+  });
+  await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
+});
+
 test('Save is a SILENT OPFS commit: dot clears, saved.json lands, the draft retires (#456)', async ({ page }, testInfo) => {
   const dialogs = [];
   await openFixture(page, testInfo, dialogs);

--- a/index.html
+++ b/index.html
@@ -411,6 +411,23 @@ If you are creating an open source application under a license compatible with t
             <svg id="sidebar-close-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sidebar-close"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect><path d="M9 3v18"></path><path d="m16 15-3-3 3-3"></path></svg>
             <svg id="sidebar-open-icon" style="display: none" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sidebar-open"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect><path d="M9 3v18"></path><path d="m14 9 3 3-3 3"></path></svg>
           </button>
+          <!-- Transcript/captions view switch: a recessed track whose raised thumb
+               slides under the active segment (styles in hyperaudio-lite-editor.css).
+               The active view is marked by the thumb and aria-pressed, never by
+               disabled — disabled reads as "unavailable", not "current view".
+               editor-core.js keeps the state in sync. In the LEFT cluster with the
+               other view/editing controls (#423): what-am-I-looking-at on the left,
+               document-lifecycle actions on the right — the grouping the Glider
+               top bar reached independently (hyperaudio/glider#156). ids are a
+               programmatic contract (engines click #transcript-editor-btn). -->
+          <div id="view-switch" role="group" aria-label="Editor view">
+            <button id="transcript-editor-btn" class="btn btn-square tooltip" data-tip="Transcript view" aria-label="Transcript view" aria-pressed="true">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-file-text"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
+            </button>
+            <button id="caption-editor-btn" class="btn btn-square tooltip" data-tip="Captions view" aria-label="Captions view" aria-pressed="false">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-subtitles"><path d="M7 13h4"></path><path d="M15 13h2"></path><path d="M7 9h2"></path><path d="M13 9h4"></path><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10Z"></path></svg>
+            </button>
+          </div>
           <button id="strikethrough" class="btn btn-square btn-outline tooltip" data-tip="Strikethrough" style="margin-right:4px" aria-label="Strike through text">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-strikethrough"><path d="M16 4H9a3 3 0 0 0-2.83 4"/><path d="M14 12a4 4 0 0 1 0 8H6"/><line x1="4" x2="20" y1="12" y2="12"/></svg>
           </button>
@@ -538,19 +555,6 @@ If you are creating an open source application under a license compatible with t
           <!--<label for="captions-modal" class="btn btn-outline gap-2" style="margin-right:4px">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-subtitles"><path d="M7 13h4"></path><path d="M15 13h2"></path><path d="M7 9h2"></path><path d="M13 9h4"></path><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10Z"></path></svg>
           </label>-->
-          <!-- Transcript/captions view switch: a recessed track whose raised thumb
-               slides under the active segment (styles in hyperaudio-lite-editor.css).
-               The active view is marked by the thumb and aria-pressed, never by
-               disabled — disabled reads as "unavailable", not "current view".
-               editor-core.js keeps the state in sync. -->
-          <div id="view-switch" role="group" aria-label="Editor view">
-            <button id="transcript-editor-btn" class="btn btn-square tooltip" data-tip="Transcript view" aria-label="Transcript view" aria-pressed="true">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-file-text"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
-            </button>
-            <button id="caption-editor-btn" class="btn btn-square tooltip" data-tip="Captions view" aria-label="Captions view" aria-pressed="false">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-subtitles"><path d="M7 13h4"></path><path d="M15 13h2"></path><path d="M7 9h2"></path><path d="M13 9h4"></path><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10Z"></path></svg>
-            </button>
-          </div>
           <input type="checkbox" id="captions-modal" class="modal-toggle" tabindex="-1" aria-hidden="true" />
           <div class="modal" style="content-visibility: hidden;">
             <div class="modal-box relative">

--- a/index.html
+++ b/index.html
@@ -411,30 +411,6 @@ If you are creating an open source application under a license compatible with t
             <svg id="sidebar-close-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sidebar-close"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect><path d="M9 3v18"></path><path d="m16 15-3-3 3-3"></path></svg>
             <svg id="sidebar-open-icon" style="display: none" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sidebar-open"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect><path d="M9 3v18"></path><path d="m14 9 3 3-3 3"></path></svg>
           </button>
-          <!-- Transcript/captions view switch: a recessed track whose raised thumb
-               slides under the active segment (styles in hyperaudio-lite-editor.css).
-               The active view is marked by the thumb and aria-pressed, never by
-               disabled — disabled reads as "unavailable", not "current view".
-               editor-core.js keeps the state in sync. In the LEFT cluster with the
-               other view/editing controls (#423): what-am-I-looking-at on the left,
-               document-lifecycle actions on the right — the grouping the Glider
-               top bar reached independently (hyperaudio/glider#156). ids are a
-               programmatic contract (engines click #transcript-editor-btn). -->
-          <div id="view-switch" role="group" aria-label="Editor view">
-            <button id="transcript-editor-btn" class="btn btn-square tooltip" data-tip="Transcript view" aria-label="Transcript view" aria-pressed="true">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-file-text"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
-            </button>
-            <button id="caption-editor-btn" class="btn btn-square tooltip" data-tip="Captions view" aria-label="Captions view" aria-pressed="false">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-subtitles"><path d="M7 13h4"></path><path d="M15 13h2"></path><path d="M7 9h2"></path><path d="M13 9h4"></path><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10Z"></path></svg>
-            </button>
-          </div>
-          <button id="strikethrough" class="btn btn-square btn-outline tooltip" data-tip="Strikethrough" style="margin-right:4px" aria-label="Strike through text">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-strikethrough"><path d="M16 4H9a3 3 0 0 0-2.83 4"/><path d="M14 12a4 4 0 0 1 0 8H6"/><line x1="4" x2="20" y1="12" y2="12"/></svg>
-          </button>
-          <label id="remove-gaps-btn" for="remove-gaps-modal" class="btn btn-square btn-outline relative tooltip" data-tip="Skip gaps between speech" style="margin-right:4px" aria-label="Remove gaps between speech">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-rabbit"><path d="M13 16a3 3 0 0 1 2.24 5"/><path d="M18 12h.01"/><path d="M18 21h-8a4 4 0 0 1-4-4 7 7 0 0 1 7-7h.2L9.6 6.4a1 1 0 1 1 2.8-2.8L15.8 7h.2c3.3 0 6 2.7 6 6v1a2 2 0 0 1-2 2h-1a3 3 0 0 0-3 3"/><path d="M20 8.54V4a2 2 0 1 0-4 0v3"/><path d="M7.612 12.524a3 3 0 1 0-1.6 4.3"/></svg>
-            <span id="remove-gaps-active-dot" style="display:none;position:absolute;top:4px;right:4px;width:9px;height:9px;border-radius:9999px;background-color:oklch(var(--p));z-index:2;pointer-events:none;"></span>
-          </label>
           <div class="dropdown menu-compact">
             <label tabindex="0" class="btn btn-outline gap-2" style="margin-right:4px; flex-wrap:nowrap;">
               <span id="file-dropdown-text">FILE</span>
@@ -495,6 +471,30 @@ If you are creating an open source application under a license compatible with t
                 </details>
               </li>
             </ul>
+          </div>
+          <button id="strikethrough" class="btn btn-square btn-outline tooltip" data-tip="Strikethrough" style="margin-right:4px" aria-label="Strike through text">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-strikethrough"><path d="M16 4H9a3 3 0 0 0-2.83 4"/><path d="M14 12a4 4 0 0 1 0 8H6"/><line x1="4" x2="20" y1="12" y2="12"/></svg>
+          </button>
+          <label id="remove-gaps-btn" for="remove-gaps-modal" class="btn btn-square btn-outline relative tooltip" data-tip="Skip gaps between speech" style="margin-right:4px" aria-label="Remove gaps between speech">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-rabbit"><path d="M13 16a3 3 0 0 1 2.24 5"/><path d="M18 12h.01"/><path d="M18 21h-8a4 4 0 0 1-4-4 7 7 0 0 1 7-7h.2L9.6 6.4a1 1 0 1 1 2.8-2.8L15.8 7h.2c3.3 0 6 2.7 6 6v1a2 2 0 0 1-2 2h-1a3 3 0 0 0-3 3"/><path d="M20 8.54V4a2 2 0 1 0-4 0v3"/><path d="M7.612 12.524a3 3 0 1 0-1.6 4.3"/></svg>
+            <span id="remove-gaps-active-dot" style="display:none;position:absolute;top:4px;right:4px;width:9px;height:9px;border-radius:9999px;background-color:oklch(var(--p));z-index:2;pointer-events:none;"></span>
+          </label>
+          <!-- Transcript/captions view switch: a recessed track whose raised thumb
+               slides under the active segment (styles in hyperaudio-lite-editor.css).
+               The active view is marked by the thumb and aria-pressed, never by
+               disabled — disabled reads as "unavailable", not "current view".
+               editor-core.js keeps the state in sync. In the LEFT cluster with the
+               other view/editing controls (#423): what-am-I-looking-at on the left,
+               document-lifecycle actions on the right — the grouping the Glider
+               top bar reached independently (hyperaudio/glider#156). ids are a
+               programmatic contract (engines click #transcript-editor-btn). -->
+          <div id="view-switch" role="group" aria-label="Editor view">
+            <button id="transcript-editor-btn" class="btn btn-square tooltip" data-tip="Transcript view" aria-label="Transcript view" aria-pressed="true">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-file-text"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
+            </button>
+            <button id="caption-editor-btn" class="btn btn-square tooltip" data-tip="Captions view" aria-label="Captions view" aria-pressed="false">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-subtitles"><path d="M7 13h4"></path><path d="M15 13h2"></path><path d="M7 9h2"></path><path d="M13 9h4"></path><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10Z"></path></svg>
+            </button>
           </div>
           <input type="checkbox" id="info-modal" class="modal-toggle" tabindex="-1" aria-hidden="true" />
           <div class="modal">

--- a/index.html
+++ b/index.html
@@ -414,7 +414,7 @@ If you are creating an open source application under a license compatible with t
           <button id="strikethrough" class="btn btn-square btn-outline tooltip" data-tip="Strikethrough" style="margin-right:4px" aria-label="Strike through text">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-strikethrough"><path d="M16 4H9a3 3 0 0 0-2.83 4"/><path d="M14 12a4 4 0 0 1 0 8H6"/><line x1="4" x2="20" y1="12" y2="12"/></svg>
           </button>
-          <label id="remove-gaps-btn" for="remove-gaps-modal" class="btn btn-square btn-outline relative tooltip" data-tip="Skip silent gaps" style="margin-right:4px" aria-label="Remove silent gaps">
+          <label id="remove-gaps-btn" for="remove-gaps-modal" class="btn btn-square btn-outline relative tooltip" data-tip="Skip gaps between speech" style="margin-right:4px" aria-label="Remove gaps between speech">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-rabbit"><path d="M13 16a3 3 0 0 1 2.24 5"/><path d="M18 12h.01"/><path d="M18 21h-8a4 4 0 0 1-4-4 7 7 0 0 1 7-7h.2L9.6 6.4a1 1 0 1 1 2.8-2.8L15.8 7h.2c3.3 0 6 2.7 6 6v1a2 2 0 0 1-2 2h-1a3 3 0 0 0-3 3"/><path d="M20 8.54V4a2 2 0 1 0-4 0v3"/><path d="M7.612 12.524a3 3 0 1 0-1.6 4.3"/></svg>
             <span id="remove-gaps-active-dot" style="display:none;position:absolute;top:4px;right:4px;width:9px;height:9px;border-radius:9999px;background-color:oklch(var(--p));z-index:2;pointer-events:none;"></span>
           </label>
@@ -962,7 +962,7 @@ If you are creating an open source application under a license compatible with t
   <div class="modal">
     <div class="modal-box">
       <label for="remove-gaps-modal" class="btn btn-sm btn-circle absolute right-2 top-2" aria-label="Close">✕</label>
-      <h3 class="font-bold text-lg" style="margin-bottom:16px">Remove Silent Gaps</h3>
+      <h3 class="font-bold text-lg" style="margin-bottom:16px">Remove Gaps between Speech</h3>
 
       <div class="flex flex-col gap-4 w-full">
         <div style="display:flex;align-items:center;gap:8px">

--- a/index.html
+++ b/index.html
@@ -1087,7 +1087,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=0.7.4"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.1.4"></script>
+  <script src="js/hyperaudio-save.js?v=1.1.5"></script>
   <script src="js/hyperaudio-library.js?v=1.0.0"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.1.4 — last changed in release 1.1.4
+ * @version 1.1.5 — last changed in release 1.1.5
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind
@@ -620,6 +620,12 @@
   // decide inside a click handler. Set on every capture trigger and on a new
   // transcription; cleared on save-download, open, and session end.
   let sessionEdited = false;
+  // True while onNewTranscript is birthing a project. The engines dispatch
+  // hyperaudioGenerateCaptionsFromTranscript right after hyperaudioInit as
+  // part of a transcription landing; counting that pass as an edit left the
+  // Save button dirty after every transcription even though the birth commit
+  // (which gathers AFTER the captions are generated) matches the screen.
+  let birthInProgress = false;
   // Lifecycle guards (#448): generations decide whether an async completion
   // may still be applied; in-flight flags serialize container/snapshot work.
   let editGeneration = 0;      // bumps on every edit signal
@@ -1214,6 +1220,11 @@
     if (suppressCapture) return;
     const transcriptEl = document.querySelector('#hypertranscript');
     if (transcriptEl === null || transcriptEl.querySelector('span[data-m]') === null) return;
+    // Raised synchronously inside the hyperaudioInit dispatch — i.e. BEFORE
+    // the engine's follow-up caption event fires — and lowered once the birth
+    // commit completes. User edits during the window still mark dirty through
+    // the input/click listeners; only the app's own caption pass is exempt.
+    birthInProgress = true;
     clearTimeout(autosaveTimer);
     autosaveTimer = null;
     autosavePending = false;
@@ -1242,13 +1253,17 @@
       // previous project's transcription details
       renderTranscriptionInfo(null, '');
     }
-    if (opfsAvailable && session.projectId !== null) {
-      await acquireProjectLock(session.projectId); // fresh id: always granted
-      await writeOriginOnce(htmlToJSON(getEditorHtml()));
-      await resolveMediaFile();
-      await writeMediaOnce();
-      await commitInitialState(session.projectId); // v0: as transcribed/imported
-      updateSaveIndicator();
+    try {
+      if (opfsAvailable && session.projectId !== null) {
+        await acquireProjectLock(session.projectId); // fresh id: always granted
+        await writeOriginOnce(htmlToJSON(getEditorHtml()));
+        await resolveMediaFile();
+        await writeMediaOnce();
+        await commitInitialState(session.projectId); // v0: as transcribed/imported
+        updateSaveIndicator();
+      }
+    } finally {
+      birthInProgress = false;
     }
   }
 
@@ -2229,7 +2244,12 @@
     // the strike-through toolbar mutates word styles without emitting input
     const strikeBtn = document.querySelector('#strikethrough');
     if (strikeBtn !== null) strikeBtn.addEventListener('click', scheduleAutosave);
-    document.addEventListener('hyperaudioGenerateCaptionsFromTranscript', scheduleAutosave);
+    document.addEventListener('hyperaudioGenerateCaptionsFromTranscript', () => {
+      // the engine-driven caption pass during project birth is part of the
+      // committed v0, not an edit — see birthInProgress
+      if (birthInProgress) return;
+      scheduleAutosave();
+    });
     ['#remove-gaps-enabled', '#remove-gaps-threshold', '#remove-gaps-buffer', '#show-speakers', '#show-timecodes']
       .forEach((selector) => {
         const el = document.querySelector(selector);

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2236,10 +2236,19 @@
       const t = event.target;
       if (t && t.closest && t.closest(EDIT_SCOPE) !== null) scheduleAutosave();
     }, true);
-    // blur doesn't bubble; focusout does — end-of-edit capture for the transcript
+    // blur doesn't bubble; focusout does — end-of-edit capture for the
+    // transcript. Only when an edit is actually pending: the transcript is a
+    // contenteditable that takes focus on any click into it (and Chrome
+    // restores that focus after an app switch), so an unconditional
+    // focusout-marks-dirty turned mere focus traffic — click a word, click
+    // away; leave the window, come back, click anything — into a phantom
+    // dirty dot. Every real edit fires `input` first, which sets
+    // autosavePending; this listener only hastens that flush.
     document.addEventListener('focusout', (event) => {
       const t = event.target;
-      if (t && t.closest && t.closest('#hypertranscript') !== null) scheduleAutosave();
+      if (t && t.closest && t.closest('#hypertranscript') !== null && autosavePending) {
+        scheduleAutosave();
+      }
     });
     // the strike-through toolbar mutates word styles without emitting input
     const strikeBtn = document.querySelector('#strikethrough');


### PR DESCRIPTION
Fixes #464, fixes #423.

Two independent causes made the Save button's dirty dot appear without any user edit, plus two small UI items.

## 1. The engine caption pass at project birth

Every engine dispatches `hyperaudioGenerateCaptionsFromTranscript` right after `hyperaudioInit` when a transcription lands, and the edit listener counted that as a user edit — so every transcription ended with a dirty Save button, even though the birth commit (which gathers *after* captions are generated) matches the screen exactly. A `birthInProgress` flag — raised synchronously inside the `hyperaudioInit` dispatch, provably before the engine's follow-up event — exempts only that pass. A later user-driven caption regeneration counts as an edit again.

## 2. Transcript focus traffic

The transcript is a contenteditable that takes focus on any click into it, and Chrome restores that focus after an app switch — so the unconditional `focusout` → `scheduleAutosave` "end-of-edit capture" turned mere focus movement (click a word, click away; leave the window, come back, click anything) into a phantom dirty dot. Every real edit fires `input` first, which sets `autosavePending` and marks dirty through its own listener; the `focusout` handler now only hastens that pending flush, making it incapable of introducing dirty state.

## 3. "Remove Gaps between Speech" (#464)

The modal title, toolbar tooltip and aria-label now say what the feature acts on rather than implying it removes silence from the media.

## 4. View switch joins the left control cluster (#423)

The transcript/captions switch is a view-mode control but sat mid-right, splitting the document-lifecycle cluster. It now lives in `navbar-start` with the other view/editing controls — "what am I looking at / doing to the text" on the left, "what happens to the document" on the right, the same grouping the Glider top bar reached independently (hyperaudio/glider#156). Element ids are unchanged, so the engines' programmatic `#transcript-editor-btn` click and all wiring survive.

## Testing

- Unit 74/74, e2e 86/86. New regression test simulates the exact engine birth sequence and the focus cycle: clean after birth, clean after focus in/out, dirty again on user-driven caption regen. Fix 1 verified red-green (guard disabled → test fails as the bug manifested).
- Both dirty-dot fixes reproduced and re-verified live in Chrome, including the app-switch focus-restore path; the relocated switch verified toggling both ways.