### PR TITLE
Info moves to the transcript's ⓘ; kebab becomes pure file actions

### DIFF
--- a/__TEST__/e2e/library.spec.mjs
+++ b/__TEST__/e2e/library.spec.mjs
@@ -156,17 +156,23 @@ test('switching flushes the outgoing project\'s pending edit — nothing lost, n
   await expect(page.locator('#hypertranscript')).toContainText('PENDING-B');
 });
 
-test('Info lives in the kebab: switches to the project and shows ITS details (#456)', async ({ page }, testInfo) => {
+test('Info is the transcript ⓘ, current project only; the kebab is pure file actions (#480)', async ({ page }, testInfo) => {
   await openProject(page, testInfo, 'Project A');
   await openProject(page, testInfo, 'Project B'); // B is current now
 
+  // the kebab no longer carries Info — its Info silently switched projects
   await openKebab(page, 'Project A');
-  await page.locator('#recents-menu .recents-menu-info').click();
+  await expect(page.locator('#recents-menu .recents-menu-info')).toHaveCount(0);
+  await expect(page.locator('#recents-menu .recents-menu-sep')).toHaveCount(1);
+  await page.keyboard.press('Escape');
 
-  // Info made A current (dialog-free) and opened the modal with A's stored
-  // provenance and texts — not B's, and not a stale engine report
+  // full info on another project is the honest two-step: click the row…
+  await row(page, 'Project A').click();
   await expect(activeRow(page)).toHaveText('Project A');
-  expect(await page.evaluate(() => document.getElementById('info-modal').checked)).toBe(true);
+  // …then press ⓘ, which inspects the CURRENT project without any switch
+  // (the handler reads the library index before opening — poll, don't peek)
+  await page.locator('#transcript-info-btn').click();
+  await page.waitForFunction(() => document.getElementById('info-modal').checked);
   await expect(page.locator('#project-info-name')).toHaveText('Project A');
   await expect(page.locator('#project-info-media')).toContainText('tone.wav');
   await expect(page.locator('#project-info-media')).toContainText('Duration: 0:02'); // from the index's media meta

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -616,6 +616,49 @@ html:has(#hypertranscript[aria-busy="true"]) #transcript-copy-btn { display: non
     transition: top 0.25s ease; /* follows the video collapse like the holder */
   }
 }
+/* Project-info ⓘ (#480): the copy button's top-LEFT mirror — top-right acts
+   on the content, top-left learns about it. Unlike the right edge, the
+   holder's LEFT edge moves with the sidebar (400 <-> 0), so the button
+   tracks body.sidebar-collapsed with the same 0.5s ease. */
+#transcript-info-btn {
+  position: fixed;
+  top: 88px;              /* holder top (78px) + 10px inset */
+  left: 412px;            /* holder left (400px) + 12px inset */
+  z-index: 20;
+  color: oklch(var(--bc) / 0.55);
+  transition: left 0.5s ease;
+}
+body.sidebar-collapsed #transcript-info-btn { left: 12px; }
+#transcript-info-btn:hover { color: oklch(var(--bc)); }
+html:has(#hypertranscript[aria-busy="true"]) #transcript-info-btn { display: none; }
+/* left-anchor the tooltip bubble so it opens inward, not off the card edge */
+#transcript-info-btn.tooltip::before {
+  left: 0;
+  transform: none;
+}
+@media screen and (max-width: 948px) {
+  #transcript-info-btn {
+    top: calc(var(--nav-h) + var(--player-h) + 10px);
+    left: 12px;
+    transition: top 0.25s ease;
+  }
+}
+/* the compact navbar band (#480): the holder's top drops 78px -> 58px at
+   1120, and both corner buttons must ride the card's edge with it. Bounded
+   below at 949 so the <=948 var-based rules above keep the last word. */
+@media screen and (max-width: 1120px) and (min-width: 949px) {
+  #transcript-copy-btn { top: 68px; }
+  #transcript-info-btn { top: 68px; }
+}
+
+/* Corner buttons vs scrolling text (#480): the mask-fade experiment was
+   removed — masking .transcript-holder faded the card's own top edge and
+   rounded corners away with the text, since the holder paints the chrome AND
+   is the scrollport. A fade needs those roles split (card chrome on the
+   holder, an inner scroll wrapper carrying the mask) — deferred. The
+   autoscroll landing offset (editor-core SCROLL_TOP_GAP) keeps parked lines
+   clear of the corner buttons meanwhile. */
+
 /* screen-reader-only live region for the copy announcement */
 #transcript-copy-status {
   position: absolute;
@@ -1234,6 +1277,12 @@ label[data-a11y-wired]:focus-visible {
   border-radius: 0.5rem;
   background-color: oklch(var(--b1));
   box-shadow: 0 4px 16px oklch(var(--bc) / 0.15), 0 0 0 1px oklch(var(--bc) / 0.06);
+}
+/* fences Delete off from the reversible actions (#480) */
+#recents-menu .recents-menu-sep {
+  border: none;
+  border-top: 1px solid oklch(var(--bc) / 0.12);
+  margin: 4px 6px;
 }
 #recents-menu button {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.1.3">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.1.6">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1035,7 +1035,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-extension.js?v=0.7.2"></script>
   <script src="js/caption.js?v=0.8.6"></script>
   <script src="js/transcript-serializer.js?v=0.8.5"></script>
