### PR TITLE
Stop a stale caption listener overwriting the document just opened (#499)

### DIFF
--- a/__TEST__/e2e/caption-track-reset.spec.mjs
+++ b/__TEST__/e2e/caption-track-reset.spec.mjs
@@ -15,6 +15,7 @@
 // TextTrack. On the pre-fix code the element was reused, so `sameElement` is true
 // and the stale cue can linger — this test fails there.
 import { test, expect } from '@playwright/test';
+import { ladderWav } from './helpers.mjs';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/index.html');
@@ -129,4 +130,61 @@ test('the regenerate path still flushes, via the shared helper (#356/#287)', asy
     document.dispatchEvent(new CustomEvent('hyperaudioGenerateCaptionsFromTranscript'));
   });
   expect(await flushed(page)).toBe(true);
+});
+
+// Part 3 of #356/#287 — the late, ASYNCHRONOUS write that survived the first two
+// fixes. The vendored caption.js defers its VTT to 'loadedmetadata' when the
+// media has not loaded yet, closing over THAT document's captions; nothing
+// cancels it when the document changes. So a caption pass run while the intro
+// (remote, slow) was still loading stays pending and fires when the NEXT media's
+// metadata arrives, writing the previous transcript's captions over the project
+// just opened — after everything the teardown and paint flush can reach.
+//
+// Reproduces it directly: media A that never loads metadata, a caption pass to
+// arm the straggler, then a different document applied through the door.
+test('a caption pass armed on unloaded media cannot overwrite the next document (#356/#287)', async ({ page }) => {
+  await page.route('**/__never.mp3', async () => { /* never fulfils */ });
+  await page.route('**/__real.wav', (route) => route.fulfill({
+    body: ladderWav(3), contentType: 'audio/wav',
+  }));
+
+  // 1. media A, whose metadata never arrives, plus a caption pass over
+  //    transcript A: caption.js parks a listener holding A's captions
+  await page.evaluate(() => {
+    const v = document.getElementById('hyperplayer');
+    v.src = '/__never.mp3';
+    document.getElementById('hypertranscript').innerHTML =
+      '<article><section><p><span data-m="0" data-d="500">STALEWORD </span></p></section></article>';
+    document.dispatchEvent(new CustomEvent('hyperaudioGenerateCaptionsFromTranscript'));
+  });
+  await page.waitForTimeout(300);
+  expect(await page.evaluate(() => document.getElementById('hyperplayer').readyState)).toBe(0);
+
+  // 2. a different document arrives the way a project open delivers one
+  await page.evaluate(async () => {
+    document.getElementById('hypertranscript').innerHTML =
+      '<article><section><p><span data-m="0" data-d="500">FRESHWORD </span></p></section></article>';
+    window.applyCaptionTrack(
+      'data:text/vtt,' + encodeURIComponent('WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nFRESHWORD\n'),
+      { kind: 'captions', mode: 'showing' }
+    );
+    const blob = await (await fetch('/__real.wav')).blob();
+    document.getElementById('hyperplayer').src = URL.createObjectURL(blob);
+  });
+
+  // 3. the new media's metadata is exactly when the straggler would fire
+  await page.waitForFunction(
+    () => document.getElementById('hyperplayer').readyState >= 1, null, { timeout: 15000 });
+  await page.waitForTimeout(500);
+
+  const result = await page.evaluate(() => {
+    const t = document.getElementById('hyperplayer-vtt');
+    const src = t === null ? '' : decodeURIComponent(t.src);
+    const tt = document.getElementById('hyperplayer').textTracks[0];
+    return { stale: /STALEWORD/.test(src), fresh: /FRESHWORD/.test(src), mode: tt && tt.mode };
+  });
+
+  expect(result.stale).toBe(false);   // pre-fix: true — the intro's captions won
+  expect(result.fresh).toBe(true);
+  expect(result.mode).toBe('showing');
 });

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -1489,7 +1489,8 @@
     const settings = opts || {};
     const track = resetCaptionTrack();
     if (track === null) return null;
-    if (typeof vttSrc === 'string' && vttSrc !== '') track.src = vttSrc;
+    const src = (typeof vttSrc === 'string' && vttSrc !== '') ? vttSrc : '';
+    if (src !== '') track.src = src;
     if (settings.kind !== undefined) track.kind = settings.kind;
     if (settings.label !== undefined) track.label = settings.label;
     if (settings.srcLang !== undefined) track.srcLang = settings.srcLang;
@@ -1498,11 +1499,59 @@
     const video = document.getElementById('hyperplayer');
     const textTrack = video !== null && video.textTracks !== undefined
       ? video.textTracks[0] : undefined;
-    if (textTrack !== undefined) {
-      textTrack.mode = settings.mode !== undefined ? settings.mode : 'showing';
-    }
+    const mode = settings.mode !== undefined ? settings.mode : 'showing';
+    if (textTrack !== undefined) textTrack.mode = mode;
     flushCaptionPaint();
+    guardAgainstLateCaptionWrite(video, track, src, mode);
     return track;
