### PR TITLE
Put both halves of the caption fix behind one door (#493)

### DIFF
--- a/__TEST__/e2e/caption-track-reset.spec.mjs
+++ b/__TEST__/e2e/caption-track-reset.spec.mjs
@@ -67,3 +67,66 @@ test('regenerating captions resets the <track>, so a prior cue cannot linger (#3
   // that the toggle path doesn't leave captions disabled.
   expect(result.finalMode).toBe('showing');
 });
+
+// The reason #356/#287 kept returning: each fix was attached to ONE path, so the
+// next caption writer reintroduced it. The paint flush (hidden→showing) now lives
+// in a single place — flushCaptionPaint in hyperaudio-save.js — and these tests
+// assert that every path which swaps captions for a NEW document performs it.
+//
+// The stale line is native ::cue paint, invisible to the DOM, which is why the
+// earlier tests passed while the bug was live on other routes. Instead of looking
+// for pixels, record every TextTrack.mode assignment: the flush has a distinctive
+// hidden→showing signature, so a path that skips it is detectable.
+const recordModeAssignments = (page) => page.evaluate(() => {
+  const video = document.getElementById('hyperplayer');
+  const proto = Object.getPrototypeOf(video.textTracks[0]);
+  const desc = Object.getOwnPropertyDescriptor(proto, 'mode');
+  window.__modes = [];
+  Object.defineProperty(proto, 'mode', {
+    configurable: true,
+    get() { return desc.get.call(this); },
+    set(value) { window.__modes.push(value); desc.set.call(this, value); },
+  });
+});
+
+const flushed = (page) => page.evaluate(() => {
+  // a hidden immediately followed by a showing = the overlay rebuild
+  const m = window.__modes || [];
+  return m.some((mode, i) => mode === 'hidden' && m[i + 1] === 'showing');
+});
+
+test('the SRT import flushes stale caption paint (#356/#287)', async ({ page }) => {
+  await page.waitForFunction(() => {
+    const tt = document.getElementById('hyperplayer').textTracks[0];
+    return tt && tt.cues && tt.cues.length > 0;   // the intro's cues are loaded
+  }, null, { timeout: 15000 });
+  await recordModeAssignments(page);
+
+  await page.evaluate(() => {
+    document.getElementById('hyperplayer').src = 'data:video/mp4;base64,';
+    const srt = '1\n00:00:00,320 --> 00:00:02,000\nIMPORTED caption line\n';
+    const dt = new DataTransfer();
+    dt.items.add(new File([srt], 'probe.srt', { type: 'application/x-subrip' }));
+    const input = document.getElementById('srt');
+    input.files = dt.files;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    document.getElementById('file-import-srt').click();
+  });
+  await expect(page.locator('#hypertranscript')).toContainText('IMPORTED');
+
+  expect(await flushed(page)).toBe(true);
+  // and the track was rebuilt, not reused
+  expect(await page.locator('#hyperplayer track').count()).toBe(1);
+  expect(await page.evaluate(() => document.getElementById('hyperplayer').textTracks.length)).toBe(1);
+});
+
+test('the regenerate path still flushes, via the shared helper (#356/#287)', async ({ page }) => {
+  await recordModeAssignments(page);
+  await page.evaluate(() => {
+    document.getElementById('hyperplayer').src = 'data:video/mp4;base64,';
+    document.getElementById('hypertranscript').innerHTML =
+      '<article><section><p><span data-m="0" data-d="500">Charlie </span></p></section></article>';
+    document.dispatchEvent(new CustomEvent('hyperaudioGenerateCaptionsFromTranscript'));
+  });
+  expect(await flushed(page)).toBe(true);
+});