-  <script src="js/editor-core.js?v=1.1.1"></script>
+  <script src="js/editor-core.js?v=1.1.6"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1092,7 +1092,7 @@ If you are creating an open source application under a license compatible with t
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
   <script src="js/hyperaudio-save.js?v=1.1.5"></script>
-  <script src="js/hyperaudio-library.js?v=1.0.0"></script>
+  <script src="js/hyperaudio-library.js?v=1.1.6"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>
 

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -474,7 +474,10 @@
   function hyperaudio() {
     // Leave a small gap below the navbar when autoscrolling the active paragraph
     // (passed natively as scrollOffset to the 2.5.x options-object constructor).
-    const SCROLL_TOP_GAP = 24;
+    // Clears the corner buttons' band (#480) while staying under the
+    // inter-line gap: at 36 the previous line's bottom few pixels peeked into
+    // the viewport top as a sliced sliver when autoscroll parked a paragraph.
+    const SCROLL_TOP_GAP = 30;
 
     // hyperaudio() runs on every transcript (re)load — tear down the previous
     // instance so its player/document listeners don't accumulate (2.6.0 API).

--- a/js/hyperaudio-library.js
+++ b/js/hyperaudio-library.js
@@ -3,7 +3,7 @@
  * PROJECT LIBRARY PANEL (#456) — the side panel over the OPFS library
  * ============================================================================
  *
- * @version 1.0.0 — last changed in release 1.0.0
+ * @version 1.1.6 — last changed in release 1.1.6
  *
  * The management UX of the former Recents (#434/#435/#440), resurrected from
  * its pre-#451 history and rewired: rows list the library index that
@@ -141,6 +141,14 @@
       topics.textContent = 'Topics: ' + entry.topics.join(', ');
       popoutEl.appendChild(topics);
     }
+    // glance info gained a duration line when kebab-Info went away (#480):
+    // the popout is now the only at-a-distance view of a background project
+    if (entry.media && entry.media.durationSeconds > 0) {
+      const duration = document.createElement('p');
+      duration.className = 'recents-popout-topics';
+      duration.textContent = 'Duration: ' + formatDuration(entry.media.durationSeconds);
+      popoutEl.appendChild(duration);
+    }
     document.body.appendChild(popoutEl);
     const paneRect = pane.getBoundingClientRect();
     const rowRect = rowEl.getBoundingClientRect();
@@ -177,11 +185,14 @@
     const menu = document.createElement('div');
     menu.id = 'recents-menu';
     menu.setAttribute('role', 'menu');
+    // Pure file actions (#480): Info moved to the transcript card's ⓘ — the
+    // other items act on the project as an object, Info inspects the content.
+    // The separator fences the destructive action off from the rest.
     menu.innerHTML =
-      `<button type="button" role="menuitem" class="recents-menu-info">${INFO_SVG}Info</button>` +
       `<button type="button" role="menuitem" class="recents-menu-star">${STAR_SVG}${isStarred ? 'Unstar' : 'Star'}</button>` +
       `<button type="button" role="menuitem" class="recents-menu-rename">${RENAME_SVG}Rename</button>` +
       `<button type="button" role="menuitem" class="recents-menu-duplicate">${DUPLICATE_SVG}Duplicate</button>` +
+      '<hr class="recents-menu-sep" aria-hidden="true" />' +
       `<button type="button" role="menuitem" class="recents-menu-delete">${DELETE_SVG}Delete</button>`;
     document.body.appendChild(menu);
 
@@ -192,44 +203,6 @@
       ? anchor.top - size.height - 4
       : anchor.bottom + 4) + 'px';
 
-    // Info is project-bound: make the project current (a dialog-free switch,
-    // a no-op if it already is), then open the info modal — apply() has
-    // populated it from the project's stored provenance/summary/topics.
-    menu.querySelector('.recents-menu-info').addEventListener('click', async () => {
-      closeMenu();
-      await lib().open(entry.id);
-      // the modal leads with the project's name — after the switch the
-      // session title is authoritative (rename-safe), the entry the fallback
-      const nameEl = document.getElementById('project-info-name');
-      if (nameEl !== null) {
-        nameEl.textContent = (window.HyperaudioSave.getProjectTitle && window.HyperaudioSave.getProjectTitle())
-          || entry.name || 'project';
-      }
-      const mediaEl = document.getElementById('project-info-media');
-      if (mediaEl !== null) {
-        const media = entry.media || {};
-        const rows = [];
-        if (media.kind === 'original' && media.filename) rows.push(['File', media.filename]);
-        if (media.kind === 'link') rows.push(['Source', 'remote URL']);
-        if (media.durationSeconds > 0) rows.push(['Duration', formatDuration(media.durationSeconds)]);
-        mediaEl.textContent = '';
-        if (rows.length === 0) {
-          const p = document.createElement('p');
-          p.textContent = 'No media — text only.';
-          mediaEl.appendChild(p);
-        }
-        rows.forEach(([label, value]) => {
-          const p = document.createElement('p');
-          const strong = document.createElement('strong');
-          strong.textContent = label + ':';
-          p.appendChild(strong);
-          p.appendChild(document.createTextNode(' ' + value));
-          mediaEl.appendChild(p);
-        });
-      }
-      const toggle = document.getElementById('info-modal');
-      if (toggle !== null) toggle.checked = true;
-    });
     menu.querySelector('.recents-menu-star').addEventListener('click', () => {
       closeMenu();
       lib().setStarred(entry.id, !isStarred); // the index write re-renders us
@@ -446,9 +419,80 @@
     render();
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', boot);
-  } else {
+  /* ---- Transcript-card ⓘ (#480): Info for the CURRENT project, anchored
+     top-left of the transcript card — the mirror of the copy button at
+     top-right (top-right = act on the content, top-left = learn about it).
+     It never switches projects: full info on a background project is the
+     honest two-step — click the row, press ⓘ. Same visibility rules as the
+     copy button: hidden in caption mode (view-switch wiring below) and while
+     the transcript is aria-busy (CSS). ---- */
+
+  function bootInfoButton() {
+    const btn = document.createElement('button');
+    btn.id = 'transcript-info-btn';
+    btn.type = 'button';
+    btn.className = 'btn btn-square btn-ghost btn-sm tooltip';
+    btn.setAttribute('data-tip', 'Project info');
+    btn.setAttribute('aria-label', 'Project info');
+    btn.innerHTML = INFO_SVG;
+    btn.addEventListener('click', async () => {
+      const nameEl = document.getElementById('project-info-name');
+      if (nameEl !== null) {
+        nameEl.textContent = (window.HyperaudioSave && window.HyperaudioSave.getProjectTitle
+          && window.HyperaudioSave.getProjectTitle()) || 'project';
+      }
+      const mediaEl = document.getElementById('project-info-media');
+      if (mediaEl !== null) {
+        const library = lib();
+        const entry = library
+          ? (await library.list()).find((e) => e.id === library.currentId())
+          : undefined;
+        const media = (entry && entry.media) || {};
+        const rows = [];
+        if (media.kind === 'original' && media.filename) rows.push(['File', media.filename]);
+        if (media.kind === 'link') rows.push(['Source', 'remote URL']);
+        if (media.durationSeconds > 0) rows.push(['Duration', formatDuration(media.durationSeconds)]);
+        mediaEl.textContent = '';
+        if (rows.length === 0) {
+          const p = document.createElement('p');
+          p.textContent = 'No media — text only.';
+          mediaEl.appendChild(p);
+        }
+        rows.forEach(([label, value]) => {
+          const p = document.createElement('p');
+          const strong = document.createElement('strong');
+          strong.textContent = label + ':';
+          p.appendChild(strong);
+          p.appendChild(document.createTextNode(' ' + value));
+          mediaEl.appendChild(p);
+        });
+      }
+      const toggle = document.getElementById('info-modal');
+      if (toggle !== null) toggle.checked = true;
+    });
+    document.body.appendChild(btn);
+
+    // the caption editor owns the card in caption mode — hide/show with the
+    // view switch, covering the engines' programmatic switches too (same
+    // wiring as the copy button in transcript-doc-export.js)
+    const captionBtn = document.getElementById('caption-editor-btn');
+    const transcriptBtn = document.getElementById('transcript-editor-btn');
+    if (captionBtn !== null) {
+      captionBtn.addEventListener('click', () => { btn.style.display = 'none'; });
+    }
+    if (transcriptBtn !== null) {
+      transcriptBtn.addEventListener('click', () => { btn.style.display = ''; });
+    }
+  }
+
+  function bootAll() {
     boot();
+    bootInfoButton();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bootAll);
+  } else {
+    bootAll();
   }
 })();