+  }
+
+  // Part 3 of #356/#287, and the one that survived the first two fixes.
+  //
+  // The vendored caption.js applies its VTT on 'loadedmetadata' when the media
+  // has not loaded yet — and the listener closes over THAT document's captions.
+  // Nothing cancels it when the document changes, so a caption pass run while
+  // the intro (remote, slow) was still loading stays pending, and fires when the
+  // NEXT media's metadata arrives: the previous document's captions land on top
+  // of the one just opened. Measured — the write happens after everything the
+  // synchronous teardown and paint flush can reach, which is why the track ends
+  // up holding a data:text/vtt of the PREVIOUS transcript.
+  //
+  // Registering our own one-shot listener here re-asserts the swap after any
+  // such straggler: at the target, listeners run in registration order, and ours
+  // is necessarily registered later than a pending one. Only armed while
+  // metadata is still pending — once it has loaded, any stale listener has
+  // already fired and been removed, so there is nothing to outlast, and the
+  // window in which this could contend with a legitimate later caption pass
+  // stays as small as possible.
+  //
+  // The real fix belongs upstream (capture the media identity at registration
+  // and bail if it changed); this is the local defence until that lands.
+  function guardAgainstLateCaptionWrite(video, track, src, mode) {
+    if (video === null || video.readyState >= 1 /* HAVE_METADATA */) return;
+    video.addEventListener('loadedmetadata', function reassert() {
+      video.removeEventListener('loadedmetadata', reassert);
+      // Still OUR swap? resetCaptionTrack replaces the element, so a later
+      // applyCaptionTrack — a newer document — leaves a different one in place
+      // and this re-assert must stand down. A straggler from caption.js writes
+      // .src on the existing element, so identity still holds there, which is
+      // exactly the case worth correcting. Element identity rather than the
+      // media src: apply() sets media before captions, but nothing guarantees
+      // that order for every caller.
+      const current = document.getElementById('hyperplayer-vtt');
+      if (current === null || current !== track) return;
+      let changed = false;
+      if (src !== '' && current.getAttribute('src') !== src) {
+        current.src = src;
+        changed = true;
+      }
+      const tt = video.textTracks !== undefined ? video.textTracks[0] : undefined;
+      if (tt !== undefined && tt.mode !== mode) {
+        tt.mode = mode;
+        changed = true;
+      }
+      if (changed) flushCaptionPaint();
+    });
   }
 
   // the caption-regenerate path in editor-core reaches these by global name


### PR DESCRIPTION
Fixes #499

Opening a project from Recents left the **intro's** captions on the player, over the project's own — written as a `data:text/vtt` after the load had completed. Confirmed fixed by hand-check on the Recents route.

Same symptom as #356/#287/#493, third distinct cause, and the first that is **asynchronous** — it lands after everything the synchronous teardown and paint flush can reach, which is why those fixes left it standing.

## Cause

Vendored `caption.js` applies its VTT on `loadedmetadata` when the media hasn't loaded yet, and the listener closes over *that* document's captions. Its comment claims this "prevents a listener persisting with a stale captionsVtt closure and re-applying it when a different media subsequently loads" — it doesn't. The listener is removed only *after* it fires, and nothing cancels it when the document changes.

So the boot caption pass, run over the demo transcript while the remote intro mp3 was still loading, parks a listener holding the intro's captions. When the restored project's media reaches `loadedmetadata`, it fires and overwrites what the project applied.

Measured with a probe — document A's captions landing on document B's media after B was applied correctly:

```
FINAL: hasALPHA (A's captions): true
       hasBRAVO (B's captions): false
```

## Fix

`applyCaptionTrack` arms a one-shot `loadedmetadata` listener that re-asserts the swap after any straggler — at the target, listeners run in registration order, so one registered later necessarily runs later.

Two things keep it narrow:

- **Armed only while metadata is pending.** Once loaded, a stale listener has already fired and been removed, so there is nothing to outlast — and the window where this could contend with a legitimate later caption pass stays minimal.
- **"Still our swap?" is track element identity, not media src.** `resetCaptionTrack` replaces the element, so a newer `applyCaptionTrack` leaves a different one in place and the re-assert stands down; a `caption.js` straggler writes `.src` on the existing element, so identity holds and it is corrected. (`apply()` sets media before captions, so a src comparison would have worked there too — but nothing guarantees that order for other callers, and my first attempt at a src check failed the test for exactly that reason.)

## A local defence, not the root fix

The root fix belongs upstream — capture the media identity at registration and bail if it changed — after which this guard becomes redundant and can go. `caption.js` is byte-identical to upstream v2.6.4 (#495), so it is deliberately not patched here.

#498 attacks the same problem from the other end: not running a caption pass over a document that is about to be discarded removes the opportunity rather than defending against it.

## Test

Reproduces it directly — media whose metadata never arrives, a caption pass to arm the straggler, a different document applied through the door, then real media loading. Verified to fail without the guard.

Full suite: 95 passed.

Unverified: Safari. Caption overlay behaviour is where WebKit differs most, and CI here is Chromium-only.
