### PR TITLE
Canonical transcript.html on save, lossless through wrappers (#486)

### DIFF
--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -621,3 +621,40 @@ test('the tab-guard banner is dismissible (per appearance, no persistence)', asy
   await expect(page2.locator('#tab-guard-banner')).toHaveCount(0);
   await page2.close();
 });
+
+// #486: the writer used to ship the live DOM's editing noise into
+// transcript.html. Searching wraps matches in <mark class="search-mark"> inside
+// the word spans, and a save taken while that highlight was up persisted the
+// marks — § 4 defines the entry as one <span> per word. The saved HTML must
+// contain word spans and nothing else, whatever the DOM currently holds.
+test('the saved transcript.html carries no markup but word spans (#486)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+
+  // dirty the document, then raise a search highlight over it
+  await page.evaluate(() => {
+    const span = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    span.textContent = 'HIGHLIGHTED ';
+    span.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  // per-character typing: the vendored search runs on keyup, so fill() alone
+  // sets the value without ever triggering it
+  await page.locator('#search-box').pressSequentially('HIGH');
+  await expect(page.locator('#hypertranscript mark.search-mark')).not.toHaveCount(0);
+
+  await page.keyboard.press('Control+s');
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+
+  const html = (await readCurrentProject(page)).saved.html;
+  expect(html).toContain('HIGHLIGHTED');   // the word survives, as text
+  expect(html).not.toContain('<mark');     // the highlight does not
+
+  // nothing but <article>/<section>/<p>/<span> in the persisted markup
+  const tags = [...html.matchAll(/<([a-zA-Z][^\s/>]*)/g)].map((m) => m[1].toLowerCase());
+  expect([...new Set(tags)].sort()).toEqual(['article', 'p', 'section', 'span']);
+
+  // and the JSON — the source of truth — is unaffected by the highlight
+  const words = JSON.parse((await readCurrentProject(page)).saved.json).transcript.words;
+  expect(words.some((w) => w.text === 'HIGHLIGHTED')).toBe(true);
+});

--- a/__TEST__/e2e/serialization.spec.mjs
+++ b/__TEST__/e2e/serialization.spec.mjs
@@ -76,3 +76,42 @@ test('strikethrough survives serialization; word text is escaped', async ({ page
   expect(html).toMatch(/&lt;inaudible&gt; /);
   expect(html).not.toMatch(/<inaudible>/);
 });
+
+// Serialization must never cost a word its timing. The save path derives the
+// project JSON from this output (hyperaudio-save.js gather()), so a span whose
+// data-m is dropped here is not merely un-timed — it disappears from the JSON,
+// and reopen rebuilds the transcript without it. Two shapes contenteditable
+// produces that used to be flattened to plain text: a wrapper AROUND word spans
+// (⌘B over a selection, or paste-injected markup, #487), and words parked
+// outside any <p>.
+test('word timings survive wrappers and stray placement (#486 review)', async ({ page }) => {
+  const cases = await page.evaluate(() => {
+    const build = (inner) => {
+      const d = document.createElement('div');
+      d.innerHTML = '<article><section>' + inner + '</section></article>';
+      return d;
+    };
+    const roundTrip = (root) => {
+      const before = htmlToJSON(root.innerHTML).words.map((w) => `${w.text}@${w.start}`);
+      const after = htmlToJSON(window.serializeTranscriptHtml(root)).words.map((w) => `${w.text}@${w.start}`);
+      return { before, after };
+    };
+    return {
+      // <b> wrapping two of the four words
+      wrapper: roundTrip(build('<p><span data-m="0" data-d="100">one </span>'
+        + '<b><span data-m="100" data-d="100">two </span><span data-m="200" data-d="100">three </span></b>'
+        + '<span data-m="300" data-d="100">four </span></p>')),
+      // a word left as a direct child of <section>, alongside a real <p>
+      orphan: roundTrip(build('<p><span data-m="0" data-d="100">alpha </span></p>'
+        + '<span data-m="100" data-d="100">orphan </span>')),
+      // no paragraph structure at all (the pre-existing fallback)
+      noParagraphs: roundTrip(build('<span data-m="0" data-d="100">solo </span>'
+        + '<span data-m="100" data-d="100">words </span>')),
+    };
+  });
+
+  expect(cases.wrapper.after).toEqual(cases.wrapper.before);
+  expect(cases.wrapper.after).toHaveLength(4);
+  expect(cases.orphan.after).toEqual(cases.orphan.before);
+  expect(cases.noParagraphs.after).toEqual(cases.noParagraphs.before);
+});

--- a/index.html
+++ b/index.html
@@ -1034,7 +1034,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite.js?v=2.6.4"></script>
   <script src="js/hyperaudio-lite-extension.js?v=0.7.2"></script>
   <script src="js/caption.js?v=0.8.6"></script>
-  <script src="js/transcript-serializer.js?v=0.8.5"></script>
+  <script src="js/transcript-serializer.js?v=1.1.8"></script>
   <script src="js/editor-core.js?v=1.1.7"></script>
 
 
@@ -1091,7 +1091,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=0.7.4"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.1.5"></script>
+  <script src="js/hyperaudio-save.js?v=1.1.8"></script>
   <script src="js/hyperaudio-library.js?v=1.1.6"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -1031,7 +1031,7 @@ If you are creating an open source application under a license compatible with t
 
 
   <script src="js/hyperaudio-push-notification.js"></script>
-  <script src="js/hyperaudio-lite.js?v=2.6.2"></script>
+  <script src="js/hyperaudio-lite.js?v=2.6.4"></script>
   <script src="js/hyperaudio-lite-extension.js?v=0.7.2"></script>
   <script src="js/caption.js?v=0.8.6"></script>
   <script src="js/transcript-serializer.js?v=0.8.5"></script>

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.6.2 */
+/*! Version 2.6.4 */
 
 'use strict';
 
@@ -478,7 +478,7 @@ class HyperaudioLite {
         const popover = document.getElementById('popover');
 
         if (selection.toString().length > 0) {
-          this.selectionText = selection.toString().replaceAll("'", "`");
+          this.selectionText = selection.toString();
           const range = selection.getRangeAt(0);
           const rect = range.getBoundingClientRect();
 
@@ -772,6 +772,10 @@ class HyperaudioLite {
       const indices = this.updateTranscriptVisualState(this.currentTime, true);
       if (indices.currentWordIndex > 0 && this.autoscroll) {
         this.scrollToParagraph(indices.currentParentElementIndex, indices.currentWordIndex);
+      }
+      if (!this.myPlayer.paused) {
+        this.clearTimer();
+        this.checkStatus();
       }
     })();
   }

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.1.5 — last changed in release 1.1.5
+ * @version 1.1.8 — last changed in release 1.1.8
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind
@@ -650,16 +650,44 @@
     return new Date().toISOString();
   }
 
+  // Canonical serialization of a transcript root for the writer (#486). Raw
+  // innerHTML shipped whatever the live DOM had accumulated straight into
+  // transcript.html — search's <mark class="search-mark">, elements a paste
+  // injected (#487), WebKit inline styles — but § 4 of the format defines that
+  // entry as one <span> per word. serializeTranscriptHtml rebuilds each span
+  // from textContent, keeping the two functional bits of state (speaker class,
+  // strikethrough), so foreign markup is flattened to its text rather than
+  // persisted.
+  //
+  // The word set is preserved, which matters because gather() derives the
+  // project JSON from this same string: the serializer descends into wrappers
+  // that enclose timed spans and keeps spans belonging to no <p>, so no word
+  // loses its data-m/data-d (and with it its place in the JSON) on the way out.
+  //
+  // No class strip on the canonical path: the serializer emits class="speaker"
+  // and nothing else, while running the strip's regex over the whole string
+  // could delete a literal class="…" appearing inside a word's own text. The
+  // innerHTML fallback — loader markup mid transcription, no timed spans yet —
+  // still sanitizes exactly as it did before.
+  function canonicalTranscriptHtml(root) {
+    const hasWords = typeof root.querySelector === 'function'
+      && root.querySelector('span[data-m]') !== null;
+    if (hasWords && typeof serializeTranscriptHtml === 'function') {
+      return serializeTranscriptHtml(root);
+    }
+    return sanitizeTranscriptClasses(root.innerHTML);
+  }
+
   // The transcript's markup for the writer. Reads the live element directly
   // (NOT getTranscriptData(), whose blanket class strip destroys the speaker
   // class); in caption mode the transcript element only exists inside
   // editor-core's transcriptCache clone — read it from there.
   function getEditorHtml() {
     const el = document.querySelector('#hypertranscript');
-    if (el !== null) return sanitizeTranscriptClasses(el.innerHTML);
+    if (el !== null) return canonicalTranscriptHtml(el);
     if (typeof transcriptCache !== 'undefined' && transcriptCache !== null) {
       const cached = transcriptCache.querySelector('#hypertranscript');
-      if (cached !== null) return sanitizeTranscriptClasses(cached.innerHTML);
+      if (cached !== null) return canonicalTranscriptHtml(cached);
     }
     return typeof getTranscriptData === 'function' ? getTranscriptData() : '';
   }

--- a/js/transcript-serializer.js
+++ b/js/transcript-serializer.js
@@ -1,7 +1,7 @@
 /**
  * transcript-serializer.js
  * (C) The Hyperaudio Project
- * @version 0.8.5 — last changed in release 0.8.5
+ * @version 1.1.8 — last changed in release 1.1.8
  * @license MIT
  *
  * Canonical transcript serialization for the HTML and interactive-transcript
@@ -49,17 +49,30 @@
   function serializeParagraph(p, indent) {
     const inner = indent + '  ';
     const lines = [indent + '<p>'];
-    p.childNodes.forEach((node) => {
-      if (node.nodeType === Node.ELEMENT_NODE && node.tagName === 'SPAN' && node.hasAttribute('data-m')) {
-        lines.push(inner + spanLine(node));
-      } else if (node.nodeType === Node.TEXT_NODE && node.nodeValue.trim() !== '') {
-        // stray text between spans — keep it (escaped) rather than lose words
-        lines.push(inner + escapeText(node.nodeValue.trim()) + ' ');
-      } else if (node.nodeType === Node.ELEMENT_NODE && node.textContent.trim() !== '') {
-        // unexpected wrapper (e.g. residual mark/span): flatten to its text
-        lines.push(inner + escapeText(node.textContent.trim()) + ' ');
-      }
-    });
+    const emit = (nodes) => {
+      nodes.forEach((node) => {
+        if (node.nodeType === Node.ELEMENT_NODE && node.tagName === 'SPAN' && node.hasAttribute('data-m')) {
+          lines.push(inner + spanLine(node));
+        } else if (node.nodeType === Node.TEXT_NODE && node.nodeValue.trim() !== '') {
+          // stray text between spans — keep it (escaped) rather than lose words
+          lines.push(inner + escapeText(node.nodeValue.trim()) + ' ');
+        } else if (node.nodeType === Node.ELEMENT_NODE) {
+          // An unexpected wrapper. When it ENCLOSES timed spans, descend into it:
+          // contenteditable produces these (⌘B over a selection wraps the spans
+          // in <b>; paste-injected markup does the same, cf. #487), and
+          // flattening them to text would strip data-m/data-d from real words —
+          // and, since the writer derives the project JSON from this output,
+          // delete those words outright. Only a wrapper holding no timed span of
+          // its own is flattened to its text (a residual search <mark>, #486).
+          if (node.querySelector('span[data-m]') !== null) {
+            emit([...node.childNodes]);
+          } else if (node.textContent.trim() !== '') {
+            lines.push(inner + escapeText(node.textContent.trim()) + ' ');
+          }
+        }
+      });
+    };
+    emit([...p.childNodes]);
     lines.push(indent + '</p>');
     return lines;
   }
@@ -75,17 +88,19 @@
     if (root.querySelector('span[data-m]') === null) {
       return root.innerHTML || '';
     }
-    const paragraphs = root.querySelectorAll('p');
     const lines = ['<article>', '  <section>'];
-    if (paragraphs.length > 0) {
-      paragraphs.forEach((p) => {
-        if (p.querySelector('span[data-m]') === null) return; // skip empty/UI paragraphs
-        lines.push(...serializeParagraph(p, '    '));
-      });
-    } else {
-      // no <p> structure — treat every timed span as one paragraph's content
-      const pseudo = { childNodes: root.querySelectorAll('span[data-m]') };
-      lines.push(...serializeParagraph(pseudo, '    '));
+    root.querySelectorAll('p').forEach((p) => {
+      if (p.querySelector('span[data-m]') === null) return; // skip empty/UI paragraphs
+      lines.push(...serializeParagraph(p, '    '));
+    });
+    // Timed spans belonging to no <p> at all: the whole transcript when it has
+    // no paragraph structure, and otherwise words that editing parked as a
+    // direct child of <section> (or inside a non-<p> wrapper there). Iterating
+    // only <p> elements dropped those words from the output entirely.
+    const orphans = [...root.querySelectorAll('span[data-m]')]
+      .filter((span) => span.closest('p') === null);
+    if (orphans.length > 0) {
+      lines.push(...serializeParagraph({ childNodes: orphans }, '    '));
     }
     lines.push('  </section>', '</article>');
     return lines.join('\n');


### PR DESCRIPTION
Fixes #486

The writer read the transcript's raw innerHTML, so whatever the live DOM had accumulated went into the saved `transcript.html`: search's `<mark class="search-mark">`, elements a paste injected (#487), WebKit inline styles. § 4 of the format defines that entry as one `<span>` per word.

Route it through `serializeTranscriptHtml` instead, which rebuilds each span from `textContent` and keeps the two functional bits of state (speaker class, strikethrough). The class strip now applies only to the innerHTML fallback used while a transcription is still loading: its regex would otherwise delete a literal `class="…"` appearing inside a word's own text.

The serializer itself lost word timings in two shapes contenteditable produces, which mattered because `gather()` derives the project JSON from this output — a flattened span is not merely un-timed, it disappears from the JSON and reopen rebuilds the transcript without it:

| Case | Raw innerHTML | Serialized (before this PR) |
|---|---|---|
| `<b>` wrapping two of four words (⌘B over a selection, paste-injected markup) | 4 words | 2 |
| Timed spans belonging to no `<p>` | 2 words | 1 |

`serializeParagraph` now descends into wrappers that enclose timed spans and flattens only those holding none (still what removes a residual `<mark>`), and `serializeTranscriptHtml` picks up spans outside every `<p>`, which subsumes its old no-paragraph fallback. Both also serve the interactive-transcript and HTML exports, where the same flattening was latent and predates this change.

## Verification

Full suite green — 88 passed. Two tests added:

- the saved `transcript.html` carries no markup but word spans, taken with a search highlight raised at save time
- serialization keeps every word's timing through wrappers and stray placement

Also checked by hand in Chrome across six shapes (wrapper, orphan span, no-paragraph, mark-inside-span, nested `div`>`b`>`span`, speaker + struck): word sets identical to raw `innerHTML`, marks still flattened, speaker class and strikethrough preserved, and the saved JSON unchanged.

## Note for review

#489 proposes projecting `transcript.html` from the JSON with `jsonToHTML` instead of serializing the DOM a second time, which would remove `serializeTranscriptHtml` from the save path entirely. This PR is still worth landing first — #486 is a bug in shipped files — and the serializer fix keeps its value either way, since the export paths share it.