### PR DESCRIPTION
Fixes #480 (the fade question split off to #482).

## Info is the transcript card's ⓘ (top-left)

The kebab's other items act on the project as an object — Info inspects the content. It now lives as an ⓘ button at the transcript's top-left, the copy button's mirror (top-right = act on the content, top-left = learn about it), so its referent is unmistakable. It never switches projects: full info on a background project is the honest two-step — click the row, press ⓘ. Same visibility rules as the copy button (hidden in caption mode and while transcribing), and it tracks the card's edges everywhere: the sidebar collapse (left 400↔0, same ease) and every breakpoint — including a fix for the 949–1120px band where BOTH corner buttons sat 30px below the card edge.

- Kebab: Star · Rename · Duplicate · ─ · Delete, with a separator fencing the destructive action.
- Hover popout gains a `Duration:` line — glance info for background rows, replacing what kebab-Info's silent project switch used to provide.

## Scroll landing

Autoscroll parks the active paragraph 30px down (`SCROLL_TOP_GAP` 24 → 30): clear of the corner buttons, yet under the inter-line gap so no sliced sliver of the previous line peeks in at the viewport top.

## The fade

The issue's mask-fade was implemented and backed out after visual review: masking `.transcript-holder` faded the card's own top border and rounded corners away with the text, since the holder paints the chrome AND is the scrollport. Whether a fade is wanted at all, plus the split-the-roles design if so, is #482.

## Testing

Unit 74/74, e2e 86/86 — the kebab-Info spec rewritten to the new model (no Info in the kebab, separator present, row-click-then-ⓘ shows that project's details, never a switch). Visual pass done across widths, sidebar collapse, and both view modes.