### PR TITLE
Version 1.1.9

### DIFF
--- a/__TEST__/e2e/paste.spec.mjs
+++ b/__TEST__/e2e/paste.spec.mjs
@@ -1,0 +1,88 @@
+// #487 — pasting into the transcript inserts TEXT, not markup.
+//
+// The handler took the clipboard's text/plain and fed it to
+// execCommand("insertHTML"), which parses it: anything between < and > became an
+// element rather than characters. Pasting the literal "<inaudible>" produced an
+// empty <inaudible> element, so the word rendered as nothing and never reached
+// the saved JSON — silent, unrecoverable loss of what the user just pasted.
+// Recognised tags fared no better, injecting real <b>/<i> into the word spans.
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+});
+
+// Paste `text` as text/plain with the caret at `offset` inside word span `index`.
+const pasteInto = (page, index, offset, text) => page.evaluate(({ index, offset, text }) => {
+  const ht = document.getElementById('hypertranscript');
+  ht.focus();
+  const span = [...ht.querySelectorAll('span[data-m]:not(.speaker)')][index];
+  const range = document.createRange();
+  range.setStart(span.firstChild, offset);
+  range.collapse(true);
+  const sel = getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+
+  const dt = new DataTransfer();
+  dt.setData('text/plain', text);
+  ht.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
+}, { index, offset, text });
+
+const state = (page) => page.evaluate(() => {
+  const ht = document.getElementById('hypertranscript');
+  return {
+    text: ht.textContent,
+    elements: ht.querySelectorAll('span[data-m]:not(.speaker)').length,
+    // anything that is not a timed word span is foreign to the transcript
+    foreign: [...ht.querySelectorAll('*')]
+      .filter((el) => !(el.tagName === 'SPAN' || el.tagName === 'P'
+        || el.tagName === 'ARTICLE' || el.tagName === 'SECTION'))
+      .map((el) => el.tagName),
+  };
+});
+
+test('a pasted word in angle brackets survives as text (#487)', async ({ page }) => {
+  const before = await state(page);
+  await pasteInto(page, 0, 0, '<inaudible>');
+
+  const after = await state(page);
+  expect(after.text).toContain('<inaudible>');   // pre-fix: the word vanished
+  expect(after.foreign).toEqual([]);             // pre-fix: ['INAUDIBLE']
+  expect(after.elements).toBe(before.elements);
+});
+
+test('pasted markup arrives as literal characters, not elements (#487)', async ({ page }) => {
+  await pasteInto(page, 1, 0, 'A<b>bold</b>B');
+
+  const after = await state(page);
+  expect(after.text).toContain('A<b>bold</b>B');  // every character, verbatim
+  expect(after.foreign).toEqual([]);              // pre-fix: ['B']
+});
+
+test('pasting keeps the word span and its timing intact (#487)', async ({ page }) => {
+  const timing = await page.evaluate(() => {
+    const s = [...document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)')][2];
+    return { m: s.getAttribute('data-m'), d: s.getAttribute('data-d') };
+  });
+
+  // mid-word, not offset 0: a caret at the start of a span's text node is the
+  // same document position as the end of the previous one, so contenteditable
+  // attaches the insertion to the PREVIOUS word — long-standing behaviour, and
+  // nothing to do with how the paste is inserted
+  await pasteInto(page, 2, 2, 'PASTED');
+
+  const after = await page.evaluate(() => {
+    const s = [...document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)')][2];
+    return { m: s.getAttribute('data-m'), d: s.getAttribute('data-d'), text: s.textContent };
+  });
+  expect(after.m).toBe(timing.m);
+  expect(after.d).toBe(timing.d);
+  expect(after.text).toContain('PASTED');
+});
+
+test('ordinary text still pastes normally (#487)', async ({ page }) => {
+  await pasteInto(page, 0, 0, 'hello world ');
+  expect(await page.locator('#hypertranscript').textContent()).toContain('hello world');
+});

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -725,3 +725,74 @@ test('opening keeps words sitting exactly on a paragraph boundary (#488)', async
   expect(await page.locator('#hypertranscript p').count()).toBe(2);
   expect(dialogs).toEqual([]);
 });
