### PR TITLE
Offer a multi-file export as one zip, in one folder (#396)

### DIFF
--- a/__TEST__/e2e/export-project.spec.mjs
+++ b/__TEST__/e2e/export-project.spec.mjs
@@ -42,8 +42,10 @@ test('flattened .hyperaudio export: edited media, re-timed struck-free transcrip
   await page.waitForFunction(() => document.getElementById('export-format').options.length > 0, null, { timeout: 60000 });
   await page.selectOption('#export-format', 'wav');
   await page.evaluate(() => {
-    // only the media file + the project container
-    for (const id of ['export-retime', 'export-vtt', 'export-srt', 'export-burn']) {
+    // only the media file + the project container, delivered separately —
+    // export-zip is on by default for multi-file runs (#396) and this test is
+    // about the container itself, not the packaging
+    for (const id of ['export-retime', 'export-vtt', 'export-srt', 'export-burn', 'export-zip']) {
       const c = document.getElementById(id);
       if (c) c.checked = false;
     }

--- a/__TEST__/e2e/export-zip.spec.mjs
+++ b/__TEST__/e2e/export-zip.spec.mjs
@@ -1,0 +1,142 @@
+// #396 — a multi-file export arrives as ONE .zip containing ONE folder.
+//
+// The reason is not tidiness. The interactive transcript links its media by bare
+// filename, and handing the browser several downloads lets its de-duplication
+// rename one of them: "clip.mp4" lands as "clip (1).mp4" when Downloads already
+// holds that name, and the transcript then silently plays whatever the older
+// file was — wrong media that plays, rather than a dead player. Archive entries
+// cannot be renamed that way, and a colliding FOLDER is suffixed while its
+// contents keep their names and their pairing.
+//
+// Requires network: the export modal lazy-loads mediabunny.
+import { test, expect } from '@playwright/test';
+import { createRequire } from 'node:module';
+import { ladderWav, transcriptHtml } from './helpers.mjs';
+
+const require = createRequire(import.meta.url);
+const JSZip = require('jszip');
+
+// Load a short tone ladder and a matching transcript, then open the export modal.
+async function openExportModal(page) {
+  const wav = ladderWav(3);
+  await page.route('**/__zip.wav', (route) => route.fulfill({ body: wav, contentType: 'audio/wav' }));
+  await page.goto('/index.html');
+  await page.waitForFunction(() => typeof window.getPlayableSections === 'function');
+
+  await page.evaluate(async () => {
+    const blob = await (await fetch('/__zip.wav')).blob();
+    document.getElementById('hyperplayer').src = URL.createObjectURL(blob);
+  });
+  await page.waitForFunction(() => {
+    const p = document.getElementById('hyperplayer');
+    return p.readyState >= 1 && p.duration > 2;
+  });
+  await page.evaluate((html) => {
+    document.getElementById('hypertranscript').innerHTML = html;
+  }, transcriptHtml([[0, 1000], [1000, 1000], [2000, 1000]]));
+
+  await page.evaluate(() => {
+    const m = document.getElementById('export-modal');
+    m.checked = true;
+    m.dispatchEvent(new Event('change'));
+  });
+  await page.waitForFunction(
+    () => document.getElementById('export-format').options.length > 0, null, { timeout: 60000 });
+  await page.selectOption('#export-format', 'wav');
+}
+
+test('a multi-file export downloads once, as a zip holding one folder', async ({ page }) => {
+  await openExportModal(page);
+
+  // media + SRT = two outputs, so the zip applies
+  await page.evaluate(() => {
+    const set = (id, on) => {
+      const c = document.getElementById(id);
+      if (c) { c.checked = on; c.dispatchEvent(new Event('change')); }
+    };
+    ['export-retime', 'export-vtt', 'export-burn', 'export-project'].forEach((id) => set(id, false));
+    set('export-srt', true);
+    set('export-zip', true);
+    document.getElementById('export-name').value = 'my clip';
+  });
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.click('#export-start');
+  const download = await downloadPromise;
+  await page.waitForFunction(
+    () => document.getElementById('export-status').textContent.startsWith('Done'));
+
+  expect(download.suggestedFilename()).toBe('my clip.zip');
+
+  const fs = await import('node:fs/promises');
+  const zip = await JSZip.loadAsync(await fs.readFile(await download.path()));
+  const paths = Object.keys(zip.files);
+
+  // every entry sits under exactly one top-level folder
+  const tops = new Set(paths.map((p) => p.split('/')[0]));
+  expect([...tops]).toEqual(['my clip']);
+
+  // and that folder holds both files, under their own names
+  const names = paths.filter((p) => !zip.files[p].dir).map((p) => p.split('/').pop()).sort();
+  expect(names).toEqual(['my clip.srt', 'my clip.wav']);
+
+  // the media survives the round trip as real bytes
+  const wavEntry = zip.file('my clip/my clip.wav');
+  expect(wavEntry).not.toBeNull();
+  const bytes = await wavEntry.async('uint8array');
+  expect(bytes.length).toBeGreaterThan(1000);
+  expect(Buffer.from(bytes.slice(0, 4)).toString('ascii')).toBe('RIFF');
+});
+
+test('a single-file export is not zipped, and the offer is hidden', async ({ page }) => {
+  await openExportModal(page);
+
+  await page.evaluate(() => {
+    const set = (id, on) => {
+      const c = document.getElementById(id);
+      if (c) { c.checked = on; c.dispatchEvent(new Event('change')); }
+    };
+    ['export-retime', 'export-vtt', 'export-srt', 'export-burn', 'export-project']
+      .forEach((id) => set(id, false));
+    document.getElementById('export-name').value = 'solo';
+  });
+
+  // nothing to bundle, so the toggle is not offered
+  await expect(page.locator('#export-zip-row')).toBeHidden();
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.click('#export-start');
+  const download = await downloadPromise;
+  await page.waitForFunction(
+    () => document.getElementById('export-status').textContent.startsWith('Done'));
+
+  expect(download.suggestedFilename()).toBe('solo.wav');
+});
+
+test('the zip offer appears once a second file is selected', async ({ page }) => {
+  await openExportModal(page);
+  await page.evaluate(() => {
+    ['export-retime', 'export-vtt', 'export-srt', 'export-burn', 'export-project'].forEach((id) => {
+      const c = document.getElementById(id);
+      if (c) { c.checked = false; c.dispatchEvent(new Event('change')); }
+    });
+  });
+  await expect(page.locator('#export-zip-row')).toBeHidden();
+
+  // the "keep them together" warning is what the zip replaces
+  await page.evaluate(() => {
+    const c = document.getElementById('export-srt');
+    c.checked = true;
+    c.dispatchEvent(new Event('change'));
+  });
+  await expect(page.locator('#export-zip-row')).toBeVisible();
+  await expect(page.locator('#export-name-note')).toContainText('one .zip');
+
+  // turning the zip off brings the warning back
+  await page.evaluate(() => {
+    const c = document.getElementById('export-zip');
+    c.checked = false;
+    c.dispatchEvent(new Event('change'));
+  });
+  await expect(page.locator('#export-name-note')).toContainText('keep the downloads together');
+});

--- a/index.html
+++ b/index.html
@@ -821,7 +821,7 @@ If you are creating an open source application under a license compatible with t
       <select id="export-format" class="select select-bordered w-full" style="margin-top:4px"></select>
       <label class="label-text" for="export-name" style="display:block; margin-top:14px">Save as</label>
       <input id="export-name" type="text" class="input input-bordered w-full" style="margin-top:4px" placeholder="file name (no extension)" />
-      <div style="font-size:82%; opacity:0.7; margin-top:6px">All exported files use this name. The interactive transcript links the video by it — keep the downloads together in one folder.</div>
+      <div id="export-name-note" style="font-size:82%; opacity:0.7; margin-top:6px">All exported files use this name. The interactive transcript links the video by it — keep the downloads together in one folder.</div>
       <label id="export-adjust-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
         <input type="checkbox" id="export-adjust" class="toggle toggle-primary" />
         <span class="label-text">Adjust speed / length (pitch preserved)</span>
@@ -865,6 +865,10 @@ If you are creating an open source application under a license compatible with t
       <label id="export-project-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
         <input type="checkbox" id="export-project" class="toggle toggle-primary" />
         <span class="label-text">Download a new project (.hyperaudio) — edits applied, struck words removed, safe to share</span>
+      </label>
+      <label id="export-zip-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
+        <input type="checkbox" id="export-zip" class="toggle toggle-primary" checked />
+        <span class="label-text">Download everything as a single .zip (one folder, files stay paired)</span>
       </label>
       <progress id="export-progress" class="progress progress-primary w-full" value="0" max="100" style="visibility:hidden; margin-top:14px"></progress>
       <div id="export-status" aria-live="polite" style="font-size:85%; opacity:0.75; min-height:1.3em; margin-top:2px"></div>
@@ -1075,7 +1079,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/editor-main.js?v=0.8.0"></script>
   <script src="js/find-replace.js?v=0.6.29"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
-  <script src="js/media-export.js?v=1.1.4"></script>
+  <script src="js/media-export.js?v=1.1.8"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
   <script src="js/word-vtt.js?v=1.1.6"></script>
   <!-- end of caption editor additions -->

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -1,7 +1,7 @@
 /**
  * media-export.js
  * (C) The Hyperaudio Project
- * @version 1.1.4 — last changed in release 1.1.4
+ * @version 1.1.8 — last changed in release 1.1.8
  * @license MIT
  *
  * Media export via mediabunny (#289, #291, #292): export the loaded media as
@@ -537,6 +537,36 @@
     return name.replace(/\.[a-z0-9]+$/i, '');
   };
 
+  // Bundle the run's outputs into one archive (#396). Everything goes inside a
+  // single top-level FOLDER, which is the point: the interactive transcript
+  // links its media by bare filename, and handing the browser several downloads
+  // lets its de-duplication rename one of them — "clip.mp4" arrives as
+  // "clip (1).mp4" when Downloads already holds that name, and the transcript
+  // then silently plays whatever the older file was. Archive entries can't be
+  // renamed that way, and if the FOLDER collides on extraction it is the folder
+  // that gets suffixed while its contents keep their names and pairing.
+  //
+  // STORE, not deflate: the payload is already-compressed media, so compressing
+  // buys nothing and costs time on large exports.
+  const zipFolderName = (name) => {
+    const cleaned = String(name).replace(/[\\/:*?"<>|]+/g, '-').replace(/^\.+/, '').trim();
+    return cleaned !== '' ? cleaned : 'hyperaudio-export';
+  };
+
+  const buildOutputsZip = async (outputs, baseName, onProgress) => {
+    if (!window.HyperaudioSave || typeof window.HyperaudioSave.loadJSZip !== 'function') {
+      throw new Error('zip writer unavailable');
+    }
+    const JSZipImpl = await window.HyperaudioSave.loadJSZip();
+    const zip = new JSZipImpl();
+    const folder = zip.folder(zipFolderName(baseName));
+    outputs.forEach((out) => folder.file(out.name, out.blob));
+    return zip.generateAsync(
+      { type: 'blob', compression: 'STORE' },
+      (meta) => { if (typeof onProgress === 'function' && meta) onProgress(meta.percent || 0); }
+    );
+  };
+
   const downloadBlob = (blob, filename) => {
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
@@ -570,6 +600,9 @@
   const retimeCheck = document.getElementById('export-retime');
   const vttRow = document.getElementById('export-vtt-row');
   const vttCheck = document.getElementById('export-vtt');
+  const zipRow = document.getElementById('export-zip-row');
+  const zipCheck = document.getElementById('export-zip');
+  const nameNote = document.getElementById('export-name-note');
   const srtRow = document.getElementById('export-srt-row');
   const srtCheck = document.getElementById('export-srt');
   const projectRow = document.getElementById('export-project-row');
@@ -723,6 +756,30 @@
       projectRow.style.display =
         (show === 'flex' && window.HyperaudioSave
           && typeof window.HyperaudioSave.buildFlattenedProjectBlob === 'function') ? 'flex' : 'none';
+    }
+    updateZipVisibility();
+  };
+
+  // The zip only means anything when the run produces more than one file, so the
+  // toggle appears exactly then — and the "keep the downloads together" warning
+  // is only true when it is off, since a zip keeps them together by construction.
+  const checkedAndVisible = (check, row) =>
+    check !== null && check.checked && row !== null && row.style.display !== 'none';
+
+  const updateZipVisibility = () => {
+    if (zipRow === null) return;
+    const extras = [
+      checkedAndVisible(retimeCheck, retimeRow),
+      checkedAndVisible(vttCheck, vttRow),
+      checkedAndVisible(srtCheck, srtRow),
+      checkedAndVisible(projectCheck, projectRow),
+    ].filter(Boolean).length;
+    const multi = extras > 0;   // the media itself is always the first output
+    zipRow.style.display = multi ? 'flex' : 'none';
+    if (nameNote !== null) {
+      nameNote.textContent = (multi && zipCheck !== null && zipCheck.checked)
+        ? 'All exported files use this name. They arrive in one .zip, in a folder that keeps them together.'
+        : 'All exported files use this name. The interactive transcript links the video by it — keep the downloads together in one folder.';
     }
   };
 
@@ -947,11 +1004,32 @@
         }
       }
 
-      // 4. hand the browser each file, spaced out so Safari doesn't drop all but
-      // the last of a multi-file download
-      for (let i = 0; i < outputs.length; i++) {
-        downloadBlob(outputs[i].blob, outputs[i].name);
-        if (i < outputs.length - 1) await sleep(250);
+      // 4. hand the files to the browser — as one .zip when asked, else each on
+      // its own, spaced out so Safari doesn't drop all but the last (#396).
+      // Decided by what the run actually produced plus the toggle — NOT by the
+      // row's visibility, which is presentation and can lag a programmatic
+      // checkbox change that fired no 'change' event.
+      const asZip = outputs.length > 1 && zipCheck !== null && zipCheck.checked;
+      let zipped = false;
+      if (asZip) {
+        try {
+          setStatus('Packaging…');
+          const zipBlob = await buildOutputsZip(outputs, baseName, (pct) => {
+            setStatus(`Packaging… ${Math.round(pct)}%`);
+          });
+          downloadBlob(zipBlob, `${baseName}.zip`);
+          zipped = true;
+        } catch (e) {
+          // A failed package must not cost the user the render they just waited
+          // for — fall through to the individual downloads instead.
+          console.warn('media-export: zip packaging failed, downloading separately', e);
+        }
+      }
+      if (!zipped) {
+        for (let i = 0; i < outputs.length; i++) {
+          downloadBlob(outputs[i].blob, outputs[i].name);
+          if (i < outputs.length - 1) await sleep(250);
+        }
       }
 
       setProgress(1);
@@ -967,6 +1045,11 @@
   };
 
   modalToggle.addEventListener('change', () => { if (modalToggle.checked) populateModal(); });
+  // the zip offer tracks how many files the run will produce, so it has to
+  // re-evaluate whenever a sidecar is toggled (and its own state changes the note)
+  [retimeCheck, vttCheck, srtCheck, projectCheck, zipCheck].forEach((el) => {
+    if (el !== null) el.addEventListener('change', updateZipVisibility);
+  });
   sourceEntire.addEventListener('change', () => { updateRetimeVisibility(); refreshAdjustForContent(); });
   sourceEdited.addEventListener('change', () => { updateRetimeVisibility(); refreshAdjustForContent(); });
   formatSelect.addEventListener('change', updateBurnVisibility);


### PR DESCRIPTION
Fixes #396

The export modal can produce up to four files, each handed to the browser as its own download with a 250ms stagger so Safari doesn't drop all but the last. The interactive transcript links its media by bare filename, so the modal has to warn "keep the downloads together in one folder".

That warning understates the failure — as hit live (see the comment on #396). Download de-duplication can rename one of them: media exported as `clip.mp4` arrives as `clip (1).mp4` when Downloads already holds that name, while the transcript still points at `clip.mp4`. The page then plays whatever the *older* file was. The files are in the same folder, the instruction was followed, and the result is **wrong media that plays** — far worse than the dead player the template already explains, and self-evidently not fixable by a better warning.

## One folder, not loose entries

Archive entries cannot be renamed by download de-duplication, and if the extracted **folder** collides it is the folder that gets suffixed while its contents keep their names and their pairing. Loose entries extracted into a populated Downloads folder can be de-duplicated individually, which would reintroduce the bug at extraction time instead of download time. A folder also makes behaviour deterministic across macOS Archive Utility, Windows Explorer and the rest, rather than depending on each one's single-entry-vs-many heuristic.

## Details

- The toggle appears only when the run produces more than one file, and **defaults on**. The "keep them together" note swaps to zip wording while it applies, since that warning is only true when the toggle is off.
- Packaging reuses the **vendored JSZip** (`loadJSZip` on `HyperaudioSave`), already precached by the service worker so offline export keeps working. The hand-rolled STORE writer this issue proposed predates that dependency existing. `STORE`, not deflate — the payload is already-compressed media.
- A failed package **falls back to individual downloads** rather than costing the user the render they just waited for.
- Whether to zip is decided by the outputs the run actually produced plus the toggle, **not** by the row's visibility — visibility is presentation and can lag a programmatic checkbox change that fired no `change` event.

`export-project.spec.mjs` now opts out explicitly: it produces two files, so the default-on zip would otherwise change what it receives, and that test is about the container rather than the packaging. `export-cuts` and `export-length` produce one file each and are unaffected.

## Tests

Three new, in `export-zip.spec.mjs`: a multi-file export downloads **once** as `<name>.zip` with every entry under one folder and the WAV intact (`RIFF` header checked); a single-file export isn't zipped and the toggle stays hidden; the toggle appears when a second file is selected, with the note text tracking it. Verified the first fails without the change (`my clip.wav` instead of `my clip.zip`).

Full suite: 98 passed.

## Not addressed

**zip64.** A multi-GB video export may exceed what JSZip 3.10.1 writes correctly — the concern raised in the issue is still open. The fallback catches a throw but not silent truncation, so this is worth testing before relying on it for very large video.

Also unverified in Safari, though the risk is low here — it's blob-and-download rather than anything engine-specific.
