### PR TITLE
Suppress bold/italic/underline in the transcript (#496)

### DIFF
--- a/__TEST__/e2e/span-merge.spec.mjs
+++ b/__TEST__/e2e/span-merge.spec.mjs
@@ -267,3 +267,101 @@ test('a clean transcript is untouched on blur (no spurious merges)', async ({ pa
   });
   expect(after).toBe(before);
 });
+
+// The transcript models words and timings, not rich text — but #hypertranscript
+// is a plain contenteditable, so the browser's own formatting applied anyway:
+// ⌘B over a selection wrapped the word spans in <b>, and the writer then
+// flattened it away on save, silently discarding what the user had applied.
+//
+// Measured while writing this: headless Chromium treats Ctrl+B in contenteditable
+// as inert (no bold, and no beforeinput), and document.execCommand('bold') raises
+// no beforeinput at all. So neither the real shortcut nor execCommand can stand in
+// for the user's route here. What IS deterministic is our own guard: assert the
+// handler cancels the shortcut, and that the transcript stays free of formatting.
+test('the transcript cancels the bold/italic/underline shortcuts', async ({ page }) => {
+  const cancelled = await page.evaluate(() => {
+    const ht = document.getElementById('hypertranscript');
+    ht.focus();
+    const fire = (key, mods) => {
+      const e = new KeyboardEvent('keydown', Object.assign(
+        { key, bubbles: true, cancelable: true }, mods));
+      ht.dispatchEvent(e);
+      return e.defaultPrevented;
+    };
+    return {
+      metaB: fire('b', { metaKey: true }),
+      metaI: fire('i', { metaKey: true }),
+      metaU: fire('u', { metaKey: true }),
+      ctrlB: fire('b', { ctrlKey: true }),
+      // unmodified typing and unrelated shortcuts must pass through untouched
+      // ('k' is bound to nothing; ⌘S is deliberately cancelled by the save
+      // handler in hyperaudio-save.js, so it is no use as a control here)
+      plainB: fire('b', {}),
+      metaK: fire('k', { metaKey: true }),
+    };
+  });
+
+  expect(cancelled.metaB).toBe(true);
+  expect(cancelled.metaI).toBe(true);
+  expect(cancelled.metaU).toBe(true);
+  expect(cancelled.ctrlB).toBe(true);
+  expect(cancelled.plainB).toBe(false);   // typing the letter b still works
+  expect(cancelled.metaK).toBe(false);    // unrelated shortcuts are untouched
+});
+
+test('format* input types are refused by the transcript', async ({ page }) => {
+  // the other hook: routes that raise beforeinput (menu bar, context menu)
+  const result = await page.evaluate(() => {
+    const ht = document.getElementById('hypertranscript');
+    const send = (inputType) => {
+      const e = new InputEvent('beforeinput', { inputType, bubbles: true, cancelable: true });
+      ht.dispatchEvent(e);
+      return e.defaultPrevented;
+    };
+    // NB: Chromium's InputEvent constructor validates inputType against a known
+    // list and normalises anything else to "" — formatBackColor and
+    // formatFontColor arrive empty, so they cannot be exercised this way. Only
+    // constructible types are asserted here; the guard itself matches on the
+    // format* prefix, so it covers the rest when a real UI raises them.
+    return {
+      bold: send('formatBold'),
+      italic: send('formatItalic'),
+      underline: send('formatUnderline'),
+      strike: send('formatStrikeThrough'),
+      typing: send('insertText'),                 // ordinary input must survive
+      paste: send('insertFromPaste'),
+    };
+  });
+
+  expect(result.bold).toBe(true);
+  expect(result.italic).toBe(true);
+  expect(result.underline).toBe(true);
+  expect(result.strike).toBe(true);
+  expect(result.typing).toBe(false);
+  expect(result.paste).toBe(false);
+});
+
+test('suppressing formatting leaves typing and redaction alone', async ({ page }) => {
+  await page.evaluate(() => {
+    const ht = document.getElementById('hypertranscript');
+    ht.focus();
+    const span = ht.querySelector('span[data-m]:not(.speaker)');
+    const range = document.createRange();
+    range.setStart(span.firstChild, 0);
+    range.collapse(true);
+    const sel = getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+  });
+  await page.keyboard.type('TYPED');
+  await expect(page.locator('#hypertranscript')).toContainText('TYPED');
+
+  // redaction sets span.style directly and bypasses both hooks
+  const struck = await page.evaluate(() => {
+    const span = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    span.style.textDecoration = 'line-through';
+    return /line-through/.test(span.getAttribute('style') || '');
+  });
+  expect(struck).toBe(true);
+  expect(await page.locator('#hypertranscript b, #hypertranscript i').count()).toBe(0);
+});

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -66,6 +66,45 @@
 
   let editableDiv = document.querySelector('#hypertranscript');
 