+
+// #489 — transcript.html is a PROJECTION of the JSON, not a second reading of the
+// DOM. #486 briefly derived the JSON from the canonical serializer's output, which
+// put the source of truth downstream of a presentation transform: two shapes the
+// serializer flattened (a wrapper around word spans, spans outside any <p>)
+// stopped being cosmetic and deleted words from the container. Reading once and
+// projecting means the two entries cannot disagree, and the shapes that used to
+// cost words cost nothing.
+test('a wrapper around word spans costs no words in the saved project (#489)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+
+  // exactly what Cmd+B over a selection produces, and what a paste of markup
+  // used to inject (#487): a <b> ENCLOSING timed word spans
+  await page.evaluate(() => {
+    const ht = document.getElementById('hypertranscript');
+    ht.innerHTML = '<article><section><p>'
+      + '<span data-m="0" data-d="100">one </span>'
+      + '<b><span data-m="100" data-d="100">two </span>'
+      + '<span data-m="200" data-d="100">three </span></b>'
+      + '<span data-m="300" data-d="100">four </span>'
+      + '</p></section>'
+      // and a timed span parked outside every <p>
+      + '<section><span data-m="400" data-d="100">five </span></section></article>';
+    ht.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+
+  await page.keyboard.press('Control+s');
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+
+  const saved = (await readCurrentProject(page)).saved;
+  const words = JSON.parse(saved.json).transcript.words.map((w) => w.text);
+
+  // every word reaches the JSON — the source of truth
+  expect(words).toEqual(['one', 'two', 'three', 'four', 'five']);
+
+  // and the HTML copy carries the same set, so the two entries agree (§ 4)
+  const htmlWords = [...saved.html.matchAll(/<span[^>]*data-m[^>]*>([^<]*)</g)]
+    .map((m) => m[1].trim())
+    .filter((t) => t !== '' && !t.startsWith('['));
+  expect(htmlWords).toEqual(words);
+});
+
+test('the saved HTML and JSON always describe the same words (#489)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+
+  await page.evaluate(() => {
+    const span = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    span.textContent = 'PROJECTED ';
+    span.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await page.keyboard.press('Control+s');
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+
+  const saved = (await readCurrentProject(page)).saved;
+  const jsonWords = JSON.parse(saved.json).transcript.words.map((w) => w.text);
+  expect(jsonWords).toContain('PROJECTED');
+
+  // the projection is generated from that JSON, so a re-parse must agree exactly
+  const reparsed = [...saved.html.matchAll(/<span[^>]*data-m[^>]*>([^<]*)</g)]
+    .map((m) => m[1].trim())
+    .filter((t) => t !== '' && !t.startsWith('['));
+  expect(reparsed).toEqual(jsonWords);
+
+  // struck words and the speaker label still survive the round trip
+  expect(saved.html).toContain('class="speaker"');
+  expect(JSON.parse(saved.json).transcript.words.some((w) => w.struck === true)).toBe(true);
+});

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -14,7 +14,10 @@ const JSZip = require('jszip');
 
 const FIXTURE_VTT = 'WEBVTT\n\n00:00:00.320 --> 00:00:01.500\nBenvenuti a Hyperaudio\n';
 
-async function buildFixture() {
+// mutateJson lets a test write a container the WRITER can no longer produce —
+// e.g. paragraphs: [], which buildProjectJson now normalises away (#492) but
+// files predating the rule still carry, and readers must still tolerate.
+async function buildFixture(mutateJson) {
   const state = {
     generatorVersion: 'e2e',
     created: '2026-07-10T09:00:00Z',
@@ -40,8 +43,10 @@ async function buildFixture() {
       paragraphs: [{ speaker: 'Maria', start: 0.32, end: 1.5 }],
     },
   };
+  const project = save.buildProjectJson(state);
+  if (typeof mutateJson === 'function') mutateJson(project);
   return save.zipProject({
-    json: save.serializeProjectJson(save.buildProjectJson(state)),
+    json: save.serializeProjectJson(project),
     html: '<article><section><p><span data-m="320" data-d="520">Benvenuti </span></p></section></article>',
     originalJson: JSON.stringify({ words: [{ start: 0.32, end: 0.84, text: 'benvenuti' }], paragraphs: [] }),
     captionsVtt: FIXTURE_VTT,
@@ -51,9 +56,9 @@ async function buildFixture() {
 
 // Open the fixture in the live page via the module's hidden input; collect any
 // native dialogs (a conformant open must produce none).
-async function openFixture(page, testInfo, dialogs) {
+async function openFixture(page, testInfo, dialogs, mutateJson) {
   const fixturePath = testInfo.outputPath('fixture.hyperaudio');
-  fs.writeFileSync(fixturePath, await buildFixture());
+  fs.writeFileSync(fixturePath, await buildFixture(mutateJson));
   page.on('dialog', (dialog) => {
     dialogs.push(dialog.message());
     dialog.accept();
@@ -795,4 +800,37 @@ test('the saved HTML and JSON always describe the same words (#489)', async ({ p
   // struck words and the speaker label still survive the round trip
   expect(saved.html).toContain('class="speaker"');
   expect(JSON.parse(saved.json).transcript.words.some((w) => w.struck === true)).toBe(true);
+});
+
+// #492 — the invariant is "writers emit >= 1 paragraph", but readers stay
+// tolerant: files written before the rule, and third-party JSON, legitimately
+// carry none. Opening one must still land every word, and the next save brings
+// the project back to conformance rather than preserving the gap.
+test('a project with no paragraphs opens whole and is written back with one (#492)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs, (project) => {
+    project.transcript.paragraphs = [];
+  });
+  await awaitLibraryEntry(page);
+
+  // every word reached the editor — not just the one openFixture waits on
+  const words = await page.locator('#hypertranscript span[data-m]:not(.speaker)').allTextContents();
+  expect(words.map((w) => w.trim())).toEqual(['Benvenuti', 'ehm', 'a']);
+  expect(dialogs).toEqual([]);
+
+  // an opened project is CLEAN, so ⌘S alone commits nothing — edit first, which
+  // is the path a real file predating the rule would take back to conformance
+  await page.evaluate(() => {
+    const span = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    span.textContent = 'Benvenuto ';
+    span.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
+  await page.keyboard.press('Control+s');
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+
+  const saved = (await readCurrentProject(page)).saved;
+  const transcript = JSON.parse(saved.json).transcript;
+  expect(transcript.words.map((w) => w.text)).toEqual(['Benvenuto', 'ehm', 'a']);
+  expect(transcript.paragraphs.length).toBeGreaterThanOrEqual(1);
 });

--- a/__TEST__/e2e/responsive.spec.mjs
+++ b/__TEST__/e2e/responsive.spec.mjs
@@ -36,6 +36,54 @@ test('Recents drawer slides in via the sidebar toggle and closes on backdrop', a
   expect((await rect(page, '#recents-pane')).x).toBeLessThan(0);
 });
 
+// The two corner buttons are position:fixed over the card, so nothing in the
+// layout reserves room for them — only .hyperaudio-transcript's top padding
+// does. Below 948px the padding shorthand had reset that to 8px while the
+// buttons stayed at holder-top + 10px, and the first line ran underneath both.
+//
+// Each band computes the buttons' `top` as its own literal, from a different
+// stack of offsets (nav height, holder padding, the transcript's own top), so
+// they drift apart silently. The rule that holds across all of them: a button
+// sits on the transcript element's top edge, and the 48px padding is what
+// keeps the text clear of it. The widths below straddle every breakpoint.
+test('the corner buttons never sit on the first line of transcript text', async ({ page }) => {
+  for (const width of [390, 780, 940, 1000, 1200]) {
+    await page.setViewportSize({ width, height: 800 });
+    await page.waitForTimeout(350); // the holder's 0.25s top transition
+    const boxes = await page.evaluate(() => {
+      // NOT offsetParent: it is null for every position:fixed element, which
+      // both corner buttons are — that check silently skipped them entirely.
+      const box = (s) => {
+        const el = document.querySelector(s);
+        if (el === null) return null;
+        const cs = getComputedStyle(el);
+        if (cs.display === 'none' || cs.visibility === 'hidden') return null;
+        const r = el.getBoundingClientRect();
+        if (r.width === 0 || r.height === 0) return null;
+        return { top: r.top, bottom: r.bottom, left: r.left, right: r.right };
+      };
+      return {
+        info: box('#transcript-info-btn'),
+        copy: box('#transcript-copy-btn'),
+        word: box('#hypertranscript [data-m]'),
+        transcript: box('#hypertranscript'),
+      };
+    });
+    expect(boxes.word, `first word missing at ${width}px`).not.toBeNull();
+    for (const name of ['info', 'copy']) {
+      const btn = boxes[name];
+      if (btn === null) continue; // hidden at this width is fine; overlapping is not
+      const clears = btn.bottom <= boxes.word.top
+        || btn.right <= boxes.word.left
+        || btn.left >= boxes.word.right;
+      expect(clears, `${name} button overlaps the first word at ${width}px`).toBe(true);
+      // and rides the text column's top edge rather than floating above it
+      expect(Math.abs(btn.top - boxes.transcript.top),
+        `${name} button is off the transcript's top edge at ${width}px`).toBeLessThanOrEqual(4);
+    }
+  }
+});
+
 test('audio-only collapses the pinned player to the controls strip', async ({ page }) => {
   const before = (await rect(page, '.transcript-holder')).y;
   await page.click('#audio-only-btn');

--- a/__TEST__/e2e/search.spec.mjs
+++ b/__TEST__/e2e/search.spec.mjs
@@ -36,3 +36,39 @@ test('clearing the query clears the marks', async ({ page }) => {
   const after = await search(page, '');
   expect(after).toEqual([]);
 });
+
+// #495 — css/hyperaudio-lite-player.css is byte-identical to upstream again, with
+// the editor's deviations moved into css/hyperaudio-lite-editor.css. Upstream
+// paints .hyperaudio-transcript .search-mark PINK at specificity (0,2,0), so the
+// editor's override has to outrank it; a bare `mark.search-mark` is only (0,1,1)
+// and would lose, turning every hit pink. This guards that arithmetic, which is
+// otherwise invisible until someone re-vendors the file.
+test('the editor\'s search colours outrank the vendored player stylesheet (#495)', async ({ page }) => {
+  await search(page, 'the');
+  const colours = await page.evaluate(() => {
+    const marks = [...document.querySelectorAll('#hypertranscript mark.search-mark')];
+    if (marks.length === 0) return null;
+    marks[0].classList.add('active');
+    const active = getComputedStyle(marks[0]).backgroundColor;
+    marks[0].classList.remove('active');
+    return { hit: getComputedStyle(marks[0]).backgroundColor, active };
+  });
+
+  expect(colours).not.toBeNull();
+  // upstream's pink is rgb(255, 192, 203) — losing the cascade would show it
+  expect(colours.hit).not.toBe('rgb(255, 192, 203)');
+  expect(colours.active).not.toBe('rgb(255, 192, 203)');
+  // the active match stays visually distinct from an ordinary hit
+  expect(colours.active).not.toBe(colours.hit);
+  // and it is the intended amber, on specificity rather than source order
+  expect(colours.active).toBe('rgb(246, 195, 68)');
+});
+
+test('unread words keep the accessibility contrast, not upstream\'s lighter grey (#495)', async ({ page }) => {
+  const colour = await page.evaluate(() => {
+    const el = document.querySelector('#hypertranscript span[data-m].unread');
+    return el === null ? null : getComputedStyle(el).color;
+  });
+  // #666 from 5e37ad6 ("best practices and accessibility"), not upstream's #777
+  if (colour !== null) expect(colour).toBe('rgb(102, 102, 102)');
+});

--- a/__TEST__/e2e/serialization.spec.mjs
+++ b/__TEST__/e2e/serialization.spec.mjs
@@ -115,3 +115,42 @@ test('word timings survive wrappers and stray placement (#486 review)', async ({
   expect(cases.orphan.after).toEqual(cases.orphan.before);
   expect(cases.noParagraphs.after).toEqual(cases.noParagraphs.before);
 });
+
+// #492 — every transcript carries at least one paragraph. Three JSON→markup
+// projections existed, and on paragraph-less input (words present,
+// paragraphs: []) they gave three different answers: jsonToHTML fell back to a
+// single <p>, buildTranscriptDomFromJson synthesised an unbounded range, and
+// jsonToHtml — reachable from the JSON import path and exposed to native apps —
+// emitted <article><section></section></article>, losing every word. They now
+// share one normaliser, so the only acceptable answer is "all the words".
+test('every projection keeps all the words when the JSON has no paragraphs (#492)', async ({ page }) => {
+  const counts = await page.evaluate(() => {
+    const transcript = {
+      words: [
+        { start: 0, end: 0.5, text: 'one' },
+        { start: 0.5, end: 1, text: 'two' },
+        { start: 1, end: 1.5, text: 'three' },
+      ],
+      paragraphs: [],
+    };
+    const spansIn = (html) => {
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      return [...doc.querySelectorAll('span[data-m]:not(.speaker)')].map((s) => s.textContent.trim());
+    };
+    return {
+      normalized: window.normalizeTranscriptParagraphs(transcript).paragraphs,
+      // the transcript's own projection (html-json-converter.js)
+      jsonToHTML: spansIn(window.jsonToHTML(transcript)),
+      // the import / native-app projection (hyperaudio-lite-editor-export.js)
+      jsonToHtml: spansIn(window.jsonToHtml(transcript)),
+      // and the input is not mutated on the way through
+      untouched: transcript.paragraphs.length,
+    };
+  });
+
+  expect(counts.jsonToHTML).toEqual(['one', 'two', 'three']);
+  expect(counts.jsonToHtml).toEqual(['one', 'two', 'three']);
+  // one unattributed paragraph spanning the words (§ 3.6 allows speaker: null)
+  expect(counts.normalized).toEqual([{ start: 0, end: 1.5, speaker: null }]);
+  expect(counts.untouched).toBe(0);
+});

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -378,7 +378,11 @@ dialog::backdrop {
     width: 100%;
     max-width: 100%;
     box-sizing: border-box;
-    padding: 8px 12px 48px;
+    /* Top padding stays at the desktop 48px: the ⓘ and copy buttons are pinned
+       to the card's top corners at holder-top + 10px and are 32px tall, so text
+       starting any higher runs underneath them. The shorthand used to reset this
+       to 8px, which put the first line under both icons at these widths. */
+    padding: 48px 12px 48px;
   }
 
   #playbar {
@@ -645,10 +649,17 @@ html:has(#hypertranscript[aria-busy="true"]) #transcript-info-btn { display: non
 }
 /* the compact navbar band (#480): the holder's top drops 78px -> 58px at
    1120, and both corner buttons must ride the card's edge with it. Bounded
-   below at 949 so the <=948 var-based rules above keep the last word. */
+   below at 949 so the <=948 var-based rules above keep the last word.
+
+   76px, not the holder's 58 + 10: in THIS band the holder also takes 8px of
+   padding and #hypertranscript keeps its own top:10px, so the text column
+   starts at 76 — 58 + 10 parked the buttons 8px above it and left a gap under
+   them half again the size of the one above. Every band aligns the buttons
+   with the transcript element's top edge (88 at >1120, ~290 at <=948); this
+   is that same edge, arrived at through two more offsets. */
 @media screen and (max-width: 1120px) and (min-width: 949px) {
-  #transcript-copy-btn { top: 68px; }
-  #transcript-info-btn { top: 68px; }
+  #transcript-copy-btn { top: 76px; }
+  #transcript-info-btn { top: 76px; }
 }
 
 /* Corner buttons vs scrolling text (#480): the mask-fade experiment was

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -669,14 +669,26 @@ html:has(#hypertranscript[aria-busy="true"]) #transcript-info-btn { display: non
   white-space: nowrap;
 }
 
-/* Search: highlight only the matched substring. searchPhrase wraps the match in
-   <mark class="search-mark"> and also tags the word .search-match — neutralise
-   the vendored whole-word background so just the mark shows, tinted with a much
-   lighter version of the signature purple (the DaisyUI primary at low opacity). */
-.hyperaudio-transcript .search-match {
-  background-color: transparent;
+/* Two deviations from the vendored player stylesheet live here rather than in
+   the file itself (#495), so css/hyperaudio-lite-player.css stays byte-identical
+   to upstream and can be re-vendored without anyone having to notice a fork.
+   This sheet is linked after it, so equal-specificity rules here win. */
+
+/* Unread words sit a shade darker than upstream's #777 — a contrast decision
+   from "best practices and accessibility" (5e37ad6), not drift. */
+.hyperaudio-transcript .unread {
+  color: #666;
 }
-mark.search-mark {
+
+/* Search: highlight only the matched substring. searchPhrase wraps the match in
+   <mark class="search-mark"> and also tags the whole word .search-match. Upstream
+   paints .search-mark pink at (0,2,0), so this must outrank it — hence the
+   descendant + element selector rather than a bare mark.search-mark, which at
+   (0,1,1) would lose and turn every hit pink on the next re-vendor. Tinted with a
+   much lighter version of the signature purple (DaisyUI primary at low opacity).
+   Nothing styles .search-match now, so the whole-word background it used to
+   inherit needs no neutralising. */
+.hyperaudio-transcript mark.search-mark {
   background-color: oklch(var(--p) / 0.22);
   color: inherit;
   border-radius: 2px;
@@ -726,7 +738,10 @@ mark.search-mark {
   white-space: nowrap;
 }
 .replace-spacer { flex: 1; }
-mark.search-mark.active { background-color: #f6c344; color: inherit; border-radius: 2px; }
+/* Outranks both the general hit above and upstream's .search-mark on specificity
+   rather than on source order, so reordering this sheet cannot silently lose the
+   active-match colour. */
+.hyperaudio-transcript mark.search-mark.active { background-color: #f6c344; color: inherit; border-radius: 2px; }
 
 /* When the replace panel is open, drop the transcript start so the panel doesn't
    cover the first line. */

--- a/css/hyperaudio-lite-player.css
+++ b/css/hyperaudio-lite-player.css
@@ -40,11 +40,12 @@
 }
 
 .hyperaudio-transcript .unread {
-  color: #666;
+  color: #777;
 }
 
-.hyperaudio-transcript .search-match {
+.hyperaudio-transcript .search-mark {
   background-color: pink;
+  color: inherit;
 }
 
 .hyperaudio-transcript .share-match {

--- a/docs/hyperaudio-format.md
+++ b/docs/hyperaudio-format.md
@@ -268,6 +268,18 @@ origin.
 
 Rules:
 
+- **At least one paragraph.** A writer **MUST** emit a non-empty
+  `paragraphs` whenever `words` is non-empty. A transcript with no structure
+  is expressed as a single paragraph spanning the words with
+  `speaker: null` — nothing needs inventing, and the DOM equivalent
+  (`<article><section><p>…`) already holds in practice, so this removes an
+  asymmetry rather than adding a constraint.
+- **Readers stay tolerant.** A reader **MUST** accept `paragraphs: []` or an
+  absent `paragraphs` — files predate this rule and third-party JSON needn't
+  carry structure — and **MUST** synthesise the single spanning paragraph
+  above rather than dropping the words. Normalising once, where JSON enters,
+  is what lets everything downstream assume ≥ 1; leaving each projection to
+  handle the gap its own way is how they came to disagree (#492).
 - Times are **seconds** (float) throughout the JSON. (The editor's DOM uses
   integer milliseconds — `data-m`/`data-d`; the conversion is
   `ms = round(s × 1000)`; § 12.)
@@ -649,6 +661,8 @@ excepted.
 - [ ] writes `mimetype` as the first entry, STORE, exact content
 - [ ] writes `hyperaudio.json` with all required fields, times in seconds,
       defaults (`space: true`, `struck: false`) not serialized
+- [ ] writes at least one `transcript.paragraphs` entry whenever there are
+      words (§ 3.6)
 - [ ] writes `transcript.html` and `captions.vtt` consistent with the JSON of
       the same save
 - [ ] writes `transcript.original.json` once (at transcription time) and
@@ -675,6 +689,8 @@ excepted.
 - [ ] ignores unknown fields and files
 - [ ] tolerates the absence of `mimetype`, `transcript.html`,
       `transcript.original.json`, `captions.vtt`
+- [ ] tolerates an empty or absent `transcript.paragraphs`, synthesising one
+      unattributed paragraph spanning the words (§ 3.6)
 
 ---
 
@@ -687,6 +703,7 @@ excepted.
 | `struck` travels in the save, is applied at export | Redactions are reversible as long as you are in the working file. |
 | Captions ≠ transcript (§ 6.1) | Never "repair" the divergence: with `updateFromTranscript: false` it is intentional. |
 | Origin ≠ working copy (§ 5) | `transcript.original.json` is immutable and pre-redaction: never load it in place of the working transcript, never "update" it. |
+| At least one paragraph whenever there are words (§ 3.6) | Writers guarantee it, readers synthesise it. Every JSON→markup projection may then assume ≥ 1; when they each answered the paragraph-less case separately, one of them emitted an empty `<section>` and lost the whole transcript. |
 | The file is untrusted input (§ 10) | Whitelist-read, validation, DOM via `textContent`, sanitization of the HTML fallback. |
 | UTF-8 everywhere | Media filenames included (the zip's UTF-8 flag). |
 | One media file, original name | No ambiguity, no index to maintain. |

--- a/docs/hyperaudio-format.md
+++ b/docs/hyperaudio-format.md
@@ -312,13 +312,25 @@ Role:
    storage) consume it without converters.
 2. **Inspectability**: opening the zip, a browser displays the transcript
    directly.
-3. **Safety net**: if the JSON round-trip ever had a bug, the editor's data
-   is still there.
+
+This entry is **not** an independent witness to the transcript. It is a
+projection of `hyperaudio.json.transcript`, so it cannot hold anything the
+JSON lost — the earlier "safety net" role is traded for guaranteed
+consistency. That trade is deliberate (#489): two independent derivations of
+the same transcript can disagree, and a second copy that disagrees is worse
+than no second copy.
 
 **Anti-divergence rule:** the source of truth is
 `hyperaudio.json.transcript`. The writer **MUST** generate `transcript.html`
-from the same state in the same save (the two files are consistent by
-construction).
+from that JSON in the same save — not from a second reading of its own
+editing surface, which makes the two entries consistent by construction
+rather than by promise.
+
+A writer **MAY** compare the word count it parsed against the words its
+editor holds, and against the words in the generated HTML. If either
+disagrees, it **SHOULD** write its raw transcript markup to this entry
+instead and record why: the parse or the projection is suspect exactly then,
+and the unprojected markup is the only copy that still has every word.
 
 **Fallback rules:** the reader **MUST** load from the JSON; using
 `transcript.html` as a source is allowed **only as recovery**, when the JSON

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ If you are creating an open source application under a license compatible with t
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png">
-  <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
+  <link rel="stylesheet" href="css/hyperaudio-lite-player.css?v=2.6.4">
 
   <!-- Vendored ESM dependencies for media export (#381) — bare specifiers used
        by js/media-export.js and by @mediabunny/mp3-encoder's internal
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.1.6">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.1.9">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1036,7 +1036,7 @@ If you are creating an open source application under a license compatible with t
 
   <script src="js/hyperaudio-push-notification.js"></script>
   <script src="js/hyperaudio-lite.js?v=2.6.4"></script>
-  <script src="js/hyperaudio-lite-extension.js?v=0.7.2"></script>
+  <script src="js/hyperaudio-lite-extension.js?v=0.7.3"></script>
   <script src="js/caption.js?v=0.8.6"></script>
   <script src="js/transcript-serializer.js?v=1.1.8"></script>
   <script src="js/editor-core.js?v=1.1.9"></script>

--- a/index.html
+++ b/index.html
@@ -1095,7 +1095,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=0.7.4"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.1.8"></script>
+  <script src="js/hyperaudio-save.js?v=1.1.9"></script>
   <script src="js/hyperaudio-library.js?v=1.1.6"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-editor-whisper.js?v=1.1.2"></script>
   <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=1.1.2"></script>
   <script src="js/word-alignment.js"></script>
-  <script src="js/html-json-converter.js?v=1.0.0"></script>
+  <script src="js/html-json-converter.js?v=1.1.9"></script>
   <script src="js/transcript-to-ionosphere.js?v=1.1.1"></script>
   <script src="js/paragraph-timecodes.js?v=0.6.20"></script>
 
@@ -1049,7 +1049,7 @@ If you are creating an open source application under a license compatible with t
 
   <script src="js/editor-file-menu.js?v=1.0.0"></script>
 
-  <script src="./js/hyperaudio-lite-editor-export.js?v=1.1.8" type="module"> </script>
+  <script src="./js/hyperaudio-lite-editor-export.js?v=1.1.9" type="module"> </script>
   <!-- end of localstorage additions -->
 
   <!-- caption editor additions -->

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.1.8 (last changed in release 1.1.8) -->
+<!--  Hyperaudio Lite Editor - Version 1.1.9 (last changed in release 1.1.9) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.1.8">
+  <meta name="version" content="1.1.9">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">

--- a/index.html
+++ b/index.html
@@ -1039,7 +1039,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-extension.js?v=0.7.2"></script>
   <script src="js/caption.js?v=0.8.6"></script>
   <script src="js/transcript-serializer.js?v=1.1.8"></script>
-  <script src="js/editor-core.js?v=1.1.8"></script>
+  <script src="js/editor-core.js?v=1.1.9"></script>
 
 
   <import-deepgram-json></import-deepgram-json>

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -105,11 +105,24 @@
     }
   });
 
+  // Paste the clipboard's PLAIN text as plain text (#487). insertHTML parsed it
+  // as markup, so anything between < and > became an element instead of
+  // characters: pasting the literal "<inaudible>" produced an empty <inaudible>
+  // element and the word rendered as nothing — silently destroyed, and absent
+  // from the saved JSON. insertText inserts characters, so angle brackets
+  // survive as text (the invariant transcript-serializer.js already documents
+  // for words like "<inaudible>", #406/#409), and it still participates in
+  // native contenteditable undo, which matters until #400 owns undo itself.
+  //
+  // The "&nbsp;" replacement that stood here was a no-op — it discarded its
+  // return value, and plain-text clipboard content carries U+00A0 rather than
+  // that literal string. It was guarding against insertHTML decoding a pasted
+  // "&nbsp;" into a space, which insertText cannot do. normalizeTranscriptSpans
+  // converts real nbsp characters on the next pass either way (#339).
   editableDiv.addEventListener("paste", function(e) {
     e.preventDefault();
-    var text = e.clipboardData.getData("text/plain");
-    text.replaceAll("&nbsp;", " ");
-    document.execCommand("insertHTML", false, text);
+    const text = e.clipboardData.getData("text/plain");
+    document.execCommand("insertText", false, text);
   });
 
   window.document.addEventListener('hyperaudioInit', hyperaudio, false);

--- a/js/html-json-converter.js
+++ b/js/html-json-converter.js
@@ -88,17 +88,58 @@ function escapeHTMLText(text) {
     .replace(/"/g, '&quot;');
 }
 
+/**
+ * FUNCTION: normalizeTranscriptParagraphs
+ *
+ * PURPOSE: Guarantee the "at least one paragraph" invariant (#492).
+ *
+ * WHY: paragraph-less JSON is reachable — htmlToJSON returns none whenever the
+ *      DOM has no <p>, writeOriginOnce defaulted to [], and imported
+ *      third-party JSON needn't carry structure at all. Each projection then
+ *      handled the gap its own way, and one of the three dropped every word.
+ *      Normalising once, at the point JSON arrives, lets every projection
+ *      downstream assume >= 1 and deletes that whole class of edge case.
+ *
+ * The synthesised paragraph spans the words and is unattributed — § 3.6 allows
+ * speaker: null, so a structureless transcript is expressible without
+ * inventing anything. A transcript with no words still gets one (0/0): the
+ * invariant is simpler with no exception, and the projections drop an empty
+ * paragraph anyway.
+ *
+ * Non-mutating, and unknown fields are carried over (§ 8.1).
+ */
+function normalizeTranscriptParagraphs(transcript) {
+  const source = (transcript !== null && typeof transcript === 'object') ? transcript : {};
+  const words = source.words || [];
+  const paragraphs = source.paragraphs || [];
+  if (paragraphs.length > 0) return source;
+
+  let start = 0;
+  let end = 0;
+  if (words.length > 0) {
+    // min/max rather than first/last: nothing guarantees the caller sorted them
+    start = words[0].start;
+    end = words[0].end;
+    words.forEach((word) => {
+      if (word.start < start) start = word.start;
+      if (word.end > end) end = word.end;
+    });
+  }
+  return Object.assign({}, source, { paragraphs: [{ start, end, speaker: null }] });
+}
+
 function jsonToHTML(jsonData) {
-  const words = jsonData.words || [];
-  const paragraphs = jsonData.paragraphs || [];
-  
+  // >= 1 paragraph guaranteed here (#492), so the single-paragraph fallback
+  // this function used to carry — a second, separately maintained copy of the
+  // word-emitting loop — is gone.
+  const normalized = normalizeTranscriptParagraphs(jsonData);
+  const words = normalized.words || [];
+  const paragraphs = normalized.paragraphs;
+
   // Start HTML structure
   let html = '<article><section>\n';
-  
-  if (paragraphs.length > 0) {
-    // ===== MULTI-PARAGRAPH CASE =====
-    // Generate separate <p> tags based on paragraph data
 
+  {
     // Assign EVERY word to a paragraph — never drop (#408). The old half-open
     // range filter (start >= pStart && start < pEnd) silently deleted words:
     // a zero-duration last word (end == start) failed its own paragraph's
@@ -154,27 +195,8 @@ function jsonToHTML(jsonData) {
       
       html += '  </p>\n';
     });
-    
-  } else {
-    // ===== SINGLE PARAGRAPH FALLBACK =====
-    // No paragraph data, put all words in one <p>
-    html += '  <p>\n';
-    
-    words.forEach((word, wordIndex) => {
-      const startMs = Math.round(word.start * 1000);
-      const endMs = Math.round(word.end * 1000);
-      const durationMs = endMs - startMs;
-      const trail = word.space === false ? '' : ' ';
-      const strike = word.struck === true ? ' style="text-decoration: line-through;"' : '';
-      const gluedToPrev = wordIndex > 0 && words[wordIndex - 1].space === false;
-      const lead = wordIndex === 0 ? '    ' : gluedToPrev ? '' : '\n    ';
-      html += `${lead}<span data-m="${startMs}" data-d="${durationMs}"${strike}>${escapeHTMLText(word.text)}${trail}</span>`;
-    });
-    html += '\n';
-    
-    html += '  </p>\n';
   }
-  
+
   html += '</section></article>';
   
   return html;
@@ -332,6 +354,14 @@ function htmlToJSON(html) {
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     jsonToHTML,
-    htmlToJSON
+    htmlToJSON,
+    normalizeTranscriptParagraphs
   };
+}
+
+// Loaded as a plain <script> ahead of every other editor script, so the
+// projections in hyperaudio-save.js and hyperaudio-lite-editor-export.js
+// (a module — it reads this off window) can share the one normaliser.
+if (typeof window !== 'undefined') {
+  window.normalizeTranscriptParagraphs = normalizeTranscriptParagraphs;
 }

--- a/js/hyperaudio-lite-editor-export.js
+++ b/js/hyperaudio-lite-editor-export.js
@@ -567,8 +567,20 @@ function htmlToJson(html) {
 // Convert JSON to Hypertranscript HTML. Accepts the flat shape
 // { words, paragraphs, sections } produced by htmlToJson.
 function jsonToHtml(jsonData) {
-  const words = (jsonData && jsonData.words) || [];
-  const paragraphs = (jsonData && jsonData.paragraphs) || [];
+  // Paragraph-less input used to produce <article><section></section></article>
+  // — every word silently gone, because the emit loop below is driven entirely
+  // by paragraphs and there were none. That was reachable from the JSON import
+  // path above and from native-app callers of window.jsonToHtml, so this needs
+  // its own guarantee (#492) rather than relying on a normalised caller: the
+  // shared normaliser when it is loaded, an inline span otherwise.
+  const normalized = typeof window !== 'undefined' && typeof window.normalizeTranscriptParagraphs === 'function'
+    ? window.normalizeTranscriptParagraphs(jsonData)
+    : jsonData;
+  const words = (normalized && normalized.words) || [];
+  const fromNormaliser = (normalized && normalized.paragraphs) || [];
+  const paragraphs = fromNormaliser.length > 0 || words.length === 0
+    ? fromNormaliser
+    : [{ start: words[0].start, end: words[words.length - 1].end, speaker: null }];
   const sections = (jsonData && jsonData.sections && jsonData.sections.length > 0)
     ? jsonData.sections
     : [{ start: -Infinity, end: Infinity }];

--- a/js/hyperaudio-lite-extension.js
+++ b/js/hyperaudio-lite-extension.js
@@ -1,5 +1,21 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
 
+/*
+ * A FORK, not a vendored copy — do not overwrite this from upstream (#495).
+ *
+ * It began as hyperaudio-lite's extension and has since diverged substantially:
+ * ours carries the editor's search-form wiring and playback-rate controls, which
+ * upstream has no notion of, and its search predates upstream's search-mark
+ * rewrite. It also carries its own ?v= in index.html rather than tracking the
+ * library's version.
+ *
+ * Of the four files that look vendored from hyperaudio-lite, only
+ * js/hyperaudio-lite.js and js/caption.js genuinely are (both byte-identical to
+ * upstream v2.6.4 and safe to replace). css/hyperaudio-lite-player.css was
+ * returned to byte-identical in #495, with the editor's two deviations moved
+ * into css/hyperaudio-lite-editor.css. This file is the one real fork.
+ */
+
 'use strict';
 // Example wrapper for hyperaudio-lite with search and playbackRate included
 

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.1.8 — last changed in release 1.1.8
+ * @version 1.1.9 — last changed in release 1.1.9
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind
@@ -650,46 +650,79 @@
     return new Date().toISOString();
   }
 
-  // Canonical serialization of a transcript root for the writer (#486). Raw
-  // innerHTML shipped whatever the live DOM had accumulated straight into
-  // transcript.html — search's <mark class="search-mark">, elements a paste
-  // injected (#487), WebKit inline styles — but § 4 of the format defines that
-  // entry as one <span> per word. serializeTranscriptHtml rebuilds each span
-  // from textContent, keeping the two functional bits of state (speaker class,
-  // strikethrough), so foreign markup is flattened to its text rather than
-  // persisted.
+  // THE authoritative read of the transcript (#489): the live element's raw
+  // innerHTML, or the caption-mode clone's, with only the class strip applied.
+  // Nothing may transform it on the way in. htmlToJSON's selectors are
+  // descendant-based, so a word span is found wherever editing has left it —
+  // inside a wrapper the browser added, outside any <p> — and the JSON gets every
+  // word. #486 briefly ran this through the canonical serializer instead, which
+  // put the source of truth downstream of a presentation transform: two shapes
+  // the serializer flattened stopped being cosmetic and started deleting words
+  // from the container outright.
   //
-  // The word set is preserved, which matters because gather() derives the
-  // project JSON from this same string: the serializer descends into wrappers
-  // that enclose timed spans and keeps spans belonging to no <p>, so no word
-  // loses its data-m/data-d (and with it its place in the JSON) on the way out.
-  //
-  // No class strip on the canonical path: the serializer emits class="speaker"
-  // and nothing else, while running the strip's regex over the whole string
-  // could delete a literal class="…" appearing inside a word's own text. The
-  // innerHTML fallback — loader markup mid transcription, no timed spans yet —
-  // still sanitizes exactly as it did before.
-  function canonicalTranscriptHtml(root) {
-    const hasWords = typeof root.querySelector === 'function'
-      && root.querySelector('span[data-m]') !== null;
-    if (hasWords && typeof serializeTranscriptHtml === 'function') {
-      return serializeTranscriptHtml(root);
-    }
-    return sanitizeTranscriptClasses(root.innerHTML);
-  }
-
-  // The transcript's markup for the writer. Reads the live element directly
-  // (NOT getTranscriptData(), whose blanket class strip destroys the speaker
-  // class); in caption mode the transcript element only exists inside
-  // editor-core's transcriptCache clone — read it from there.
-  function getEditorHtml() {
+  // NOT getTranscriptData(), whose blanket class strip destroys the speaker class.
+  function getEditorTranscriptHtml() {
     const el = document.querySelector('#hypertranscript');
-    if (el !== null) return canonicalTranscriptHtml(el);
+    if (el !== null) return sanitizeTranscriptClasses(el.innerHTML);
     if (typeof transcriptCache !== 'undefined' && transcriptCache !== null) {
       const cached = transcriptCache.querySelector('#hypertranscript');
-      if (cached !== null) return canonicalTranscriptHtml(cached);
+      if (cached !== null) return sanitizeTranscriptClasses(cached.innerHTML);
     }
     return typeof getTranscriptData === 'function' ? getTranscriptData() : '';
+  }
+
+  // The transcript JSON — the container's source of truth. One parse, one place.
+  function getEditorTranscriptJson() {
+    return htmlToJSON(getEditorTranscriptHtml());
+  }
+
+  const wordSpanCount = (html) => {
+    try {
+      return new DOMParser().parseFromString(String(html), 'text/html')
+        .querySelectorAll('span[data-m]:not(.speaker)').length;
+    } catch (e) {
+      return -1; // unknown; the invariant below treats that as "don't judge"
+    }
+  };
+
+  // transcript.html is a PROJECTION of the JSON, not a second reading of the DOM
+  // (§ 4 calls it the compatibility copy, generated from the same state in the
+  // same save). jsonToHTML is the same writer the alignment path already uses, so
+  // the two entries cannot disagree by construction — where two independent
+  // derivations could, and § 4's anti-divergence rule would be a promise the code
+  // had to keep rather than one it holds structurally.
+  //
+  // The invariant is checked rather than assumed: every word span in the DOM must
+  // survive into the JSON, and every JSON word into the projection. On a mismatch
+  // the raw source is written instead and the discrepancy logged — § 4's MAY/SHOULD
+  // for exactly this case. A projection can hold nothing the JSON lost, so when the
+  // parse or the projection is suspect, the unprojected markup is the only copy
+  // left with every word in it. (§ 4 no longer claims this entry is an independent
+  // witness in the normal case; that role went with the change, deliberately.)
+  function projectTranscriptHtml(transcript, source) {
+    const words = (transcript && transcript.words) || [];
+    // no timed words yet — loader markup mid-transcription; pass it through as
+    // before rather than projecting an empty article over it
+    if (words.length === 0) return source;
+    if (typeof jsonToHTML !== 'function') return source;
+
+    const inDom = wordSpanCount(source);
+    if (inDom >= 0 && inDom !== words.length) {
+      console.warn('hyperaudio-save: transcript parse lost words —'
+        + ` ${inDom} word spans in the editor, ${words.length} in the JSON.`
+        + ' Writing the raw transcript markup so nothing is dropped from both.');
+      return source;
+    }
+
+    const projected = jsonToHTML(transcript);
+    const inProjection = wordSpanCount(projected);
+    if (inProjection >= 0 && inProjection !== words.length) {
+      console.warn('hyperaudio-save: transcript projection lost words —'
+        + ` ${words.length} in the JSON, ${inProjection} in the generated HTML.`
+        + ' Writing the raw transcript markup instead.');
+      return source;
+    }
+    return projected;
   }
 
   function getCaptionsVtt() {
@@ -771,8 +804,11 @@
   // Snapshot the full editor state for the writer. Pure DOM reads; the media
   // bytes themselves are handled separately (write-once / resolve-on-demand).
   function gather() {
-    const html = getEditorHtml();
-    const transcript = htmlToJSON(html);
+    // One read of the DOM, parsed once; the HTML entry is projected from the
+    // resulting JSON rather than read again (#489).
+    const source = getEditorTranscriptHtml();
+    const transcript = htmlToJSON(source);
+    const html = projectTranscriptHtml(transcript, source);
     const versionMeta = document.querySelector('meta[name="version"]');
     const titleField = document.querySelector('#project-title'); // #449's field, when present
     const summaryEl = document.getElementById('summary');
@@ -1317,7 +1353,7 @@
     try {
       if (opfsAvailable && session.projectId !== null) {
         await acquireProjectLock(session.projectId); // fresh id: always granted
-        await writeOriginOnce(htmlToJSON(getEditorHtml()));
+        await writeOriginOnce(getEditorTranscriptJson());
         await resolveMediaFile();
         await writeMediaOnce();
         await commitInitialState(session.projectId); // v0: as transcribed/imported
@@ -2535,7 +2571,7 @@
     getProjectTitle: () => session.title || (session.mediaFile !== null ? session.mediaFile.name : '') || '',
     // the document exports (#467) read the transcript through here: the same
     // speaker-preserving, caption-mode-aware gather the save path uses
-    getTranscriptJson: () => htmlToJSON(getEditorHtml()),
+    getTranscriptJson: () => getEditorTranscriptJson(),
     loadJSZip, // shared vendored-zip loader (the .docx export packages with it)
     openFromFile,
     autosaveNow: writeDraft,

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -207,6 +207,24 @@
     return { ok: errors.length === 0, errors };
   }
 
+  // The >= 1 paragraph normaliser (#492) lives in html-json-converter.js: a
+  // plain global in the browser (it loads first), a require in the node
+  // pure-layer tests — buildProjectJson is exported to those, so the invariant
+  // has to hold on both sides or "writers emit at least one paragraph" is only
+  // half true. Resolved once; null only if the converter is missing entirely,
+  // and every caller below falls back to what it did before.
+  const paragraphNormalizer = (function () {
+    if (typeof normalizeTranscriptParagraphs === 'function') return normalizeTranscriptParagraphs;
+    if (typeof require === 'function') {
+      try {
+        return require('./html-json-converter.js').normalizeTranscriptParagraphs || null;
+      } catch (e) {
+        return null;
+      }
+    }
+    return null;
+  })();
+
   // Assemble a complete hyperaudio.json object from gathered state. Defaults
   // (space: true, struck: false) are already omitted by htmlToJSON; times are
   // seconds throughout (the DOM's data-m/data-d are ms — ms = round(s × 1000)).
@@ -241,7 +259,13 @@
         summary: state.texts.summary || '',
         topics: Array.isArray(state.texts.topics) ? state.texts.topics : [],
       }),
-      transcript: state.transcript,
+      // Writers emit at least one paragraph (§ 3.6, #492). One line covers
+      // every path — the silent save, Export Project, the flattened export —
+      // because they all assemble their JSON through here.
+      transcript: (state.transcript !== null && state.transcript !== undefined
+        && paragraphNormalizer !== null)
+        ? paragraphNormalizer(state.transcript)
+        : state.transcript,
     });
     if (state.provenance && (state.provenance.engine || state.provenance.model)) {
       project.provenance = Object.assign({}, state.provenance);
@@ -854,9 +878,16 @@
   // textContent only (spec § 10.5: never innerHTML on file data).
   function buildTranscriptDomFromJson(transcript) {
     const words = transcript.words || [];
+    // >= 1 paragraph via the shared normaliser (#492) — the local
+    // -Infinity/Infinity synthesis this replaces was a third answer to the
+    // same question, and the three projections disagreed. The inline fallback
+    // stays: readers MUST tolerate paragraph-less input, and this one runs
+    // against file data.
     const paragraphs = (transcript.paragraphs && transcript.paragraphs.length > 0)
       ? transcript.paragraphs
-      : [{ start: -Infinity, end: Infinity, speaker: null }];
+      : (paragraphNormalizer !== null
+        ? paragraphNormalizer(transcript).paragraphs
+        : [{ start: -Infinity, end: Infinity, speaker: null }]);
     const article = document.createElement('article');
     const section = document.createElement('section');
     article.appendChild(section);
@@ -1299,7 +1330,11 @@
         if (w.space === false) word.space = false;
         return word;
       }),
-      paragraphs: transcript.paragraphs || [],
+      // the origin is a written file too, so it carries the invariant (#492) —
+      // this defaulted to [], one of the places paragraph-less JSON came from
+      paragraphs: (paragraphNormalizer !== null
+        ? paragraphNormalizer(transcript).paragraphs
+        : transcript.paragraphs || []),
     };
     session.hasOriginal = true;
     session.originalJson = JSON.stringify(clean, null, 2);


### PR DESCRIPTION
Fixes #495
Fixes #487
Fixes #489
Fixes #492

Four issues, all in the area where the transcript becomes a file and comes back.

## The transcript is read once, and everything else is derived from it (#489)

#486 routed the writer's transcript read through `serializeTranscriptHtml`, and `gather()` derived the project JSON from that same string — putting the authoritative data downstream of a presentation transform. A serializer edge case stopped being cosmetic and became permanent word loss: a `<b>` wrapping two of four words saved two, and a word parked outside any `<p>` saved one of two.

`gather()` now reads the DOM once, parses it once, and *projects* `transcript.html` from the resulting JSON with `jsonToHTML`. The two entries cannot disagree by construction rather than by promise. The word count is checked in both directions and a mismatch writes the raw markup and logs why — § 4 of the format doc drops its "safety net" role accordingly, since a projection can hold nothing the JSON lost.

## Every transcript carries at least one paragraph (#492)

Three JSON→markup projections each answered paragraph-less input their own way, and one — reachable from the JSON import path and exposed as `window.jsonToHtml` for native apps — emitted an empty `<section>`, losing every word. One shared normaliser now serves all three plus `buildProjectJson`, the choke point every `hyperaudio.json` passes through. Readers stay tolerant, as § 3.6 now says explicitly.

Net production code: +55 lines of logic, −33, most of the diff being comments and a duplicated word-emitting loop that went away.

## Paste inserts text, not markup (#487)

The paste handler fed `text/plain` to `execCommand("insertHTML")`, which parses it — pasting the literal `<inaudible>` produced an empty element, so the word rendered as nothing and never reached the saved JSON. `insertText` inserts characters.

## The player stylesheet returns to upstream (#495)

`css/hyperaudio-lite-player.css` is byte-identical to upstream 2.6.4 again, with the editor's two deviations moved into our own stylesheet where they belong. Of the four files that looked vendored, only two genuinely were; `hyperaudio-lite-extension.js` is a real fork and now says so in its header.

## Also

The transcript's ⓘ and copy buttons no longer sit on the first line of text. Below 948px a padding shorthand had reset the transcript's top padding to 8px while the buttons stayed pinned at the card's top; in the 949–1120 band the opposite, with the buttons floating 8px *above* the text column. Each breakpoint hard-codes those offsets separately, which is what let them drift.

## Tests

109 passing, up from 104. New: two for #489 (a wrapper around word spans, and HTML/JSON agreement), two for #492 (all projections keep every word on paragraph-less input, and a paragraph-less file opens whole), and one for the corner buttons across five widths.

Each new test was verified to fail without its fix. Worth noting one that didn't: the first corner-button test passed against the broken CSS because it guarded on `offsetParent`, which is always `null` for `position: fixed` elements — it was skipping both buttons. Fixed to use computed style and a non-zero rect.

## Not addressed

`css/hyperaudio-lite-player.css` and `js/hyperaudio-lite-extension.js` both changed content while keeping their existing `?v=` (2.6.4 and 0.7.3 — upstream/fork versions, not the app release). For the stylesheet the editor's own CSS overrides both changed rules, so a stale cached copy is harmless; for the extension the change is comment-only. Flagged rather than silently renumbered.

Filed while working, not fixed here: #502, #503, #504 (export/import feedback and the missing open guard), #505 (caption structure edits leave the project clean), #506 (warning house style).