--- a/__TEST__/unit/caption-door.test.mjs
+++ b/__TEST__/unit/caption-door.test.mjs
@@ -1,0 +1,58 @@
+// #356/#287 ("two sets of captions") kept coming back for a structural reason:
+// each fix was attached to ONE path, so the next path to swap captions
+// reintroduced it. The bug has two halves — stale cue DATA (a reused <track>) and
+// stale cue PIXELS (a paused video never re-composites its native caption
+// overlay) — and a path that does only the first still shows the previous
+// document's caption line.
+//
+// Both halves now live behind one door: applyCaptionTrack / flushCaptionPaint in
+// js/hyperaudio-save.js. This test is the guard rail — it fails when a new
+// caption writer sets the track's src itself instead of going through the door,
+// which is the mistake that caused each recurrence. The e2e spec
+// (caption-track-reset.spec.mjs) checks that the paths actually flush; this one
+// checks that no path can quietly opt out.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const JS_DIR = new URL('../../js/', import.meta.url);
+
+// Where the door itself lives — the one legitimate `track.src =`.
+const DOOR = 'hyperaudio-save.js';
+
+// The live-edit sanitise path assigns .src in place on every debounced keystroke
+// and must NOT swap the element or churn the caption paint (see the note in
+// editor-core.js's regenerate handler). Deliberately exempt.
+const LIVE_EDIT = new Set(['editor-core.js', 'editor-main.js']);
+
+// Vendored from hyperaudio-lite — not ours to edit. caption.js's applyCaptions is
+// reached only through generateCaptionsFromTranscript, whose caller flushes.
+const VENDORED = new Set([
+  'caption.js',
+  'hyperaudio-lite.js',
+  'hyperaudio-lite-extension.js',
+]);
+
+test('only the caption door assigns the caption track src (#356/#287)', () => {
+  const offenders = [];
+  const files = fs.readdirSync(JS_DIR).filter((f) => f.endsWith('.js'));
+  assert.ok(files.length > 5, 'expected to find the js/ sources');
+
+  for (const name of files) {
+    if (name === DOOR || LIVE_EDIT.has(name) || VENDORED.has(name)) continue;
+    const text = fs.readFileSync(new URL(name, JS_DIR), 'utf8');
+    text.split('\n').forEach((line, i) => {
+      const code = line.replace(/\/\/.*$/, '');           // ignore comments
+      if (/-vtt['"]\)\s*\.src\s*=/.test(code) || /\btrack\.src\s*=/.test(code)) {
+        offenders.push(`${name}:${i + 1}: ${line.trim()}`);
+      }
+    });
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    'these must call applyCaptionTrack() so the paint flush cannot be skipped:\n'
+      + offenders.join('\n')
+  );
+});

--- a/index.html
+++ b/index.html
@@ -1035,7 +1035,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-extension.js?v=0.7.2"></script>
   <script src="js/caption.js?v=0.8.6"></script>
   <script src="js/transcript-serializer.js?v=1.1.8"></script>
-  <script src="js/editor-core.js?v=1.1.7"></script>
+  <script src="js/editor-core.js?v=1.1.8"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1045,7 +1045,7 @@ If you are creating an open source application under a license compatible with t
 
   <script src="js/editor-file-menu.js?v=1.0.0"></script>
 
-  <script src="./js/hyperaudio-lite-editor-export.js?v=1.1.1" type="module"> </script>
+  <script src="./js/hyperaudio-lite-editor-export.js?v=1.1.8" type="module"> </script>
   <!-- end of localstorage additions -->
 
   <!-- caption editor additions -->

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -854,16 +854,19 @@
     // Swapping the <track> element drops the old cue's DATA, but a PAUSED video
     // won't re-composite its native caption overlay on its own — so the previous
     // cue's PIXELS stay stranded on screen under the new captions (the remaining
-    // half of #356/#287; the load path avoids it because loading new media forces
-    // a full video relayout, which the transcribe path never triggers). Toggling
-    // the track's display mode forces the overlay to rebuild, flushing the stale
-    // ::cue paint. Only meaningful while the intended mode is 'showing' — mp3/m4a
-    // are deliberately 'hidden' by generateCaptionsFromTranscript, nothing to flush.
-    const player = document.getElementById('hyperplayer');
-    const captionTrack = player && player.textTracks[0];
-    if (captionTrack && captionTrack.mode === 'showing') {
-      captionTrack.mode = 'hidden';
-      captionTrack.mode = 'showing';
+    // half of #356/#287). flushCaptionPaint (hyperaudio-save.js) owns that
+    // toggle now, so every caption path shares one implementation rather than
+    // each route growing its own — the reason this bug kept returning. Inline
+    // fallback kept for when that module is absent.
+    if (typeof flushCaptionPaint === 'function') {
+      flushCaptionPaint();
+    } else {
+      const player = document.getElementById('hyperplayer');
+      const captionTrack = player && player.textTracks[0];
+      if (captionTrack && captionTrack.mode === 'showing') {
+        captionTrack.mode = 'hidden';
+        captionTrack.mode = 'showing';
+      }
     }
   }
 

--- a/js/hyperaudio-lite-editor-export.js
+++ b/js/hyperaudio-lite-editor-export.js
@@ -228,7 +228,9 @@ class ImportSrt extends HTMLElement {
       const blob = new Blob([vttData], { type: "text/vtt" });
       // Generate a URL for the Blob
       const vttUrl = URL.createObjectURL(blob);
-      document.querySelector('#hyperplayer-vtt').src = vttUrl;
+      // Through the caption door (#356/#287): assigning .src on the reused track
+      // leaves the previous document's cue pixels painted on the paused video.
+      applyCaptionTrack(vttUrl, { mode: 'showing' });
 
       // Preserve original format
       updateCaptionsFromTranscript = false;
@@ -352,7 +354,8 @@ class ImportVtt extends HTMLElement {
       const blob = new Blob([vttData], { type: "text/vtt" });
       // Generate a URL for the Blob
       const vttUrl = URL.createObjectURL(blob);
-      document.querySelector('#hyperplayer-vtt').src = vttUrl;
+      // Through the caption door (#356/#287) — see the SRT import above.
+      applyCaptionTrack(vttUrl, { mode: 'showing' });
 
       // Preserve original format
       updateCaptionsFromTranscript = false;

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -971,17 +971,26 @@
         player.src = loaded.project.media.url;
       }
 
-      // Captions: fresh track (#356 stale-cue teardown), then the saved VTT.
-      const track = resetCaptionTrack();
+      // Captions through the one door: fresh track AND a paint flush (#356/#287).
+      // Opening a project — Recents included — reuses the paused <video>, so the
+      // previous document's cue pixels linger without the flush. This path had
+      // the teardown but not the flush, which is how the bug came back on the
+      // Recents route after the transcribe route was fixed.
+      const captionsSrc = loaded.captionsVtt
+        ? 'data:text/vtt,' + encodeURIComponent(loaded.captionsVtt)
+        : '';
+      const track = applyCaptionTrack(captionsSrc, {
+        kind: loaded.captionsVtt ? 'captions' : 'subtitles',
+        // no VTT: leave the fresh track disabled exactly as before and let the
+        // regenerate event below build the captions (it flushes too)
+        mode: loaded.captionsVtt ? 'showing' : 'disabled',
+      });
       const options = loaded.recovered ? null : loaded.project.options;
       if (typeof updateCaptionsFromTranscript !== 'undefined') {
         updateCaptionsFromTranscript = options && options.captions
           ? options.captions.updateFromTranscript !== false : true;
       }
       if (loaded.captionsVtt && track !== null) {
-        track.src = 'data:text/vtt,' + encodeURIComponent(loaded.captionsVtt);
-        track.kind = 'captions';
-        if (player.textTracks[0] !== undefined) player.textTracks[0].mode = 'showing';
         const vttLink = document.querySelector('#download-vtt');
         if (vttLink !== null) vttLink.setAttribute('href', 'data:text/vtt,' + encodeURIComponent(loaded.captionsVtt));
         if (typeof populateCaptionEditorFromVtt === 'function') {
@@ -1446,9 +1455,61 @@
     video.appendChild(track);
     return track;
   }
-  // the caption-regenerate path in editor-core reaches this by global name
-  // (typeof-guarded), as it did when the legacy module defined it
+  // Part 2 of #356/#287, and the half that keeps getting lost. Replacing the
+  // <track> drops the old cue DATA, but a PAUSED video does not re-composite its
+  // native caption overlay, so the previous cue's PIXELS stay stranded on screen
+  // — under the new captions, which is the "two sets of captions" report.
+  //
+  // Resetting the track and setting mode = 'showing' once is NOT enough: that is
+  // exactly what the transcribe path already did when #356/#287 was still live,
+  // and fcc323c had to add this explicit toggle on top of it. Only a deliberate
+  // hidden -> showing transition, after the new src is in place, rebuilds the
+  // overlay. Nothing to flush when the intended mode is 'hidden' (mp3/m4a).
+  function flushCaptionPaint(videoDomId = 'hyperplayer') {
+    const video = document.getElementById(videoDomId);
+    const textTrack = video !== null && video.textTracks !== undefined
+      ? video.textTracks[0] : undefined;
+    if (textTrack === undefined) return;
+    if (textTrack.mode === 'showing') {
+      textTrack.mode = 'hidden';
+      textTrack.mode = 'showing';
+    }
+  }
+
+  // THE one door for a caption swap that comes with a NEW document (#356/#287):
+  // project open, Recents switch, SRT/VTT import, transcribe/regenerate. It does
+  // both halves — fresh <track> element, then the paint flush — so no caller has
+  // to remember either, which is how this bug kept coming back one path at a
+  // time. Every new caption writer should call this rather than assigning
+  // #hyperplayer-vtt.src directly.
+  //
+  // NOT for the live-edit sanitise path: that re-runs on every keystroke and must
+  // neither swap the element nor churn the caption paint.
+  function applyCaptionTrack(vttSrc, opts) {
+    const settings = opts || {};
+    const track = resetCaptionTrack();
+    if (track === null) return null;
+    if (typeof vttSrc === 'string' && vttSrc !== '') track.src = vttSrc;
+    if (settings.kind !== undefined) track.kind = settings.kind;
+    if (settings.label !== undefined) track.label = settings.label;
+    if (settings.srcLang !== undefined) track.srcLang = settings.srcLang;
+    // A fresh <track> element starts 'disabled', so the intended mode has to be
+    // set explicitly or the captions simply never appear.
+    const video = document.getElementById('hyperplayer');
+    const textTrack = video !== null && video.textTracks !== undefined
+      ? video.textTracks[0] : undefined;
+    if (textTrack !== undefined) {
+      textTrack.mode = settings.mode !== undefined ? settings.mode : 'showing';
+    }
+    flushCaptionPaint();
+    return track;
+  }
+
+  // the caption-regenerate path in editor-core reaches these by global name
+  // (typeof-guarded), as it did when the legacy module defined resetCaptionTrack
   window.resetCaptionTrack = resetCaptionTrack;
+  window.flushCaptionPaint = flushCaptionPaint;
+  window.applyCaptionTrack = applyCaptionTrack;
 
   function triggerDownload(blob, name) {
     const url = URL.createObjectURL(blob);


### PR DESCRIPTION
Fixes #493

Loading a project from Recents left the previous document's caption line painted under the new captions. Confirmed fixed by hand-check on the Recents route.

**Not a regression of #424** — that fix is intact and the transcribe route is still correct, which is why transcribing looked fine. This is a third path.

## Cause

Two halves: stale cue **data** (a reused `<track>`) and stale cue **pixels** (a paused video never re-composites its native caption overlay). `apply()` — every open, Recents included via `switchToProject` → `applyProjectFiles` → `apply()` — did the teardown, then set `mode = 'showing'` once. That is precisely the state proven insufficient last time: `fcc323c` added the explicit `hidden`→`showing` toggle **on top of** code that already reset the track and already set `showing`. Only a real transition rebuilds the overlay.

The old comment claimed the load path was safe because new media forces a relayout — true once, but the #456 library reuses the paused element and may keep the same media. The SRT (`hyperaudio-lite-editor-export.js:231`) and VTT (`:355`) imports had **neither** half.

## Fix

One door in `js/hyperaudio-save.js`: `applyCaptionTrack()` (teardown + src + flush) and `flushCaptionPaint()` (the transition). Routed through it: project open/Recents, SRT import, VTT import. The regenerate handler now calls the shared `flushCaptionPaint()` instead of its own inline copy, so there is one implementation rather than one per route — the reason this kept returning. The live-edit sanitise paths stay exempt by design.

## Tests

The stale line is native `::cue` paint, invisible to the DOM — which is why previous tests passed while the bug was live on other routes.

- `caption-track-reset.spec.mjs` wraps the `TextTrack.prototype.mode` setter to record assignments, asserting the `hidden`→`showing` signature for the SRT import and the regenerate path. Observes the mechanism, not pixels, and needs no production instrumentation.
- `__TEST__/unit/caption-door.test.mjs` scans `js/` and fails if any file outside the door assigns the caption track's src, with documented exemptions for the live-edit paths and the vendored files. **Verified to fail on the pre-fix code**, naming both import lines — this is the guard against the next recurrence.

Full suite: 91 passed (plus the new unit test in the unit lane).

## Unverified / noted

- **Safari** — Playwright here is Chromium-only, and caption overlay compositing is exactly what WebKit does differently. One Recents switch in Safari is worth doing before release.
- Vendored `caption.js`'s `applyCaptions` defers to `loadedmetadata` when metadata isn't ready, landing after the synchronous flush — a latent timing hole on the transcribe path, unconfirmed and upstream-owned.

Related: #356, #287 (same symptom, different paths — left closed), #424 (previous fix).