+  // The transcript is time-aligned speech, not a rich-text document: a word is a
+  // <span data-m data-d> and the model carries no formatting. But #hypertranscript
+  // is a plain contenteditable, so the browser's own formatting commands applied
+  // anyway — ⌘B wrapped the selected word spans in <b>, which the writer then
+  // flattened away on save, silently losing what the user had just applied.
+  //
+  // Suppress the whole family rather than named shortcuts. beforeinput (not
+  // keydown) is the hook that catches every route into it — keyboard, the
+  // right-click menu, and the macOS Format/Edit menu bar — and inputType tells us
+  // which operation it is. Every format* type either injects an element or sets a
+  // style the transcript doesn't model, formatRemove included: nothing gets in, so
+  // there is nothing to clear (anything that does arrive — legacy files, or a
+  // paste per #487 — is flattened by the writer anyway).
+  //
+  // The editor's OWN strikethrough (redaction) sets span.style programmatically
+  // and never goes through either hook, so it is unaffected.
+  //
+  // Two hooks, because neither covers the ground alone:
+  //  - keydown stops ⌘/Ctrl+B/I/U, which is how this is actually reached (no UI
+  //    offers it). Deterministic, and the only route testable in our headless
+  //    Chromium, where the shortcut is otherwise inert.
+  //  - beforeinput catches format* from routes that raise it instead — a menu
+  //    bar, a context menu — and covers types no shortcut has. Measured caveat:
+  //    document.execCommand('bold') raises NO beforeinput in Chromium, so this
+  //    is not a general "no formatting can ever appear" guarantee; it closes the
+  //    user-reachable routes. Markup that still gets in (legacy files, a paste
+  //    per #487) is flattened by the writer on save.
+  editableDiv.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && !e.altKey && /^[biu]$/i.test(e.key)) {
+      e.preventDefault();
+    }
+  });
+
+  editableDiv.addEventListener('beforeinput', function (e) {
+    if (typeof e.inputType === 'string' && e.inputType.startsWith('format')) {
+      e.preventDefault();
+    }
+  });
+
   editableDiv.addEventListener("paste", function(e) {
     e.preventDefault();
     var text = e.clipboardData.getData("text/plain");


### PR DESCRIPTION
Refs #496 — which stays open for the design question this defers.

`#hypertranscript` is a plain `contenteditable`, so the browser's own formatting commands applied even though the editor offers no controls for them: ⌘B over a selection wrapped the word spans in `<b>`. The writer then flattened that away on save, so the user's change silently vanished — the worst of both worlds, since the transcript models words and timings and carries no formatting.

## The fix

Two hooks, because measurement showed neither covers the ground alone:

- **keydown** cancels ⌘/Ctrl+B/I/U — how this is actually reached, since no UI offers formatting, and the only route testable in our headless Chromium (where the shortcut is otherwise inert).
- **beforeinput** refuses `format*` input types — catching routes that raise it instead (menu bar, context menu) and types no shortcut has.

The editor's own strikethrough sets `span.style` programmatically and goes through neither hook, so redaction is unaffected.

## Measured caveats

Three findings from probing rather than assuming, all recorded on #496:

- `document.execCommand('bold')` raises **no** `beforeinput` in Chromium. So this closes the user-reachable routes rather than making formatting impossible; markup that still arrives (legacy files, a paste per #487) is flattened by the writer as before.
- Headless Chromium treats Ctrl+B in `contenteditable` as inert — no bold, no event — so the real keyboard path can't be exercised headlessly. The tests assert our guard's own behaviour instead.
- Chromium's `InputEvent` constructor validates `inputType` against a known list and normalises unrecognised values to `""`, so `formatBackColor`/`formatFontColor` cannot be synthesised in a test.

## Tests

Three, in `span-merge.spec.mjs`: the shortcuts are cancelled (and unrelated ones aren't), `format*` is refused (and `insertText`/`insertFromPaste` aren't), and ordinary typing plus the redaction strikethrough still work. Both guard tests verified to fail without the guard.

Full suite: 94 passed.

## Not decided here

Whether formatting should instead be *supported* — as word-level booleans mirroring `struck`, rather than wrapper elements that would break one-word-one-span (#394) — is left open in #496, along with the prior question of what bold would even mean in a transcript.
