### PR TITLE
Wrap each karaoke-VTT word in <c> so ::cue(:past/:future) can style it

### DIFF
--- a/__TEST__/unit/word-vtt.test.mjs
+++ b/__TEST__/unit/word-vtt.test.mjs
@@ -67,8 +67,9 @@ test('generateWordVtt: header, cue timing, inline per-word timestamps', () => {
   ]);
   const vtt = generateWordVtt({ source: root, maxWords: 5, maxGap: 0.8 });
   assert.match(vtt, /^WEBVTT\n/);
-  assert.match(vtt, /\n00:00:01\.200 --> 00:00:01\.850\n<00:00:01\.200>So <00:00:01\.550>if\n/);
-  assert.match(vtt, /\n00:00:09\.000 --> 00:00:09\.400\n<00:00:09\.000>Yeah\.\n/);
+  // each word wrapped in <c> so ::cue(:past/:future) has an element to match (#437)
+  assert.match(vtt, /\n00:00:01\.200 --> 00:00:01\.850\n<00:00:01\.200><c>So<\/c> <00:00:01\.550><c>if<\/c>\n/);
+  assert.match(vtt, /\n00:00:09\.000 --> 00:00:09\.400\n<00:00:09\.000><c>Yeah\.<\/c>\n/);
 });
 
 test('generateWordVtt: no words yields just the header', () => {
@@ -82,9 +83,9 @@ test('generateWordVtt: cue text is escaped so <tags> and & survive parsing (#409
   ]);
   const vtt = generateWordVtt({ source: root });
   // words become entities, not markup…
-  assert.match(vtt, /<00:00:01\.000>&lt;inaudible&gt; <00:00:01\.400>AT&amp;T\n/);
-  // …while the timestamp tags themselves stay raw
-  assert.match(vtt, /<00:00:01\.000>/);
+  assert.match(vtt, /<00:00:01\.000><c>&lt;inaudible&gt;<\/c> <00:00:01\.400><c>AT&amp;T<\/c>\n/);
+  // …while the timestamp and <c> tags themselves stay raw
+  assert.match(vtt, /<00:00:01\.000><c>/);
   assert.doesNotMatch(vtt, /<inaudible>/);
 });
 

--- a/index.html
+++ b/index.html
@@ -1077,7 +1077,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/stream-stretch.js?v=0.8.6"></script>
   <script src="js/media-export.js?v=1.1.4"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
-  <script src="js/word-vtt.js?v=0.8.5"></script>
+  <script src="js/word-vtt.js?v=1.1.6"></script>
   <!-- end of caption editor additions -->
 
   <!-- responsive small-screen UI toggles (#349) -->

--- a/js/word-vtt.js
+++ b/js/word-vtt.js
@@ -1,7 +1,7 @@
 /**
  * word-vtt.js
  * (C) The Hyperaudio Project
- * @version 0.8.5 — last changed in release 0.8.5
+ * @version 1.1.6 — last changed in release 1.1.6
  * @license MIT
  *
  * Word-level ("karaoke") WebVTT export (#387, part 1).
@@ -134,8 +134,12 @@
     chunks.forEach((chunk) => {
       const start = chunk[0].start;
       const end = chunk[chunk.length - 1].end;
+      // Each word sits in <c>…</c>: a cue holding only leaf text nodes gives
+      // ::cue(:past)/::cue(:future) nothing to match (W3C bug 16875), so bare
+      // words can't be karaoke-highlighted with native cue styling (#437).
+      // The inter-word spaces stay as plain text nodes — they need no styling.
       const line = chunk
-        .map((w) => `<${formatTimestamp(w.start)}>${escapeVttText(w.text)}`)
+        .map((w) => `<${formatTimestamp(w.start)}><c>${escapeVttText(w.text)}</c>`)
         .join(' ');
       vtt += `\n${formatTimestamp(start)} --> ${formatTimestamp(end)}\n${line}\n`;
     });


### PR DESCRIPTION
Fixes #437.

## What

The word-level ("karaoke") VTT export emitted bare text after each inline timestamp. Structurally valid WebVTT — but a cue holding only leaf text nodes gives `::cue(:past)` / `::cue(:future)` nothing to match (W3C bug 16875), so native karaoke styling highlighted nothing. Each word is now wrapped in `<c>…</c>`:

```
<00:00:00.500><c>The</c> <00:00:01.000><c>archive</c> …
```

Inter-word spaces remain plain text nodes (they need no styling). The #409 escaping is unchanged and now sits inside the `<c>` wrapper; the burn-in renderer is untouched (it consumes `buildWordChunks`, which stays raw).

## Verified

- Live with `video::cue(:past){color:red}` on a generated track: words sweep to red word-by-word in **Chrome** and **Safari**. **Firefox** renders the captions but has never implemented the `:past`/`:future` cue pseudo-classes, so it shows them unhighlighted — same as before the change, no regression.
- Unit tests updated to the new cue text (including the escaping test).