### PR TITLE
Version 1.2.0

### DIFF
--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -834,3 +834,73 @@ test('a project with no paragraphs opens whole and is written back with one (#49
   expect(transcript.words.map((w) => w.text)).toEqual(['Benvenuto', 'ehm', 'a']);
   expect(transcript.paragraphs.length).toBeGreaterThanOrEqual(1);
 });
+
+// Undo landing exactly on the last committed state clears the dirty dot (the
+// VS Code / NSDocument semantics) — compared by state signature, not by step
+// count, so a pending edit undo can't reach keeps the dot honest.
+test('undo back to the last save clears the dirty dot and retires the draft', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page); // v0 committed: the screen IS the saved state
+
+  // a real keystroke, so the history module owns the edit
+  await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    t.focus();
+    const span = t.querySelector('span[data-m]:not(.speaker)');
+    const sel = window.getSelection();
+    const r = document.createRange();
+    r.setStart(span.firstChild, 2);
+    r.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(r);
+  });
+  await page.keyboard.type('ZZ');
+  await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
+
+  await page.keyboard.press('Meta+z');
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+
+  // the pre-undo draft dies with the cleanliness — reload must not resurrect
+  // "unsaved edits" that no longer exist
+  await pollPage(page, async () => {
+    const id = window.HyperaudioSave.library.currentId();
+    const root = await navigator.storage.getDirectory();
+    const dir = await (await root.getDirectoryHandle('work')).getDirectoryHandle(id);
+    try { await dir.getFileHandle('draft.json'); return false; } catch (e) { return true; }
+  });
+
+  // and redoing away from the save is dirty again
+  await page.keyboard.press('Shift+Meta+z');
+  await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
+});
+
+test('undo does not clear the dot while a non-transcript edit is pending', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+
+  // an edit undo cannot reach: the summary
+  await page.evaluate(() => {
+    const s = document.getElementById('summary');
+    s.textContent = 'still pending';
+    s.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
+
+  await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    t.focus();
+    const span = t.querySelector('span[data-m]:not(.speaker)');
+    const sel = window.getSelection();
+    const r = document.createRange();
+    r.setStart(span.firstChild, 2);
+    r.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(r);
+  });
+  await page.keyboard.type('ZZ');
+  await page.keyboard.press('Meta+z'); // transcript back to saved; summary is not
+
+  await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
+});

--- a/__TEST__/e2e/responsive.spec.mjs
+++ b/__TEST__/e2e/responsive.spec.mjs
@@ -92,3 +92,45 @@ test('audio-only collapses the pinned player to the controls strip', async ({ pa
   expect((await rect(page, '.transcript-holder')).y).toBeLessThan(before);
   expect(await page.evaluate(() => document.body.classList.contains('video-collapsed'))).toBe(true);
 });
+
+// The undo/redo corner float (#400): touch-only, riding the transcript card's
+// top edge like ⓘ/copy. The default test context is a fine-pointer device, so
+// here they must be hidden regardless of viewport width.
+test('undo/redo buttons are hidden on fine-pointer devices', async ({ page }) => {
+  await expect(page.locator('#transcript-undo')).toBeHidden();
+  await expect(page.locator('#transcript-redo')).toBeHidden();
+});
+
+test.describe('touch devices', () => {
+  test.use({ isMobile: true, hasTouch: true });
+
+  test('undo/redo float on the card edge, clear of the copy button and the text', async ({ page }) => {
+    const boxes = await page.evaluate(() => {
+      const box = (s) => {
+        const el = document.querySelector(s);
+        const cs = getComputedStyle(el);
+        if (cs.display === 'none' || cs.visibility === 'hidden') return null;
+        const r = el.getBoundingClientRect();
+        return { top: r.top, bottom: r.bottom, left: r.left, right: r.right };
+      };
+      return {
+        undo: box('#transcript-undo'),
+        redo: box('#transcript-redo'),
+        copy: box('#transcript-copy-btn'),
+        word: box('#hypertranscript [data-m]'),
+        transcript: box('#hypertranscript'),
+      };
+    });
+    expect(boxes.undo).not.toBeNull();
+    expect(boxes.redo).not.toBeNull();
+    // riding the same top edge as the rest of the corner family
+    for (const name of ['undo', 'redo']) {
+      expect(Math.abs(boxes[name].top - boxes.transcript.top),
+        `${name} off the transcript's top edge`).toBeLessThanOrEqual(4);
+      expect(boxes[name].bottom, `${name} overlaps the first line`).toBeLessThanOrEqual(boxes.word.top);
+    }
+    // ↶ ↷ 📋 in a row, no overlaps
+    expect(boxes.undo.right).toBeLessThanOrEqual(boxes.redo.left);
+    if (boxes.copy !== null) expect(boxes.redo.right).toBeLessThanOrEqual(boxes.copy.left);
+  });
+});

--- a/__TEST__/e2e/span-merge.spec.mjs
+++ b/__TEST__/e2e/span-merge.spec.mjs
@@ -365,3 +365,82 @@ test('suppressing formatting leaves typing and redaction alone', async ({ page }
   expect(struck).toBe(true);
   expect(await page.locator('#hypertranscript b, #hypertranscript i').count()).toBe(0);
 });
+
+// #511 — the caret survives the debounced sanitise pass. The nbsp walk ran
+// BEFORE the caret was saved: rewriting nodeValue on the caret's own text node
+// collapses the selection to a node boundary, so the save recorded the corpse
+// and the restore reproduced it — after every natural typing pause the caret
+// parked before the word being typed, and the next keystrokes landed there.
+test('the caret stays where the user typed across the sanitise pass (#511)', async ({ page }) => {
+  // caret at the end of a word span, then real typing (this is what leaves
+  // nbsp in the node — the trigger)
+  await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    t.focus();
+    const span = [...t.querySelectorAll('span[data-m]')].find((s) => s.textContent.trim() === 'makes');
+    const sel = window.getSelection();
+    const r = document.createRange();
+    r.setStart(span.firstChild, span.firstChild.nodeValue.length);
+    r.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(r);
+  });
+  await page.keyboard.type('scooby dooby doo ');
+  await page.waitForTimeout(1600); // past the debounced sanitise (splits fire)
+
+  const r = await page.evaluate(() => {
+    const sel = window.getSelection();
+    return {
+      // the caret must sit at the end of the last typed word, inside its span
+      anchorText: sel.anchorNode && sel.anchorNode.nodeValue,
+      atEnd: sel.anchorNode && sel.anchorOffset === sel.anchorNode.nodeValue.length,
+      spans: [...document.querySelectorAll('#hypertranscript span[data-m]')]
+        .map((s) => s.textContent.trim()).filter((t) => /^(scooby|dooby|doo)$/.test(t)),
+    };
+  });
+  expect(r.spans).toEqual(['scooby', 'dooby', 'doo']); // the split still works
+  expect(r.anchorText).toBe('doo ');
+  expect(r.atEnd).toBe(true);
+});
+
+test('the caret survives a pass where only the nbsp rewrite fires (#511)', async ({ page }) => {
+  // one word, no internal space: no split/merge/reflow — the old restore
+  // condition skipped this case entirely, so the nbsp rewrite alone lost the
+  // caret with nothing to put it back
+  await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    t.focus();
+    const span = [...t.querySelectorAll('span[data-m]')].find((s) => s.textContent.trim() === 'makes');
+    const sel = window.getSelection();
+    const r = document.createRange();
+    r.setStart(span.firstChild, 2);
+    r.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(r);
+  });
+  await page.keyboard.type('X');
+  // force an nbsp into the caret's node the way contenteditable does
+  await page.evaluate(() => {
+    const sel = window.getSelection();
+    const node = sel.anchorNode;
+    const offset = sel.anchorOffset;
+    node.nodeValue = node.nodeValue.replace(/^ma/, 'ma '.slice(0, 2)) // no-op guard
+      || node.nodeValue;
+    // put a real nbsp after the caret so the walk must rewrite THIS node
+    node.nodeValue = node.nodeValue.slice(0, offset) + ' ' + node.nodeValue.slice(offset + 1);
+    const r = document.createRange();
+    r.setStart(node, offset);
+    r.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(r);
+  });
+  await page.keyboard.press('Shift'); // a keyup to reset the sanitise timer
+  await page.waitForTimeout(1600);
+
+  const r = await page.evaluate(() => {
+    const sel = window.getSelection();
+    return { anchorText: sel.anchorNode && sel.anchorNode.nodeValue, offset: sel.anchorOffset };
+  });
+  expect(r.anchorText).toContain('maX'); // still in the edited word's node
+  expect(r.offset).toBe(3); // right after the typed X
+});

--- a/__TEST__/e2e/transcript-gateway.spec.mjs
+++ b/__TEST__/e2e/transcript-gateway.spec.mjs
@@ -1,0 +1,178 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript span[data-m]');
+});
+
+test('outer transaction owns nesting, returns values, and clears state after errors', async ({ page }) => {
+  const result = await page.evaluate(() => {
+    const before = [];
+    const after = [];
+    const offBefore = transcriptGateway.onBeforeMutate((tx) => before.push(tx.origin));
+    const offAfter = transcriptGateway.onAfterMutate((tx) => after.push({
+      origin: tx.origin,
+      failed: tx.error !== null,
+    }));
+
+    const value = transcriptGateway.mutate(() => transcriptGateway.mutate(
+      () => 42,
+      { origin: 'inner' },
+    ), { origin: 'outer' });
+    let message = null;
+    try {
+      transcriptGateway.mutate(() => { throw new Error('boom'); }, { origin: 'failure' });
+    } catch (error) {
+      message = error.message;
+    }
+    offBefore();
+    offAfter();
+    return {
+      value,
+      message,
+      before,
+      after,
+      isMutating: transcriptGateway.isMutating,
+      current: transcriptGateway.currentTransaction,
+    };
+  });
+
+  expect(result).toEqual({
+    value: 42,
+    message: 'boom',
+    before: ['outer', 'failure'],
+    after: [
+      { origin: 'outer', failed: false },
+      { origin: 'failure', failed: true },
+    ],
+    isMutating: false,
+    current: null,
+  });
+});
+
+test('blur normalization and debounced sanitise cross the gateway', async ({ page }) => {
+  const origins = await page.evaluate(async () => {
+    const seen = [];
+    const off = transcriptGateway.onBeforeMutate((tx) => seen.push(tx.origin));
+    const transcript = document.getElementById('hypertranscript');
+    const span = transcript.querySelector('span[data-m]:not(.speaker)');
+    span.textContent = 'two words ';
+    transcript.focus();
+    transcript.dispatchEvent(new FocusEvent('blur'));
+    document.dispatchEvent(new KeyboardEvent('keyup', { key: 'a', bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    off();
+    return seen;
+  });
+
+  expect(origins).toContain('normalize-blur');
+  expect(origins).toContain('sanitise');
+});
+
+test('Replace One, Replace All, and strike have explicit transaction origins', async ({ page }) => {
+  const result = await page.evaluate(() => {
+    const origins = [];
+    transcriptGateway.onBeforeMutate((tx) => origins.push(tx.origin));
+
+    const searchBox = document.getElementById('search-box');
+    const replaceBox = document.getElementById('replace-box');
+    document.getElementById('find-replace-toggle').click();
+    searchBox.value = 'captions';
+    searchBox.dispatchEvent(new KeyboardEvent('keyup'));
+    replaceBox.value = 'subtitles';
+    document.getElementById('replace-one').click();
+
+    searchBox.value = 'the';
+    searchBox.dispatchEvent(new KeyboardEvent('keyup'));
+    replaceBox.value = 'THE';
+    document.getElementById('replace-all').click();
+
+    const words = document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)');
+    const range = document.createRange();
+    range.selectNodeContents(words[0]);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    document.dispatchEvent(new Event('selectionchange'));
+    document.getElementById('strikethrough').click();
+
+    return {
+      origins,
+      struck: words[0].style.textDecoration.includes('line-through'),
+    };
+  });
+
+  expect(result.origins).toEqual(expect.arrayContaining([
+    'replace-one', 'replace-all', 'strike',
+  ]));
+  expect(result.struck).toBe(true);
+});
+
+test('opt-in audit distinguishes gateway, native, view, and bypass mutations', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const transcript = document.getElementById('hypertranscript');
+    const first = transcript.querySelector('span[data-m]:not(.speaker)');
+    transcriptGateway.audit.start(transcript);
+
+    transcriptGateway.mutate(() => {
+      first.setAttribute('data-d', String((parseInt(first.dataset.d, 10) || 0) + 1));
+    }, { origin: 'test-gateway' });
+
+    first.dispatchEvent(new InputEvent('beforeinput', {
+      bubbles: true,
+      inputType: 'insertText',
+      data: 'x',
+    }));
+    first.firstChild.nodeValue += 'x';
+    first.dispatchEvent(new InputEvent('input', {
+      bubbles: true,
+      inputType: 'insertText',
+      data: 'x',
+    }));
+
+    const searchBox = document.getElementById('search-box');
+    searchBox.value = 'captions';
+    searchBox.dispatchEvent(new KeyboardEvent('keyup'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    first.setAttribute('data-m', String((parseInt(first.dataset.m, 10) || 0) + 1));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const entries = transcriptGateway.audit.stop();
+    return {
+      classifications: entries.map((entry) => entry.classification),
+      origins: entries.map((entry) => entry.origin),
+      violations: entries.filter((entry) => entry.classification === 'unclassified'),
+    };
+  });
+
+  expect(result.classifications).toContain('gateway');
+  expect(result.classifications).toContain('native');
+  expect(result.classifications).toContain('view');
+  expect(result.origins).toContain('test-gateway');
+  expect(result.origins).toContain('search');
+  expect(result.violations).toHaveLength(1);
+  expect(result.violations[0].record).toMatchObject({
+    type: 'attributes',
+    attributeName: 'data-m',
+  });
+});
+
+test('restore guard is nest-safe and suppresses mutation transactions', async ({ page }) => {
+  const result = await page.evaluate(() => {
+    const origins = [];
+    transcriptGateway.onBeforeMutate((tx) => origins.push(tx.origin));
+    const value = transcriptGateway.restoring(() => transcriptGateway.restoring(() => (
+      transcriptGateway.mutate(() => 7, { origin: 'ignored-during-restore' })
+    )));
+    return {
+      value,
+      origins,
+      isRestoring: transcriptGateway.isRestoring,
+    };
+  });
+
+  expect(result).toEqual({ value: 7, origins: [], isRestoring: false });
+});

--- a/__TEST__/e2e/transcript-history.spec.mjs
+++ b/__TEST__/e2e/transcript-history.spec.mjs
@@ -1,0 +1,153 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript span[data-m]');
+  await page.evaluate(() => transcriptHistory.reset('test'));
+});
+
+async function nativeEdit(page, inputType = 'insertText') {
+  await page.evaluate((type) => {
+    const word = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    word.dispatchEvent(new InputEvent('beforeinput', { bubbles: true, inputType: type }));
+    word.firstChild.nodeValue += 'x';
+    word.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: type }));
+  }, inputType);
+}
+
+test('native typing coalesces and structural input forces a boundary', async ({ page }) => {
+  await nativeEdit(page);
+  await nativeEdit(page);
+  expect(await page.evaluate(() => transcriptHistory.inspect())).toMatchObject({ length: 2, position: 1 });
+  await nativeEdit(page, 'insertParagraph');
+  expect(await page.evaluate(() => transcriptHistory.inspect())).toMatchObject({ length: 3, position: 2 });
+});
+
+test('semantic normalization folds into current without clearing redo', async ({ page }) => {
+  const result = await page.evaluate(() => {
+    let word = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    transcriptGateway.mutate(() => { word.textContent += 'A'; }, { origin: 'first' });
+    transcriptGateway.mutate(() => { word.textContent += 'B'; }, { origin: 'second' });
+    transcriptHistory.undo();
+    word = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    const beforeFold = transcriptHistory.inspect();
+    transcriptGateway.mutate(() => { word.setAttribute('data-d', '777'); }, {
+      origin: 'test-normalize', foldPolicy: 'normalization',
+    });
+    const afterFold = transcriptHistory.inspect();
+    const redo = transcriptHistory.redo();
+    return { beforeFold, afterFold, redo };
+  });
+  expect(result.beforeFold).toMatchObject({ length: 3, position: 1 });
+  expect(result.afterFold).toMatchObject({ length: 3, position: 1 });
+  expect(result.redo).toBe(true);
+});
+
+test('keydown fallback and keydown-beforeinput execute exactly once', async ({ page, browserName }) => {
+  const result = await page.evaluate(async () => {
+    const root = document.getElementById('hypertranscript');
+    const word = root.querySelector('span[data-m]:not(.speaker)');
+    root.focus();
+    transcriptGateway.mutate(() => { word.textContent += '1'; }, { origin: 'one' });
+    transcriptGateway.mutate(() => { word.textContent += '2'; }, { origin: 'two' });
+    root.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'z', ctrlKey: true }));
+    root.dispatchEvent(new InputEvent('beforeinput', { bubbles: true, cancelable: true, inputType: 'historyUndo' }));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const paired = transcriptHistory.inspect().position;
+    root.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'z', ctrlKey: true, shiftKey: true }));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return { paired, fallback: transcriptHistory.inspect().position };
+  });
+  expect(result, browserName).toEqual({ paired: 1, fallback: 2 });
+});
+
+test('real platform shortcut performs one step', async ({ page }) => {
+  await page.evaluate(() => {
+    const root = document.getElementById('hypertranscript');
+    const word = root.querySelector('span[data-m]:not(.speaker)');
+    root.focus();
+    transcriptGateway.mutate(() => { word.textContent += '1'; }, { origin: 'one' });
+    transcriptGateway.mutate(() => { word.textContent += '2'; }, { origin: 'two' });
+  });
+  await page.keyboard.press('Meta+z');
+  await page.waitForTimeout(20);
+  expect(await page.evaluate(() => transcriptHistory.inspect().position)).toBe(1);
+});
+
+test('undo preserves backward selection and identity generation', async ({ page }) => {
+  const result = await page.evaluate(() => {
+    const root = document.getElementById('hypertranscript');
+    const text = root.querySelector('span[data-m]:not(.speaker)').firstChild;
+    root.focus();
+    getSelection().setBaseAndExtent(text, Math.min(4, text.length), text, 1);
+    const generation = transcriptLifecycle.generation();
+    transcriptGateway.mutate(() => { text.nodeValue += 'changed'; }, { origin: 'selection-test' });
+    transcriptHistory.undo();
+    return {
+      generation,
+      finalGeneration: transcriptLifecycle.generation(),
+      anchor: getSelection().anchorOffset,
+      focus: getSelection().focusOffset,
+    };
+  });
+  expect(result.finalGeneration).toBe(result.generation);
+  expect({ anchor: result.anchor, focus: result.focus }).toEqual({ anchor: 4, focus: 1 });
+});
+
+test('IME composition becomes one history step', async ({ page }) => {
+  const state = await page.evaluate(async () => {
+    const word = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    word.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    word.firstChild.nodeValue += '日本';
+    word.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertCompositionText', isComposing: true }));
+    word.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '日本' }));
+    word.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText' }));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return transcriptHistory.inspect();
+  });
+  expect(state).toMatchObject({ length: 2, position: 1 });
+});
+
+test('untimed identity clears stale history', async ({ page }) => {
+  const result = await page.evaluate(() => {
+    const root = document.getElementById('hypertranscript');
+    const word = root.querySelector('span[data-m]:not(.speaker)');
+    transcriptGateway.mutate(() => { word.textContent += 'old'; }, { origin: 'old-edit' });
+    root.innerHTML = '<p>An empty untimed document</p>';
+    return { accepted: transcriptLifecycle.signalIdentity('empty'), state: transcriptHistory.inspect() };
+  });
+  expect(result.accepted).toBe(true);
+  expect(result.state).toMatchObject({ length: 0, position: -1 });
+});
+
+test('history is bounded while retaining an undoable baseline', async ({ page }) => {
+  const state = await page.evaluate(() => {
+    for (let index = 0; index < 120; index += 1) {
+      const word = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+      transcriptGateway.mutate(() => { word.setAttribute('data-d', String(1000 + index)); }, {
+        origin: `bounded-${index}`,
+      });
+    }
+    return transcriptHistory.inspect();
+  });
+  expect(state.length).toBeLessThanOrEqual(100);
+  expect(state.position).toBe(state.length - 1);
+  expect(await page.evaluate(() => transcriptHistory.undo())).toBe(true);
+});
+
+test('caption mode is a no-op and touch controls stay unique and accessible', async ({ page }) => {
+  await page.evaluate(() => {
+    const word = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    transcriptGateway.mutate(() => { word.textContent += 'step'; }, { origin: 'step' });
+  });
+  await page.click('#caption-editor-btn');
+  expect(await page.evaluate(() => transcriptHistory.undo())).toBe(false);
+  await expect(page.locator('#transcript-undo')).toBeDisabled();
+  await page.click('#transcript-editor-btn');
+  await expect(page.locator('#transcript-undo')).toBeEnabled();
+  await page.click('#transcript-undo');
+  expect(await page.evaluate(() => document.activeElement.id)).toBe('hypertranscript');
+  await expect(page.locator('#transcript-undo')).toHaveCount(1);
+  await expect(page.locator('#transcript-redo')).toHaveCount(1);
+  await expect(page.locator('#transcript-undo')).toHaveAttribute('aria-label', 'Undo transcript edit');
+});

--- a/__TEST__/e2e/transcript-history.spec.mjs
+++ b/__TEST__/e2e/transcript-history.spec.mjs
@@ -135,7 +135,7 @@ test('history is bounded while retaining an undoable baseline', async ({ page })
   expect(await page.evaluate(() => transcriptHistory.undo())).toBe(true);
 });
 
-test('caption mode is a no-op and touch controls stay unique and accessible', async ({ page }) => {
+test('caption mode is a no-op and the controls stay unique and accessible', async ({ page }) => {
   await page.evaluate(() => {
     const word = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
     transcriptGateway.mutate(() => { word.textContent += 'step'; }, { origin: 'step' });
@@ -145,9 +145,27 @@ test('caption mode is a no-op and touch controls stay unique and accessible', as
   await expect(page.locator('#transcript-undo')).toBeDisabled();
   await page.click('#transcript-editor-btn');
   await expect(page.locator('#transcript-undo')).toBeEnabled();
-  await page.click('#transcript-undo');
-  expect(await page.evaluate(() => document.activeElement.id)).toBe('hypertranscript');
   await expect(page.locator('#transcript-undo')).toHaveCount(1);
   await expect(page.locator('#transcript-redo')).toHaveCount(1);
   await expect(page.locator('#transcript-undo')).toHaveAttribute('aria-label', 'Undo transcript edit');
+});
+
+// The ↶/↷ buttons became touch-only when they left the top bar for the
+// transcript card's corner (the ⓘ/copy pattern) — on fine-pointer devices
+// they are display:none and ⌘Z owns undo. Clicking them therefore needs a
+// touch-emulated context; the default (fine-pointer) context above can still
+// assert existence, aria and disabled state, which ignore visibility.
+test.describe('touch devices', () => {
+  test.use({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true });
+
+  test('the corner undo button undoes and returns focus to the transcript', async ({ page }) => {
+    await page.evaluate(() => {
+      const word = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+      transcriptGateway.mutate(() => { word.textContent += 'step'; }, { origin: 'step' });
+    });
+    await expect(page.locator('#transcript-undo')).toBeVisible();
+    await page.click('#transcript-undo');
+    expect(await page.evaluate(() => document.activeElement.id)).toBe('hypertranscript');
+    expect(await page.evaluate(() => transcriptHistory.canRedo())).toBe(true);
+  });
 });

--- a/__TEST__/e2e/transcript-lifecycle.spec.mjs
+++ b/__TEST__/e2e/transcript-lifecycle.spec.mjs
@@ -82,7 +82,7 @@ test('restore invalidates find references without changing identity', async ({ p
   expect(await page.evaluate(() => window.transcriptLifecycle.generation())).toBe(0);
 });
 
-test('lifecycle ignores signals while the container is loader markup', async ({ page }) => {
+test('identity remains unconditional while restore rejects loader markup', async ({ page }) => {
   const result = await page.evaluate(() => {
     const lifecycle = window.transcriptLifecycle;
     const transcript = document.getElementById('hypertranscript');
@@ -102,8 +102,8 @@ test('lifecycle ignores signals while the container is loader markup', async ({ 
 
   expect(result).toEqual({
     before: 0,
-    after: 0,
-    identityAccepted: false,
+    after: 1,
+    identityAccepted: true,
     restoreAccepted: false,
   });
 });

--- a/__TEST__/e2e/transcript-lifecycle.spec.mjs
+++ b/__TEST__/e2e/transcript-lifecycle.spec.mjs
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript span[data-m]');
+});
+
+test('identity and restore are distinct monotonic lifecycle signals', async ({ page }) => {
+  const result = await page.evaluate(() => {
+    const identities = [];
+    const restores = [];
+    document.addEventListener('hyperaudioDocumentIdentityChanged', (event) => {
+      identities.push(event.detail);
+    });
+    document.addEventListener('hyperaudioTranscriptRestored', (event) => {
+      restores.push(event.detail);
+    });
+
+    const lifecycle = window.transcriptLifecycle;
+    const initial = lifecycle.generation();
+    lifecycle.signalIdentity('test-document');
+    lifecycle.signalRestored('undo');
+    lifecycle.signalRestored('redo');
+
+    return {
+      initial,
+      final: lifecycle.generation(),
+      identities,
+      restores,
+      audit: lifecycle.auditLog().slice(-3),
+    };
+  });
+
+  expect(result.final).toBe(result.initial + 1);
+  expect(result.identities).toHaveLength(1);
+  expect(result.identities[0]).toMatchObject({
+    generation: result.final,
+    origin: 'test-document',
+  });
+  expect(result.restores).toEqual([
+    { generation: result.final, origin: 'undo' },
+    { generation: result.final, origin: 'redo' },
+  ]);
+  expect(result.audit.map((entry) => entry.type)).toEqual([
+    'identity', 'restore', 'restore',
+  ]);
+});
+
+test('hyperaudioInit commits one public identity signal through the save lifecycle', async ({ page }) => {
+  const detail = await page.evaluate(() => new Promise((resolve) => {
+    document.addEventListener('hyperaudioDocumentIdentityChanged', (event) => {
+      resolve(event.detail);
+    }, { once: true });
+    document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+  }));
+
+  expect(detail).toMatchObject({
+    generation: 1,
+    origin: 'transcription-or-import',
+  });
+  expect(await page.evaluate(() => window.transcriptLifecycle.generation())).toBe(1);
+});
+
+test('restore invalidates find references without changing identity', async ({ page }) => {
+  await page.evaluate(() => {
+    const searchBox = document.getElementById('search-box');
+    searchBox.value = 'captions';
+    searchBox.dispatchEvent(new KeyboardEvent('keyup'));
+  });
+  await expect(page.locator('#hypertranscript mark.search-mark')).not.toHaveCount(0);
+
+  await page.evaluate(() => {
+    const transcript = document.getElementById('hypertranscript');
+    transcript.querySelectorAll('mark.search-mark').forEach((mark) => {
+      mark.replaceWith(...mark.childNodes);
+    });
+    window.transcriptLifecycle.signalRestored('undo');
+  });
+
+  await expect(page.locator('#find-match-count')).toHaveText('0 / 0');
+  await expect(page.locator('#hypertranscript mark.search-mark')).toHaveCount(0);
+  expect(await page.evaluate(() => window.transcriptLifecycle.generation())).toBe(0);
+});
+
+test('lifecycle ignores signals while the container is loader markup', async ({ page }) => {
+  const result = await page.evaluate(() => {
+    const lifecycle = window.transcriptLifecycle;
+    const transcript = document.getElementById('hypertranscript');
+    const original = transcript.innerHTML;
+    const before = lifecycle.generation();
+    transcript.innerHTML = '<div class="transcribing-msg">Working...</div>';
+    const identityAccepted = lifecycle.signalIdentity('loader');
+    const restoreAccepted = lifecycle.signalRestored('undo');
+    transcript.innerHTML = original;
+    return {
+      before,
+      after: lifecycle.generation(),
+      identityAccepted,
+      restoreAccepted,
+    };
+  });
+
+  expect(result).toEqual({
+    before: 0,
+    after: 0,
+    identityAccepted: false,
+    restoreAccepted: false,
+  });
+});

--- a/__TEST__/e2e/undo-independent.spec.mjs
+++ b/__TEST__/e2e/undo-independent.spec.mjs
@@ -1,0 +1,195 @@
+// INDEPENDENT undo/redo tests (#400) — a second witness to transcript-history.
+//
+// Provenance is what makes this file worth keeping alongside
+// transcript-history.spec.mjs: it was written blind, against the engine
+// probes posted to #400 (what native undo measurably does after each
+// programmatic mutation — entries killed by the normalize passes, ⌘Z acting
+// at a distance), before this implementation was known to this session. It
+// asserts observable behaviour only — real keystrokes in, DOM and timings
+// out; the sole implementation reference is one canRedo() probe.
+//
+// Caveat: because it was written against a different implementation of the
+// same contract, overlap with transcript-history.spec.mjs is deliberate and
+// is the point — two suites from independent derivations agreeing is the
+// same defence the format doc's anti-divergence rule gives the container.
+// If a behaviour change breaks one suite but not the other, treat that as
+// signal, not noise.
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+});
+
+const words = (page) => page.evaluate(() =>
+  [...document.querySelectorAll('#hypertranscript span[data-m]')]
+    .filter((s) => !s.classList.contains('speaker'))
+    .map((s) => ({ t: s.textContent, m: +s.getAttribute('data-m'), d: +s.getAttribute('data-d') })));
+
+const wordAt = async (page, text) => (await words(page)).find((w) => w.t.trim() === text);
+
+const caretIn = (page, word, offset) => page.evaluate(({ word, offset }) => {
+  const t = document.querySelector('#hypertranscript');
+  t.focus();
+  const span = [...t.querySelectorAll('span[data-m]')]
+    .find((s) => s.textContent.trim() === word);
+  const sel = window.getSelection();
+  const r = document.createRange();
+  r.setStart(span.firstChild, offset);
+  r.collapse(true);
+  sel.removeAllRanges();
+  sel.addRange(r);
+}, { word, offset });
+
+// the app's own mid-typing normalize trigger: synthetic blur, focus retained
+const normalize = (page) => page.evaluate(() =>
+  document.querySelector('#hypertranscript').dispatchEvent(new Event('blur')));
+
+test('typing is undoable and redoable, timings intact', async ({ page }) => {
+  const before = await wordAt(page, 'makes');
+  await caretIn(page, 'makes', 2);
+  await page.keyboard.type('XX');
+  expect(await wordAt(page, 'maXXkes')).toBeTruthy();
+
+  await page.keyboard.press('Meta+z');
+  expect(await wordAt(page, 'makes')).toEqual(before);
+
+  await page.keyboard.press('Shift+Meta+z');
+  const redone = await wordAt(page, 'maXXkes');
+  expect(redone).toBeTruthy();
+  expect(redone.m).toBe(before.m);
+});
+
+test('ONE ⌘Z steps over a merge normalize, back to before the keystroke', async ({ page }) => {
+  // The scenario native undo fails: Backspace joins two words, the normalize
+  // pass merges their spans (a node removal), and native ⌘Z then does nothing
+  // in Chromium / reverts an unrelated older edit in WebKit. The module must
+  // restore both words with their ORIGINAL timings in a single press.
+  const lite = await wordAt(page, 'Lite');
+  const editor = await wordAt(page, 'Editor');
+  const countBefore = (await words(page)).length;
+
+  await caretIn(page, 'Editor', 0);
+  await page.keyboard.press('Backspace');
+  await normalize(page);
+  expect(await wordAt(page, 'LiteEditor')).toBeTruthy(); // merge really fired
+  expect((await words(page)).length).toBe(countBefore - 1);
+
+  await page.keyboard.press('Meta+z');
+  expect(await wordAt(page, 'Lite')).toEqual(lite);
+  expect(await wordAt(page, 'Editor')).toEqual(editor);
+  expect((await words(page)).length).toBe(countBefore);
+
+  // the restored state is canonical — the next normalize pass must not undo the undo
+  await normalize(page);
+  expect(await wordAt(page, 'Lite')).toEqual(lite);
+});
+
+test('ONE ⌘Z steps over a split normalize; the invented timings go with it', async ({ page }) => {
+  const before = await wordAt(page, 'makes');
+  await caretIn(page, 'makes', 2);
+  await page.keyboard.type(' ');
+  await normalize(page);
+  const half = await wordAt(page, 'kes'); // split fired, pro-rata timing invented
+  expect(half).toBeTruthy();
+  expect(half.m).toBeGreaterThan(before.m);
+
+  await page.keyboard.press('Meta+z');
+  expect(await wordAt(page, 'makes')).toEqual(before);
+  expect(await wordAt(page, 'kes')).toBeUndefined();
+});
+
+test('no action at a distance: ⌘Z reverts the LATEST edit, older edits stand', async ({ page }) => {
+  // Native's measured failure inverted: an old edit (XX in "makes"), then a
+  // join elsewhere. The first ⌘Z must revert the JOIN and leave XX alone; the
+  // second reverts XX. (Native: first press dead or reverts XX immediately.)
+  await caretIn(page, 'makes', 2);
+  await page.keyboard.type('XX');
+  await caretIn(page, 'Editor', 0);
+  await page.keyboard.press('Backspace');
+  await normalize(page);
+  expect(await wordAt(page, 'LiteEditor')).toBeTruthy();
+
+  await page.keyboard.press('Meta+z');
+  expect(await wordAt(page, 'Lite')).toBeTruthy();      // join reverted
+  expect(await wordAt(page, 'maXXkes')).toBeTruthy();   // older edit untouched
+
+  await page.keyboard.press('Meta+z');
+  expect(await wordAt(page, 'makes')).toBeTruthy();     // now the older edit
+});
+
+test('Replace All is one undoable entry', async ({ page }) => {
+  const before = await wordAt(page, 'makes');
+  await page.locator('#search-box').click();
+  await page.keyboard.type('makes');
+  await page.waitForSelector('#hypertranscript mark');
+  await page.locator('#find-replace-toggle').click();
+  await page.locator('#replace-box').click();
+  await page.keyboard.type('REPLACED');
+  await page.locator('#replace-all').click();
+  expect(await wordAt(page, 'REPLACED')).toBeTruthy();
+
+  await page.locator('#hypertranscript').click();
+  await page.keyboard.press('Meta+z');
+  const restored = await wordAt(page, 'makes');
+  expect(restored).toBeTruthy();
+  expect(restored.m).toBe(before.m);
+  expect(await wordAt(page, 'REPLACED')).toBeUndefined();
+});
+
+test('a pause splits typing into separately undoable runs', async ({ page }) => {
+  await caretIn(page, 'makes', 2);
+  await page.keyboard.type('AB');
+  await page.waitForTimeout(700); // > the 500ms group delay
+  await page.keyboard.type('CD');
+  expect(await wordAt(page, 'maABCDkes')).toBeTruthy();
+
+  await page.keyboard.press('Meta+z');
+  expect(await wordAt(page, 'maABkes')).toBeTruthy();  // CD alone reverted
+  await page.keyboard.press('Meta+z');
+  expect(await wordAt(page, 'makes')).toBeTruthy();
+});
+
+test('a new edit clears redo', async ({ page }) => {
+  await caretIn(page, 'makes', 2);
+  await page.keyboard.type('XX');
+  await page.keyboard.press('Meta+z');
+  expect(await page.evaluate(() => window.transcriptHistory.canRedo())).toBe(true);
+  await caretIn(page, 'audio', 2);
+  await page.keyboard.type('Y');
+  expect(await page.evaluate(() => window.transcriptHistory.canRedo())).toBe(false);
+});
+
+test('restore re-indexes the player word list and announces an input', async ({ page }) => {
+  await page.evaluate(() => {
+    window.__inputs = 0;
+    document.addEventListener('input', () => { window.__inputs += 1; }, true);
+  });
+  await caretIn(page, 'makes', 2);
+  await page.keyboard.type(' '); // split: span count will change
+  await normalize(page);
+  await page.evaluate(() => { window.__inputs = 0; });
+  await page.keyboard.press('Meta+z');
+
+  const r = await page.evaluate(() => {
+    const domNodes = [...document.querySelectorAll('#hypertranscript span[data-m]')];
+    const arrNodes = (window.hyperaudioInstance.wordArr || []).map((w) => w.n);
+    return {
+      inputs: window.__inputs,
+      indexed: arrNodes.length === domNodes.length && domNodes.every((n) => arrNodes.includes(n)),
+    };
+  });
+  expect(r.inputs).toBeGreaterThanOrEqual(1); // the autosave hears the undo
+  expect(r.indexed).toBe(true);               // highlighting will still work
+});
+
+test('an empty stack consumes ⌘Z without touching the transcript', async ({ page }) => {
+  // Letting the chord fall through to the native stack is exactly the
+  // action-at-a-distance the module exists to prevent.
+  const before = await page.evaluate(() => document.querySelector('#hypertranscript').innerHTML);
+  await caretIn(page, 'makes', 2);
+  await page.keyboard.press('Meta+z');
+  await page.keyboard.press('Meta+z');
+  const after = await page.evaluate(() => document.querySelector('#hypertranscript').innerHTML);
+  expect(after).toBe(before);
+});

--- a/__TEST__/soak/caption-mode.soak.spec.mjs
+++ b/__TEST__/soak/caption-mode.soak.spec.mjs
@@ -1,0 +1,164 @@
+// Soak test: caption-mode toggling must not leak.
+//
+// A long editing session toggles between transcript view and captions view many
+// times. Each round trip does a lot of teardown/rebuild work — entering clones
+// .transcript-holder into transcriptCache, replaces its innerHTML with the
+// caption editor and rebuilds the <track> (editor-core.js
+// hyperaudioGenerateCaptionsFromTranscript); leaving wipes the holder, re-inserts
+// the cached #hypertranscript and calls hyperaudio() again, which re-runs the
+// player's whole init (editor-main.js restoreTranscript). Anything that binds a
+// listener or stashes a node clone on that path and never releases it accumulates
+// silently: nothing looks wrong after one toggle, the tab is sluggish after a
+// hundred.
+//
+// So: repeat the toggle, and measure at the SAME phase of the cycle every time
+// (back in transcript view, after a forced GC). A healthy cycle returns to the
+// same DOM node count and listener count each pass; a leak shows up as a straight
+// line sloping up. We fit a least-squares trend over the samples rather than
+// comparing first-to-last, so one noisy reading can't decide the result.
+//
+// Chromium only — the counters come from the DevTools Protocol
+// (Performance.getMetrics), which has no WebKit/Firefox equivalent.
+//
+// Not part of the e2e suite: it takes minutes and is inherently a trend
+// measurement, so it lives in its own project (playwright.soak.config.mjs,
+// `npm run test:soak`) and is meant for nightly/on-demand runs, not per-push.
+//
+// Knobs (env): SOAK_PASSES, SOAK_WARMUP, SOAK_SAMPLE_EVERY,
+// SOAK_NODE_LIMIT, SOAK_LISTENER_LIMIT, SOAK_HEAP_LIMIT.
+import { test, expect } from '@playwright/test';
+
+const PASSES = Number(process.env.SOAK_PASSES || 120);
+const WARMUP = Number(process.env.SOAK_WARMUP || 10);
+const SAMPLE_EVERY = Number(process.env.SOAK_SAMPLE_EVERY || 5);
+
+// Per-pass growth allowances. A genuinely leaking listener adds ≥1 per pass, and
+// a retained transcript clone adds hundreds of nodes per pass, so these sit well
+// below any real leak while absorbing the odd node or listener that legitimately
+// settles late (lazy UI, cache fills).
+const NODE_LIMIT = Number(process.env.SOAK_NODE_LIMIT || 1);
+const LISTENER_LIMIT = Number(process.env.SOAK_LISTENER_LIMIT || 0.5);
+// Heap is reported but NOT asserted by default: JIT state, string interning and
+// GC timing move it around by megabytes between runs, so a threshold tight enough
+// to catch anything is loose enough to flake. Set SOAK_HEAP_LIMIT (bytes per
+// pass) to turn it into an assertion when chasing a specific heap regression.
+const HEAP_LIMIT = process.env.SOAK_HEAP_LIMIT ? Number(process.env.SOAK_HEAP_LIMIT) : null;
+
+// Least-squares slope of y against x — the per-pass growth rate.
+function slope(samples, key) {
+  const n = samples.length;
+  if (n < 2) return 0;
+  const mx = samples.reduce((a, s) => a + s.pass, 0) / n;
+  const my = samples.reduce((a, s) => a + s[key], 0) / n;
+  const num = samples.reduce((a, s) => a + (s.pass - mx) * (s[key] - my), 0);
+  const den = samples.reduce((a, s) => a + (s.pass - mx) ** 2, 0);
+  return den === 0 ? 0 : num / den;
+}
+
+// Force a GC, then read the renderer's own counters. Nodes counts live nodes
+// including detached ones still referenced from JS — which is precisely the
+// retained-clone case we care about — so the GC matters: without it, garbage
+// that simply hasn't been collected yet reads identically to a leak.
+async function sample(cdp, pass) {
+  await cdp.send('HeapProfiler.collectGarbage');
+  const { metrics } = await cdp.send('Performance.getMetrics');
+  const m = Object.fromEntries(metrics.map(({ name, value }) => [name, value]));
+  return {
+    pass,
+    nodes: m.Nodes,
+    listeners: m.JSEventListeners,
+    documents: m.Documents,
+    heap: m.JSHeapUsedSize,
+  };
+}
+
+// One full cycle, ending where it started: transcript view.
+async function togglePass(page) {
+  await page.click('#caption-editor-btn');
+  await page.waitForSelector('#captions-display', { timeout: 15000 });
+  await page.click('#transcript-editor-btn');
+  await page.waitForSelector('#hypertranscript [data-m]', { timeout: 15000 });
+}
+
+test('caption-mode toggling does not accumulate nodes or listeners', async ({ page, browserName }) => {
+  test.skip(browserName !== 'chromium', 'Performance.getMetrics is Chromium-only');
+
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('Performance.enable');
+  await cdp.send('HeapProfiler.enable');
+
+  // Warm up first: the first few toggles do one-off work (caption template
+  // parse, captionCache fill, lazily created UI) that would otherwise land in
+  // the trend as a fake leak.
+  for (let i = 0; i < WARMUP; i++) await togglePass(page);
+
+  const samples = [await sample(cdp, 0)];
+  for (let pass = 1; pass <= PASSES; pass++) {
+    await togglePass(page);
+    if (pass % SAMPLE_EVERY === 0) samples.push(await sample(cdp, pass));
+  }
+
+  const baseline = samples[0];
+  const final = samples[samples.length - 1];
+  const rates = {
+    nodes: slope(samples, 'nodes'),
+    listeners: slope(samples, 'listeners'),
+    heap: slope(samples, 'heap'),
+  };
+
+  const report = {
+    passes: PASSES,
+    warmup: WARMUP,
+    samples: samples.length,
+    baseline,
+    final,
+    net: {
+      nodes: final.nodes - baseline.nodes,
+      listeners: final.listeners - baseline.listeners,
+      documents: final.documents - baseline.documents,
+      heapKB: Math.round((final.heap - baseline.heap) / 1024),
+    },
+    perPass: {
+      nodes: +rates.nodes.toFixed(3),
+      listeners: +rates.listeners.toFixed(3),
+      heapBytes: Math.round(rates.heap),
+    },
+    limits: { nodes: NODE_LIMIT, listeners: LISTENER_LIMIT, heapBytes: HEAP_LIMIT },
+    series: samples,
+  };
+  await test.info().attach('soak-metrics.json', {
+    body: JSON.stringify(report, null, 2),
+    contentType: 'application/json',
+  });
+  console.log(
+    `\ncaption-mode soak — ${PASSES} passes (+${WARMUP} warmup), ${samples.length} samples\n` +
+    `  nodes     ${baseline.nodes} → ${final.nodes}  (${report.perPass.nodes}/pass, limit ${NODE_LIMIT})\n` +
+    `  listeners ${baseline.listeners} → ${final.listeners}  (${report.perPass.listeners}/pass, limit ${LISTENER_LIMIT})\n` +
+    `  heap      ${Math.round(baseline.heap / 1024)}KB → ${Math.round(final.heap / 1024)}KB  ` +
+    `(${report.perPass.heapBytes}B/pass${HEAP_LIMIT === null ? ', not asserted' : `, limit ${HEAP_LIMIT}`})\n` +
+    `  documents ${baseline.documents} → ${final.documents}\n`
+  );
+
+  // Documents is a flat-out bug check rather than a trend: a detached document
+  // per pass means an iframe or DOMParser result is being retained wholesale.
+  expect(final.documents - baseline.documents,
+    'detached documents accumulated across toggles').toBeLessThanOrEqual(1);
+
+  expect(rates.listeners,
+    `event listeners grew ${rates.listeners.toFixed(2)}/pass — something rebinds on the ` +
+    'toggle path without unbinding (see the attached soak-metrics.json series)')
+    .toBeLessThanOrEqual(LISTENER_LIMIT);
+
+  expect(rates.nodes,
+    `DOM nodes grew ${rates.nodes.toFixed(2)}/pass — nodes are being retained after ` +
+    'the holder is rebuilt (detached clones stay in this count until collected)')
+    .toBeLessThanOrEqual(NODE_LIMIT);
+
+  if (HEAP_LIMIT !== null) {
+    expect(rates.heap,
+      `JS heap grew ${Math.round(rates.heap)}B/pass`).toBeLessThanOrEqual(HEAP_LIMIT);
+  }
+});

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -662,6 +662,68 @@ html:has(#hypertranscript[aria-busy="true"]) #transcript-info-btn { display: non
   #transcript-info-btn { top: 76px; }
 }
 
+/* Undo/redo (#400): the history module injects ↶/↷ beside the strikethrough
+   button, but the top bar has no room to give — especially on mobile. So:
+   fine-pointer devices hide them entirely (⌘Z owns undo there; the rule at
+   the end of this block), and touch devices get them RELOCATED into the
+   floating corner-button pattern the ⓘ and copy buttons established — fixed
+   to the transcript card's TOP edge, left of the copy button.
+
+   Top, not bottom, deliberately: the virtual keyboard eats the bottom of the
+   viewport at exactly the moment the user is editing, which is when undo is
+   wanted. The card's top edge stays visible while typing.
+
+   Touch means ALL touch: pointer media queries cannot tell Android from iOS.
+   iOS technically doesn't need these (the system three-finger gestures reach
+   the history module via beforeinput historyUndo/historyRedo), but those
+   gestures are undiscoverable and the redundancy is harmless. Android has no
+   system undo path at all — these buttons are it.
+
+   CSS-only relocation, on purpose: the history module is another author's
+   work (#400 branch) and stays untouched. The buttons stay in the toolbar's
+   DOM; position:fixed just paints them at the card edge. Their inline
+   margin-right (set by the injector for the toolbar layout) would shift the
+   fixed box, hence the !important zero. Offsets mirror #transcript-copy-btn
+   band for band; sized down to the corner buttons' 2rem so the trio reads
+   as one family. */
+#transcript-undo,
+#transcript-redo {
+  position: fixed;
+  top: 88px;               /* holder top (78px) + 10px inset, as the others */
+  z-index: 20;
+  width: 2rem;
+  height: 2rem;
+  min-height: 2rem;
+  padding: 0;
+  margin: 0 !important;    /* neutralize the injector's toolbar margin */
+  font-size: 1rem;
+}
+#transcript-undo { right: 108px; }  /* copy (28px) + 2 button widths + gaps */
+#transcript-redo { right: 68px; }
+/* the loader owns the card while a transcription runs — same rule as ⓘ/copy */
+html:has(#hypertranscript[aria-busy="true"]) #transcript-undo,
+html:has(#hypertranscript[aria-busy="true"]) #transcript-redo { display: none; }
+@media screen and (max-width: 1120px) and (min-width: 949px) {
+  #transcript-undo { top: 76px; }
+  #transcript-redo { top: 76px; }
+}
+@media screen and (max-width: 948px) {
+  #transcript-undo,
+  #transcript-redo {
+    top: calc(var(--nav-h) + var(--player-h) + 10px);
+    transition: top 0.25s ease;  /* follows the video collapse like the holder */
+  }
+  #transcript-undo { right: 92px; }   /* copy at 12px on this band */
+  #transcript-redo { right: 52px; }
+}
+/* Desktop: the keyboard owns undo. Hidden entirely — the top bar stays clear
+   and the corner cluster stays two buttons on the devices that don't need
+   these. Must stay LAST in this block so it wins over the float rules. */
+@media (hover: hover) and (pointer: fine) {
+  #transcript-undo,
+  #transcript-redo { display: none; }
+}
+
 /* Corner buttons vs scrolling text (#480): the mask-fade experiment was
    removed — masking .transcript-holder faded the card's own top edge and
    rounded corners away with the text, since the holder paints the chrome AND

--- a/docs/hle-400-gateway-audit.md
+++ b/docs/hle-400-gateway-audit.md
@@ -1,0 +1,70 @@
+# #400 — Phase 1 gateway audit
+
+Phase 1 adds the transaction boundary used by snapshot history without yet
+installing a history subscriber. Wrapping is therefore behaviour-neutral: the
+same synchronous mutators run and return as before.
+
+## Gateway contract
+
+`window.transcriptGateway` provides:
+
+- `mutate(fn, { origin, foldPolicy })`;
+- `onBeforeMutate(callback)` / `onAfterMutate(callback)`, each returning an
+  unsubscribe function;
+- nested mutations collapsed into the outer transaction;
+- `isMutating`, `currentTransaction`, and a nest-safe `restoring(fn)` guard;
+- `try/finally` cleanup and after notification when a mutator throws;
+- an opt-in MutationObserver audit for tests/development.
+
+Subscriber errors are logged and isolated so a future history defect cannot
+prevent an editor command from running.
+
+## Routed document mutations
+
+| Origin | Owner | Scope |
+|---|---|---|
+| `normalize-blur` | `editor-core.js` | direct blur span normalization |
+| `sanitise` | `editor-core.js` | debounced normalization, orphan merging, speaker extraction |
+| `replace-one` | `find-replace.js` | one semantic text replacement |
+| `replace-all` | `find-replace.js` | all replacements as one transaction |
+| `strike` | `editor-audio-cut.js` | strike/unstrike plus derived audio refresh |
+
+The gateway script loads before every routed mutator. Each call retains a
+fallback direct invocation for partial/legacy embedding where the gateway
+script is absent.
+
+## Explicit non-document classifications
+
+- search highlighting: `mark.search-mark`, `.search-match`, and their text-node
+  wrapping/unwrapping are view state;
+- speaker `display` style changes are view state;
+- speaker `text-decoration` is not exempt because it can encode strike state;
+- native edits are claimed between delegated `beforeinput` and `input`;
+- history restore mutations are claimed by `restoring(fn)`.
+
+## Diagnostic audit
+
+The observer is off by default. Tests call:
+
+```js
+transcriptGateway.audit.start(transcript);
+// exercise one operation
+const violations = transcriptGateway.audit.violations();
+transcriptGateway.audit.stop();
+```
+
+Gateway and native records are synchronously claimed with
+`MutationObserver.takeRecords()` before their transaction window closes. Any
+remaining semantic record is `unclassified` and therefore a bypass candidate.
+
+Identity-loading mutations are not classified by this observer in Phase 1:
+the audit is scoped to a stable live transcript, and identity paths are covered
+by the Phase 0 lifecycle audit/tests.
+
+## Deferred to Phase 2
+
+Claude's Phase 0 review finding remains open: identity must advance/reset
+history even when the new document is empty or untimed. Phase 2 must move the
+timed-transcript validity guard from identity emission to restore eligibility
+(or install an equivalent unconditional reset signal). It is not a gateway
+concern and P1 does not change the current lifecycle contract.

--- a/docs/hle-400-history-phase-2.md
+++ b/docs/hle-400-history-phase-2.md
@@ -1,0 +1,53 @@
+# #400 — Phase 2 snapshot history
+
+Phase 2 installs `window.transcriptHistory` and enables transcript undo/redo.
+The live DOM remains the source of truth; history keeps at most 100 cleaned
+snapshots under a 12 MiB aggregate budget.
+
+## Snapshot and folding invariants
+
+Each entry contains cleaned restorable HTML, selection endpoints, and a semantic
+fingerprint. The fingerprint encodes article/section/paragraph structure plus
+word text, timing, speaker, and strike state. Search marks, active playback
+state, and speaker visibility are excluded.
+
+An explicit `normalization` gateway transaction may amend the current entry
+only when its pre-mutation fingerprint exactly equals that entry. This is the
+guard that lets post-restore normalization preserve redo while preventing a
+stale normalization pass from folding across a semantic edit.
+
+## Native edits and shortcuts
+
+Delegated `beforeinput` captures the pre-edit state and `input` captures the
+result. Compatible typing/deletion is coalesced for 500 ms when selection and
+identity continuity hold. Paste, cut, structural input, blur, gateway commands,
+identity changes, and composition completion force boundaries.
+
+`beforeinput` owns `historyUndo`/`historyRedo`. Cmd/Ctrl+Z keydown installs a
+next-task fallback: a matching history `beforeinput` cancels it and executes the
+action; if no such event arrives, the fallback executes once. Keyup/window blur
+flush a still-pending fallback. The protocol suite passes on Chromium, Firefox,
+and WebKit, including a real platform shortcut test.
+
+IME composition stores one pre-composition snapshot and commits once whether
+the final `input` arrives before or after `compositionend`.
+
+## Restore and identity
+
+Restore runs inside `transcriptGateway.restoring`, replaces only the current
+transcript HTML, restores anchor/focus direction, emits one synthetic `input`,
+and signals `hyperaudioTranscriptRestored`. It never emits `hyperaudioInit` or
+advances identity generation. Editor core cancels stale sanitise work and runs
+one deterministic foldable normalization after restore.
+
+Identity emission is now unconditional. An empty, untimed, loader, or error DOM
+therefore clears old history; only a valid timed transcript creates the new
+baseline. This resolves the Phase 0 review finding.
+
+## UI and caption mode
+
+Accessible native Undo/Redo buttons are injected once beside the editing tools.
+They mirror stack state, support touch sizing through the existing button
+classes, restore focus when activated, and are disabled/no-op in caption mode.
+All document listeners are delegated, so the transcript/caption clone-and-
+replace round trip does not strand history on an obsolete DOM node.

--- a/docs/hle-400-intervention-plan-revised.md
+++ b/docs/hle-400-intervention-plan-revised.md
@@ -1,0 +1,629 @@
+# #400 — Revised intervention plan: isolated snapshot undo/redo
+
+**Status:** implementation-ready revision of the engineering plan for #400.
+It preserves the accepted architecture — the live transcript DOM is the source
+of truth, history stores snapshots, and programmatic document mutations cross a
+gateway — while aligning the design with the current lifecycle on `main`
+(`v1.1.7` plus subsequent fixes; line numbers must be rechecked when coding).
+
+This revision deliberately separates:
+
+- **document identity**: a transcript was imported, transcribed, opened, or
+  otherwise replaced by a different document;
+- **document mutation**: the current transcript changed and remains the same
+  document;
+- **DOM restoration**: history replaced the DOM with an older/newer state of
+  that same document;
+- **view state**: search marks, active-word highlighting, speaker visibility,
+  focus, scroll, and other presentation details.
+
+That distinction is the main safety invariant. In particular, undo/redo must
+never look like a new project to OPFS/autosave.
+
+---
+
+## 1. Governing constraints
+
+1. The live `#hypertranscript` DOM remains the editing source of truth.
+2. Undo/redo uses bounded snapshots, not inverse commands.
+3. Every **programmatic document mutation** crosses one mutation gateway.
+4. Native user edits are observed at `beforeinput`/`input`; they do not need to
+   be reimplemented through the gateway.
+5. `hyperaudioInit` means **new document identity only**. History restore must
+   never dispatch it.
+6. History snapshots contain document state, not transient view state.
+7. New logic remains in self-contained IIFEs where practical, but isolation is
+   subordinate to correctness. Existing-file changes are small and audited,
+   rather than capped at an artificial number.
+8. Each phase is independently testable and lands behind `undoStack` until the
+   feature is ready to enable by default.
+
+---
+
+## 2. Lifecycle contract
+
+Before implementing the stack, formalise the events used by the editor.
+
+### `hyperaudioInit`
+
+Meaning: a different document has become current.
+
+Existing consumers may:
+
+- rebuild the Hyperaudio instance;
+- create/reset the save-session identity;
+- increment `identityGeneration`;
+- reset caption caches;
+- initialise a new history baseline.
+
+Sources include transcription completion and JSON/SRT/VTT import. History
+listens to this event and calls `reset()` only when a valid timed transcript is
+present.
+
+### `hyperaudioTranscriptRestored` (new)
+
+Meaning: the DOM of the **same document** was replaced by undo/redo or a future
+same-document restore operation.
+
+The event carries non-persistent detail:
+
+```js
+new CustomEvent('hyperaudioTranscriptRestored', {
+  detail: { origin: 'undo' | 'redo' | 'version' }
+})
+```
+
+Consumers may:
+
+- rebuild the player's word index and visual state;
+- rebuild strike/gap data and paragraph timecodes;
+- invalidate stale find/replace element references;
+- update controls derived from the transcript.
+
+Consumers must not:
+
+- create a project;
+- increment `identityGeneration`;
+- reset history;
+- discard the current save envelope;
+- treat the operation as an import or transcription.
+
+### Synthetic `input`
+
+After a history restore, dispatch one bubbling synthetic `input` from the
+current `#hypertranscript`. It is the existing dirty/autosave signal. History
+ignores that event while `gateway.isRestoring` is true, while the delegated save
+listener still sees it.
+
+The restore event handles structural refresh; `input` handles dirty state. The
+two responsibilities remain separate.
+
+---
+
+## 3. State model
+
+### Document state stored in history
+
+- paragraph/section/article structure;
+- word text;
+- `data-m` and `data-d` timing;
+- semantic speaker spans/classes;
+- strike state;
+- other attributes proven to affect saved/exported transcript meaning.
+
+### View/runtime state excluded from history
+
+- `mark.search-mark` and `.active`;
+- current karaoke/word highlighting;
+- speaker visibility (`style.display` driven by `#show-speakers`);
+- paragraph timecode UI outside the contenteditable;
+- focus and scroll position, except selection/caret stored separately;
+- runtime-only attributes/classes already identified by the serializer.
+
+Do not strip `style` generically: strike is currently represented by
+`text-decoration: line-through`, while speaker visibility also uses inline
+style. The snapshot cleaner must distinguish the two.
+
+### Snapshot shape
+
+```js
+{
+  html,                 // cleaned raw-ish innerHTML, suitable for restoration
+  semanticFingerprint, // structure/text/timing/strike/speaker fingerprint
+  selection,            // anchor/focus offsets and direction
+  origin,
+  timestamp
+}
+```
+
+Raw-ish HTML is used because canonical indentation changes character offsets.
+Durable versions use the canonical serializer instead.
+
+`semanticFingerprint` must cover semantic HTML/timing, not merely
+`textContent`. Equal text can still contain different timing, paragraph,
+speaker, or strike state.
+
+---
+
+## 4. New modules
+
+### `js/transcript-gateway.js`
+
+```js
+window.transcriptGateway = {
+  mutate(fn, { origin, foldPolicy } = {}),
+  get isRestoring(),
+  onBeforeMutate(callback),
+  onAfterMutate(callback)
+};
+```
+
+Responsibilities:
+
+- provide one transaction boundary for programmatic document mutations;
+- support nested mutations as one outer transaction;
+- expose before/after notifications to history;
+- suppress history capture during restore;
+- always clear internal flags with `try/finally`;
+- return the callback's result and rethrow its errors.
+
+It holds no undo stack and does not decide whether a mutation is meaningful.
+
+### `js/transcript-history.js`
+
+```js
+window.transcriptHistory = {
+  undo({ focus } = {}),
+  redo({ focus } = {}),
+  canUndo(),
+  canRedo(),
+  reset(),
+  flushPending()
+};
+```
+
+Responsibilities:
+
+- baseline, undo, and redo entries;
+- native-edit observation and typing coalescing;
+- gateway transaction capture;
+- selection capture/restore;
+- history keyboard/menu interception;
+- identity reset;
+- same-document restore;
+- depth/memory pruning;
+- Undo/Redo control state and touch UI.
+
+All transcript event listeners are delegated from `document` (normally capture
+phase) because caption mode clones and replaces `#hypertranscript`.
+
+### `js/transcript-clipboard.js`
+
+Adds validated timing-aware clipboard exchange after plain cut/paste history is
+stable.
+
+### `js/transcript-versions.js`
+
+Adds durable named canonical snapshots only after a format/storage specification
+is agreed. It is not required to close #400.
+
+---
+
+## 5. Mutation inventory and gateway coverage
+
+The implementation begins with a code audit and a test-backed inventory. At
+minimum the current gateway must cover:
+
+1. `sanitise()` document changes: orphan merging, speaker extraction, and its
+   normalization call;
+2. `normalizeTranscriptSpans()` when invoked directly from `blur` as well as
+   from the debounced sanitiser;
+3. find Replace and Replace All;
+4. strike-through commands, which currently mutate styles without emitting
+   `input`;
+5. any speaker-changing command that changes transcript semantics.
+
+The show/hide-speakers preference is view state and does not cross the gateway.
+Search highlighting is also view state.
+
+Transcription results, imports, project open, and alignment that installs a new
+transcript are identity changes, not undoable mutations of the old document.
+Their loading/error DOM is ignored, and their final valid transcript establishes
+a new baseline through the identity lifecycle.
+
+During development, attach a scoped `MutationObserver` diagnostic that records
+mutations to the live transcript occurring outside:
+
+- an active gateway transaction;
+- a native `beforeinput` → `input` edit window;
+- a history restore;
+- an explicit identity-loading window;
+- known view-state operations.
+
+The observer is an assertion/safety net, not the production history mechanism.
+The feature cannot be enabled by default while unexplained bypasses remain.
+
+---
+
+## 6. Native editing and coalescing
+
+### Before/after capture
+
+For native edits, `beforeinput` captures the pre-edit state when a new group is
+about to begin. `input` captures the resulting current state. Relying on
+`input` alone cannot reconstruct the pre-edit DOM.
+
+Group contiguous typing/deleting when all are true:
+
+- compatible `inputType` category;
+- same document identity;
+- selection continuity is plausible;
+- no forced boundary intervened;
+- elapsed time is below the chosen window (initially 500 ms).
+
+Forced boundaries include:
+
+- paste and cut;
+- paragraph/structural edits;
+- gateway mutations;
+- strike/speaker changes;
+- find-replace;
+- blur;
+- undo/redo;
+- identity change;
+- IME composition completion.
+
+IME handling:
+
+- never restore or normalize during composition;
+- ignore undo shortcuts with `event.isComposing`;
+- treat the whole composition as one edit, committed at `compositionend` and
+  its associated final input;
+- test Safari/WebKit composition ordering explicitly.
+
+---
+
+## 7. Owning Undo/Redo
+
+### Primary interception
+
+Use delegated `beforeinput` and intercept:
+
+- `historyUndo`;
+- `historyRedo`.
+
+Call `preventDefault()` before invoking history. This route covers browser UI
+that emits history input events, including context/menu actions where supported.
+
+### Keyboard fallback without double execution
+
+`keydown` for Cmd/Ctrl+Z is secondary. Because it normally precedes
+`beforeinput`, it must not execute undo immediately and then allow the later
+history event to execute it again.
+
+Use a small fallback protocol:
+
+1. on matching `keydown`, prevent native handling and schedule one fallback
+   action for the next task;
+2. if the corresponding `beforeinput` arrives, cancel the scheduled action and
+   execute exactly once there;
+3. otherwise run the scheduled fallback;
+4. clear the token on keyup/blur and after execution.
+
+Validate the precise scheduling on Chromium, Firefox, and WebKit. If preventing
+keydown suppresses `beforeinput` on a target browser, use capability/browser
+behaviour detection established by tests rather than assuming one universal
+ordering.
+
+Shortcuts are ignored when:
+
+- `event.isComposing` is true;
+- focus is in another editable/input/textarea that is not the transcript;
+- caption mode is active;
+- no valid live timed transcript exists.
+
+On macOS support Cmd+Z and Cmd+Shift+Z. On platforms that conventionally expose
+Ctrl+Y for redo, support it in addition to Ctrl+Shift+Z.
+
+---
+
+## 8. Selection model
+
+Store both selection endpoints relative to transcript text:
+
+```js
+{
+  anchor: absoluteCharacterOffset,
+  focus: absoluteCharacterOffset,
+  backward: boolean
+}
+```
+
+Character walking uses text content after view-only marks have been unwrapped,
+so mark removal does not alter offsets. Restore with
+`Selection.setBaseAndExtent()` where supported; fall back to a Range while
+accepting loss of direction only on unsupported engines.
+
+Clamp offsets safely when content differs. If no selection belongs to the
+transcript, store `null`.
+
+For toolbar Undo/Redo, focus the current transcript before restoring selection.
+For keyboard/menu operations, avoid gratuitous focus changes.
+
+---
+
+## 9. Restore transaction
+
+Undo/redo performs this sequence inside a `try/finally` restore guard:
+
+1. flush/cancel pending coalescing timers;
+2. confirm transcript mode and a valid current transcript;
+3. set `gateway.isRestoring` through an internal gateway restore helper;
+4. replace current `#hypertranscript.innerHTML` with the cleaned snapshot;
+5. restore selection as appropriate;
+6. dispatch one bubbling synthetic `input` to mark the project dirty;
+7. dispatch `hyperaudioTranscriptRestored` with `undo` or `redo` origin;
+8. clear the restore guard;
+9. update Undo/Redo controls.
+
+Never dispatch `hyperaudioInit` here.
+
+Consumers of `hyperaudioTranscriptRestored` re-index existing subsystems without
+creating a new document. Find/replace clears its cached `matches` array and
+active UI because restored HTML invalidates element references; it does not
+automatically rerun or persist search highlighting.
+
+### Post-restore normalization
+
+Do not fold mutations merely because `textContent` is unchanged.
+
+Normalization carries an explicit origin/fold policy. A normalization scheduled
+by the restored DOM may amend the just-restored current entry only when its
+semantic policy allows that transformation. It must not:
+
+- create an extra user-visible undo step;
+- clear redo;
+- absorb timing, strike, speaker, or paragraph changes that are not part of the
+  declared normalization;
+- run while IME composition or restore is active.
+
+Prefer cancelling stale pre-restore sanitise timers and scheduling one fresh
+normalization transaction after restore. Add the minimum editor-core hook needed
+to make this deterministic instead of relying on a one-second race.
+
+---
+
+## 10. Caption mode and replaced DOM nodes
+
+Caption mode is inferred through the view switch/current DOM, but listeners do
+not bind permanently to a particular transcript element.
+
+- History input/beforeinput listeners are delegated.
+- Snapshot/restore always resolves the current element afresh.
+- History entries never retain element references.
+- Undo/redo is disabled while captions are active.
+- Returning to transcript mode must not reset history; it exposes the same
+  document node cloned at mode entry.
+- A genuine import/transcription performed while caption mode is active still
+  produces an identity reset when the new transcript becomes current.
+
+Add a transcript → captions → transcript → edit → undo regression test to prove
+that listeners survive the replacement.
+
+---
+
+## 11. Touch and accessible controls
+
+Inject Undo and Redo buttons into the appropriate existing toolbar after its
+container exists. Requirements:
+
+- native `<button>` elements;
+- visible labels or icons with accessible names;
+- disabled state mirrors `canUndo()`/`canRedo()`;
+- no operation in caption mode;
+- focus is not lost after activation;
+- touch targets meet the existing mobile sizing conventions;
+- controls survive responsive layout changes without duplication.
+
+Injection avoids permanent markup when cleanly possible; a small markup slot is
+acceptable if it improves layout and accessibility.
+
+---
+
+## 12. Clipboard phase
+
+Plain native cut/paste becomes undoable through the Phase 2 native-edit path.
+Timing preservation is separate work.
+
+On copy/cut, offer:
+
+- `text/plain` always;
+- sanitized `text/html` when supported;
+- a versioned custom MIME payload as an optional enhancement, not the only
+  interoperable representation.
+
+The timed payload contains only allowlisted transcript structure and timing. On
+paste:
+
+1. validate type/version, structure, size, `data-m`, and `data-d`;
+2. reject scripts, event attributes, arbitrary styles/classes, and unexpected
+   elements;
+3. insert the timed fragment in one gateway transaction;
+4. otherwise use the safe plain-text path;
+5. create exactly one undo step.
+
+Decide with the maintainer whether to replace the current `execCommand` paste
+path. Do not insert arbitrary clipboard HTML directly.
+
+---
+
+## 13. Durable versions phase
+
+Treat versions as a separate specification/issue. Do not generically preserve
+all unknown ZIP entries.
+
+Define an allowlisted `versions/` namespace with:
+
+- manifest/version schema;
+- safe path grammar and duplicate-name behaviour;
+- maximum version count;
+- per-entry and aggregate byte limits;
+- canonical transcript representation;
+- timestamps/names/identifiers;
+- pruning policy;
+- behaviour on malformed entries;
+- OPFS working-copy relationship;
+- restore semantics: one undoable same-document transaction or explicit
+  history reset.
+
+`zipProject()` currently rebuilds a fixed entry list, so writer and reader must
+both gain explicit `versions/` handling. Security tests cover path traversal,
+zip bombs, oversized entries, invalid UTF-8, and unrecognised formats.
+
+Version restore must use the same-document restore lifecycle and must not emit
+`hyperaudioInit` unless the product intentionally defines opening a version as a
+new document.
+
+---
+
+## 14. Phased implementation
+
+### Phase 0 — lifecycle and mutation audit
+
+- [ ] Introduce/document `hyperaudioTranscriptRestored`.
+- [ ] Add non-identity refresh listeners for player/strike/gaps/timecodes.
+- [ ] Add find/replace cache invalidation on restore.
+- [ ] Inventory all live transcript mutation sites.
+- [ ] Add a diagnostic bypass observer/test.
+- [ ] Confirm `hyperaudioInit` remains identity-only.
+
+No undo UI or behavioural change yet.
+
+### Phase 1 — gateway
+
+- [ ] Add `transcript-gateway.js` with nesting and `try/finally` safety.
+- [ ] Route sanitise and direct blur normalization through it.
+- [ ] Route Replace and Replace All through it.
+- [ ] Capture strike and semantic speaker changes.
+- [ ] Explicitly exempt search and speaker visibility view state.
+- [ ] Load gateway before any wrapped mutator.
+- [ ] With flag off, prove DOM/output behaviour is unchanged.
+
+### Phase 2 — history and #400 closure
+
+- [ ] Add cleaned raw snapshot and semantic fingerprint helpers.
+- [ ] Add baseline, undo/redo stacks, pruning, and public API.
+- [ ] Capture native before/after states with coalescing.
+- [ ] Add IME-safe composition handling.
+- [ ] Add anchor/focus selection preservation.
+- [ ] Add delegated `beforeinput` ownership.
+- [ ] Add tested, single-execution keyboard fallback.
+- [ ] Reset only on valid identity events.
+- [ ] Restore using `input` + `hyperaudioTranscriptRestored`, never init.
+- [ ] Make post-restore normalization deterministic.
+- [ ] Add caption-mode no-op and DOM-replacement resilience.
+- [ ] Add accessible touch Undo/Redo controls.
+
+### Phase 3 — timed clipboard
+
+- [ ] Add safe copy/cut representations.
+- [ ] Validate and insert timed payload atomically.
+- [ ] Preserve safe plain-text fallback.
+- [ ] Decide and document `execCommand` retirement.
+
+### Phase 4 — versions specification and implementation
+
+- [ ] Approve schema, bounds, storage, and restore semantics.
+- [ ] Implement explicit container reader/writer support.
+- [ ] Add version UI and lifecycle integration.
+
+### Phase 5 — enable and cleanup
+
+- [ ] Resolve every mutation-observer bypass.
+- [ ] Enable `undoStack` by default.
+- [ ] Remove temporary diagnostics or retain a development assertion.
+- [ ] Add WebKit to Playwright CI and complete manual Safari/mobile passes.
+
+---
+
+## 15. Required tests
+
+### History correctness
+
+- typing/delete coalescing and forced boundaries;
+- cross-word and cross-paragraph undo/redo;
+- timing changes from split/merge normalization;
+- redo after post-undo normalization;
+- Replace and Replace All as one step each;
+- strike undo/redo and downstream audio cuts;
+- speaker extraction/change without capturing visibility preference;
+- new import/transcription cannot undo into the previous document;
+- undo does not change project id or `identityGeneration`;
+- undo does not trigger project birth or clear the save envelope;
+- memory/depth pruning on large transcripts.
+
+### Input and selection
+
+- forward and backward selections;
+- collapsed caret at start/end and around speaker spans;
+- IME composition;
+- autocorrect and dictation where automatable;
+- cut, paste, drag/drop, and mobile virtual keyboard;
+- Cmd/Ctrl+Z, Shift+Cmd/Ctrl+Z, and Ctrl+Y;
+- exactly one action when both keydown and beforeinput occur;
+- context/menu `beforeinput` where browser automation permits.
+
+### Lifecycle and UI
+
+- transcript → captions → transcript → edit → undo;
+- caption-mode commands are no-ops;
+- restored DOM refreshes player, strikes, gap calculations, and timecodes;
+- active search is safely invalidated after restore;
+- touch buttons, disabled state, focus, accessible names, and no duplication;
+- autosave becomes dirty after restore but document identity is unchanged.
+
+### Clipboard and versions
+
+- timed cut/copy/paste round-trip;
+- plain paste produces safe untimed content;
+- hostile clipboard HTML is rejected/sanitized;
+- version entries survive re-save within declared limits;
+- malformed/oversized/path-traversal ZIP entries are rejected.
+
+Run existing serialization, DOM hygiene, search, captions, audio-cut, export,
+project-save, and library suites as regressions.
+
+---
+
+## 16. Revised isolation scorecard
+
+| Existing area | Expected touch | Reason |
+|---|---:|---|
+| `index.html` | script tags, optional toolbar slot | load modules / accessible placement |
+| `editor-core.js` | small gateway hooks + deterministic refresh/normalization hook | sanitise and blur normalization are module-local |
+| `find-replace.js` | gateway transaction + restore cache invalidation | semantic replace and stale node references |
+| strike command owner | small gateway/event hook | strike emits no native input |
+| player/gap/timecode consumers | restore-event listener where needed | refresh same document without init |
+| `hyperaudio-save.js` | no Phase 2 identity change; Phase 4 explicit versions support | undo must not create projects |
+| transcription/import engines | normally no change | existing init remains identity boundary |
+
+The exact file count follows the mutation audit. Acceptance is based on no
+unexplained gateway bypasses and no identity side effects, not on preserving an
+arbitrary two-wrap limit.
+
+---
+
+## 17. Decisions to confirm before coding
+
+1. Initial history depth and aggregate memory budget; proposed starting point:
+   100 entries plus a conservative byte cap, pruning oldest entries while
+   retaining the current baseline.
+2. Exact semantic snapshot cleaner allowlist.
+3. Whether strike should be moved into the gateway directly or exposed through
+   a small command event/API.
+4. Browser-tested keydown fallback protocol.
+5. Clipboard scope: enriched copy only versus full timed paste.
+6. Version schema/storage/restore semantics in a separate issue.
+
+None of these decisions changes the lifecycle rule: history restoration remains
+a mutation of the same document and never emits `hyperaudioInit`.

--- a/docs/hle-400-lifecycle-audit.md
+++ b/docs/hle-400-lifecycle-audit.md
@@ -1,0 +1,85 @@
+# #400 — Phase 0 lifecycle and mutation audit
+
+This audit records the lifecycle contract implemented before transcript history.
+It is intentionally narrower than the Phase 1 gateway audit: Phase 0 identifies
+identity boundaries, same-document refresh consumers, and known mutation doors.
+
+## Lifecycle signals
+
+| Signal | Meaning | Identity generation |
+|---|---|---:|
+| `hyperaudioInit` | legacy notification that transcription/import installed a document | does not itself increment the public lifecycle counter |
+| `hyperaudioDocumentIdentityChanged` | a valid different document committed to the save session | increments once |
+| `hyperaudioTranscriptLoaded` | legacy project-apply refresh | unchanged; not an identity contract |
+| `hyperaudioTranscriptRestored` | undo/redo/version replaced DOM within the same document | unchanged |
+
+`hyperaudioInit` remains identity-only in existing production call sites, but
+history will baseline on `hyperaudioDocumentIdentityChanged`. This avoids timing
+ambiguity: the save listener commits session identity during/after init, while
+project-file and Recents loads do not dispatch init at all.
+
+Signals are accepted only while the live transcript contains `span[data-m]`, so
+loader/error markup cannot create or restore an identity.
+
+## Identity commit inventory
+
+| Path | Internal commit | Public origin |
+|---|---|---|
+| transcription, JSON import, SRT/VTT import | `onNewTranscript()` increments `identityGeneration` | `transcription-or-import` |
+| opening a portable `.hyperaudio` file | `openFromFile()` hydrates a new session and increments | `project-file-open` |
+| boot restore or switching Recents project | `applyProjectFiles()` increments | `project-library-open` |
+
+Deleting and re-homing the current Recents entry does not change the on-screen
+document and therefore does not emit a document identity signal.
+
+## Same-document restore consumers
+
+| Consumer | Restore action |
+|---|---|
+| `editor-audio-cut.js` | rebuild strike/gap data and refresh Hyperaudio word indexes |
+| `paragraph-timecodes.js` | rebind to the current transcript and reposition labels |
+| `find-replace.js` | discard stale `mark` element references and reset match UI |
+| save/autosave | no identity action; Phase 2 will send one synthetic `input` for dirty state |
+
+`hyperaudioInit` is deliberately not dispatched by the restore API.
+
+## Known document mutation inventory for Phase 1
+
+| Mutation family | Current mechanism | Required classification |
+|---|---|---|
+| native typing/delete/cut/paste | browser `beforeinput`/`input` | native edit window |
+| debounced sanitise | module-local DOM rewrite | gateway |
+| blur normalization | direct `normalizeTranscriptSpans()` call | gateway |
+| Replace / Replace All | programmatic mark replacement | gateway |
+| strike/unstrike | programmatic inline-style mutation, no `input` | gateway |
+| search highlighting | programmatic `<mark>` wrapping | view-state exemption |
+| show/hide speakers | inline `display` mutation | view-state exemption |
+| transcription/import result | wholesale `innerHTML`/children replacement | identity-loading window |
+| project open/Recents restore | wholesale children replacement | identity-loading window |
+| alignment result | wholesale transcript replacement followed by init | identity-loading window |
+| caption-mode round trip | clone/detach/reinsert transcript | view/lifecycle operation, same identity |
+
+Phase 1 must add the scoped mutation-bypass diagnostic once gateway and native
+edit-window flags exist; adding it in Phase 0 would report unavoidable false
+positives because those classifications do not yet have runtime markers.
+
+## Phase 0 invariants
+
+1. Identity generations are monotonic and advance only for a valid timed
+   document.
+2. Restore events retain the current generation.
+3. Restore never creates a save session, changes project id, or calls init.
+4. DOM-replacement consumers do not retain stale transcript/search references.
+
+## Known edge for Phase 2 (review finding)
+
+The `span[data-m]` guard sits on the identity *emitter*: opening a document
+whose transcript is empty/untimed drops the identity signal, so a history stack
+from the previous document would survive. Residual risk is narrow — undo is
+disabled without a timed transcript, and every path that later installs timed
+spans emits its own identity signal — but conceptually the guard belongs on
+*restore* (never restore into an invalid state), while identity changes are
+real regardless of DOM validity. Phase 2 must either move the guard to
+`signalRestored` only, or additionally reset history on `hyperaudioInit` as a
+belt-and-braces.
+5. Loader/error markup emits neither identity nor restore signals.

--- a/index.html
+++ b/index.html
@@ -1035,6 +1035,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-extension.js?v=0.7.2"></script>
   <script src="js/caption.js?v=0.8.6"></script>
   <script src="js/transcript-serializer.js?v=1.1.8"></script>
+  <script src="js/transcript-lifecycle.js?v=1.1.8"></script>
   <script src="js/editor-core.js?v=1.1.8"></script>
 
 

--- a/index.html
+++ b/index.html
@@ -1036,6 +1036,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/caption.js?v=0.8.6"></script>
   <script src="js/transcript-serializer.js?v=1.1.8"></script>
   <script src="js/transcript-lifecycle.js?v=1.1.8"></script>
+  <script src="js/transcript-gateway.js?v=1.1.8"></script>
   <script src="js/editor-core.js?v=1.1.8"></script>
 
 

--- a/index.html
+++ b/index.html
@@ -1076,6 +1076,7 @@ If you are creating an open source application under a license compatible with t
   </style>
   <script src="js/editor-main.js?v=0.8.0"></script>
   <script src="js/find-replace.js?v=0.6.29"></script>
+  <script src="js/transcript-history.js?v=1.1.8"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
   <script src="js/media-export.js?v=1.1.4"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.1.9 (last changed in release 1.1.9) -->
+<!--  Hyperaudio Lite Editor - Version 1.2.0 (last changed in release 1.2.0) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.1.9">
+  <meta name="version" content="1.2.0">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -51,7 +51,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js?v=1.1.9"></script>
   <script src="js/transcript-to-ionosphere.js?v=1.1.1"></script>
-  <script src="js/paragraph-timecodes.js?v=0.6.20"></script>
+  <script src="js/paragraph-timecodes.js?v=1.2.0"></script>
 
   <!-- Meta Tags required for
     Progressive Web App -->
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.1.9">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.2.0">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1039,9 +1039,9 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-extension.js?v=0.7.3"></script>
   <script src="js/caption.js?v=0.8.6"></script>
   <script src="js/transcript-serializer.js?v=1.1.8"></script>
-  <script src="js/transcript-lifecycle.js?v=1.1.8"></script>
-  <script src="js/transcript-gateway.js?v=1.1.8"></script>
-  <script src="js/editor-core.js?v=1.1.9"></script>
+  <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
+  <script src="js/transcript-gateway.js?v=1.2.0"></script>
+  <script src="js/editor-core.js?v=1.2.0"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1079,8 +1079,8 @@ If you are creating an open source application under a license compatible with t
 
   </style>
   <script src="js/editor-main.js?v=0.8.0"></script>
-  <script src="js/find-replace.js?v=0.6.29"></script>
-  <script src="js/transcript-history.js?v=1.1.8"></script>
+  <script src="js/find-replace.js?v=1.2.0"></script>
+  <script src="js/transcript-history.js?v=1.2.0"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
   <script src="js/media-export.js?v=1.1.8"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
@@ -1095,10 +1095,10 @@ If you are creating an open source application under a license compatible with t
 
   <!-- service worker script for PWA -->
   <script src="js/editor-service-worker.js?v=0.6.12"></script>
-  <script type="module" src="js/editor-audio-cut.js?v=0.7.4"></script>
+  <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.1.9"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.0"></script>
   <script src="js/hyperaudio-library.js?v=1.1.6"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/js/editor-audio-cut.js
+++ b/js/editor-audio-cut.js
@@ -12,9 +12,16 @@
 
   strikethroughBtn.addEventListener('click', () => {
     if (strikethroughBtn.classList.contains('btn-disabled')) return;
-    applyStrikeThroughToSelection();
-    rebuildAudioDataArray();
-    ensureSkipListeners();
+    const applyStrike = () => {
+      applyStrikeThroughToSelection();
+      rebuildAudioDataArray();
+      ensureSkipListeners();
+    };
+    if (window.transcriptGateway && typeof window.transcriptGateway.mutate === 'function') {
+      window.transcriptGateway.mutate(applyStrike, { origin: 'strike' });
+    } else {
+      applyStrike();
+    }
   });
 
   // #274: grey out the strikethrough button unless text is selected in the

--- a/js/editor-audio-cut.js
+++ b/js/editor-audio-cut.js
@@ -147,6 +147,9 @@
 
   registerStrikeThrus();
   window.document.addEventListener('hyperaudioTranscriptLoaded', registerStrikeThrus, false);
+  // Undo/redo replaces the DOM of the current document. Refresh derived audio
+  // and player indexes without using hyperaudioInit (which means new identity).
+  window.document.addEventListener('hyperaudioTranscriptRestored', registerStrikeThrus, false);
   // Also rebuild on hyperaudioInit so transcribe (Deepgram/Whisper) and
   // JSON/SRT/VTT import inherit the current gap-skip settings against the
   // freshly-loaded transcript.
@@ -603,4 +606,3 @@
     }
 
     // Alignment functions are now in js/word-alignment.js
-

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -385,6 +385,9 @@
   // line-through (the strikeout/cut model) and display on speaker labels (the
   // Speakers toggle). Preserve those, drop everything else, and unwrap
   // non-data-m wrapper spans so their text folds back into the flow.
+  // Returns whether any span was UNWRAPPED — the one scrub action that moves
+  // the caret's text node, so callers know the selection may need restoring
+  // (#511). The style strip touches attributes only and cannot move a caret.
   function scrubEditingArtifacts(root) {
     root.querySelectorAll('span[style]').forEach((span) => {
       const display = span.classList.contains('speaker') ? span.style.display : '';
@@ -393,10 +396,13 @@
       if (display) span.style.display = display;
       if (struck) span.style.textDecoration = 'line-through';
     });
+    let unwrapped = false;
     root.querySelectorAll('span:not([data-m])').forEach((span) => {
       if (span.classList.contains('speaker')) return;
       span.replaceWith(...span.childNodes);
+      unwrapped = true;
     });
+    return unwrapped;
   }
 
   // Spans containing a bracket belong to the SPEAKER machinery, not word
@@ -480,25 +486,40 @@
   // blur handler and the debounced sanitise pass.
   function normalizeTranscriptSpans(root) {
     if (!root || imeComposing) return;
-    // nbsp -> normal space (#339)
+    // The caret is measured BEFORE anything in this pass mutates text (#511).
+    // The nbsp walk used to run first, and writing nodeValue on the text node
+    // holding the caret collapses the selection to a node boundary —
+    // saveCaretOffset then recorded that corpse and the restore faithfully
+    // reproduced it, parking the caret before the word being typed after
+    // every natural typing pause. Both pre-steps below preserve total
+    // character count (nbsp→space is same-length; the artifact unwrap MOVES
+    // text nodes rather than rewriting them), so offsets measured here stay
+    // valid for the restore. Only when the transcript has focus — on blur
+    // there is nothing to preserve.
+    const hasFocus = document.activeElement === root;
+    const caret = hasFocus ? saveCaretOffset(root) : null;
+    // nbsp -> normal space (#339); flagged, because rewriting the caret's own
+    // node is precisely the mutation that needs the restore afterwards
+    let nbspRewritten = false;
     if (root.textContent.indexOf(' ') !== -1) {
       const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
       let node;
       while ((node = walker.nextNode())) {
         if (node.nodeValue.indexOf(' ') !== -1) {
           node.nodeValue = node.nodeValue.replace(/ /g, ' ');
+          nbspRewritten = true;
         }
       }
     }
     // artifact hygiene runs regardless of the timing-repair switch (#415)
-    scrubEditingArtifacts(root);
-    if (!WORD_SPLIT_TIMING) return;
-    // The repairs rewrite text nodes, which would throw the caret to the start
-    // of the affected word mid-edit — save it as a character offset first and
-    // re-resolve after, but only when the transcript actually has focus (on
-    // blur there is nothing to preserve) and a rewrite actually happened.
-    const hasFocus = document.activeElement === root;
-    const caret = hasFocus ? saveCaretOffset(root) : null;
+    const unwrapped = scrubEditingArtifacts(root);
+    const preChanged = nbspRewritten || unwrapped;
+    if (!WORD_SPLIT_TIMING) {
+      // no timing repairs, but the pre-steps may still have broken the live
+      // selection — restore before leaving (#511)
+      if (caret !== null && preChanged) restoreCaretOffset(root, caret);
+      return;
+    }
     // disjoint conditions, in order: reflow (internal space + no trailing),
     // merge (no internal + no trailing), split (internal space + trailing).
     const reflowed = reflowLeakedFragments(root);
@@ -511,7 +532,7 @@
         split = true;
       }
     }
-    if (caret !== null && (reflowed || merged || split)) {
+    if (caret !== null && (preChanged || reflowed || merged || split)) {
       restoreCaretOffset(root, caret);
     }
     // Re-index whenever merge or split FIRED — not on a span-count comparison:

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -51,6 +51,13 @@
   let captionMode = false; // used to detect whether we need to sanitise amongst other things
   let transcriptRequiresInit = false; // to know whether a transcript has been loaded while in captionMode and so not initialised
 
+  function mutateTranscript(fn, origin, foldPolicy) {
+    if (window.transcriptGateway && typeof window.transcriptGateway.mutate === 'function') {
+      return window.transcriptGateway.mutate(fn, { origin, foldPolicy });
+    }
+    return fn();
+  }
+
   let alertOkBtn = document.querySelector('#captionsource-alert-ok');
 
   alertOkBtn.addEventListener('click', function() {
@@ -549,7 +556,11 @@
       // and the debounced sanitise pass runs it too so it also fires while
       // editing without a blur (e.g. clicking words to seek). See normalize-
       // TranscriptSpans above and the sanitise() call below.
-      transcriptEl.addEventListener('blur', () => normalizeTranscriptSpans(transcriptEl));
+      transcriptEl.addEventListener('blur', () => mutateTranscript(
+        () => normalizeTranscriptSpans(transcriptEl),
+        'normalize-blur',
+        'normalization',
+      ));
     }
 
     const sanitisationCheck = function () {
@@ -724,7 +735,11 @@
       function resetTimer() {
         clearTimeout(time);
         if (captionMode !== true) {
-          time = setTimeout(sanitise, 1000);
+          time = setTimeout(() => mutateTranscript(
+            sanitise,
+            'sanitise',
+            'normalization',
+          ), 1000);
         }
       }
 

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -743,6 +743,17 @@
         }
       }
 
+      // History restore replaces the transcript DOM synchronously. Cancel any
+      // timer belonging to the pre-restore DOM and run exactly one fresh pass;
+      // its explicit fold policy lets history amend the restored entry without
+      // consuming redo or creating a visible step.
+      window.hyperaudioNormalizeAfterHistoryRestore = function () {
+        clearTimeout(time);
+        if (captionMode === true || imeComposing === true) return false;
+        mutateTranscript(sanitise, 'history-restore-normalize', 'normalization');
+        return true;
+      };
+
       //longpress to set playhead on mobile
 
       function longPress(element, callback) {

--- a/js/find-replace.js
+++ b/js/find-replace.js
@@ -95,11 +95,20 @@
     if (span && typeof span.normalize === 'function') span.normalize();
   };
 
+  const mutateTranscript = (fn, origin) => {
+    if (window.transcriptGateway && typeof window.transcriptGateway.mutate === 'function') {
+      return window.transcriptGateway.mutate(fn, { origin });
+    }
+    return fn();
+  };
+
   const replaceOne = () => {
     if (activeIndex < 0 || !matches[activeIndex]) return;
     const at = activeIndex;
-    replaceMark(matches[activeIndex]);
-    markDirty();
+    mutateTranscript(() => {
+      replaceMark(matches[activeIndex]);
+      markDirty();
+    }, 'replace-one');
     runSearch(true);           // refresh; keep position so we land on the next hit
     if (matches.length) {
       activeIndex = Math.min(at, matches.length - 1);
@@ -109,8 +118,10 @@
 
   const replaceAll = () => {
     if (matches.length === 0) return;
-    matches.forEach(replaceMark);
-    markDirty();
+    mutateTranscript(() => {
+      matches.forEach(replaceMark);
+      markDirty();
+    }, 'replace-all');
     activeIndex = -1;
     runSearch(false);
   };

--- a/js/find-replace.js
+++ b/js/find-replace.js
@@ -130,6 +130,15 @@
     clearActive();
   };
 
+  // A history restore replaces transcript.innerHTML, invalidating every mark
+  // reference held in matches. Search is view state: clear its UI cache and do
+  // not persist or automatically recreate highlights in the restored document.
+  document.addEventListener('hyperaudioTranscriptRestored', () => {
+    matches = [];
+    activeIndex = -1;
+    renderActive();
+  });
+
   toggle.addEventListener('click', () => { isOpen() ? closePanel() : openPanel(); });
 
   // Click anywhere outside the find/replace widget closes the panel; Escape too.

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -656,6 +656,27 @@
   let identityGeneration = 0;  // bumps when a DIFFERENT document commits
   let saveInFlight = false;
 
+  // The last committed state's signature, so an undo that lands the editor
+  // EXACTLY back on it can clear the dirty dot (the VS Code / NSDocument
+  // semantics). sessionEdited alone can't express that — it's a monotone
+  // edit-event flag with no notion of content equality. null = unknown (e.g.
+  // a draft was restored, so the saved state isn't what's on screen); unknown
+  // stays dirty, which is the previous behaviour.
+  let savedSignature = null;
+  // `modified` is stamped at every gather, so it would defeat any comparison;
+  // captions ride outside the project json and must be part of the identity —
+  // undoing the transcript back while a caption edit is pending is NOT clean.
+  function signatureOfParts(json, vtt) {
+    const project = JSON.parse(json);
+    project.modified = '';
+    return JSON.stringify(project) + '\u001f' + (vtt || '');
+  }
+  function stateSignature() {
+    const project = buildProjectJson(gather());
+    project.modified = '';
+    return JSON.stringify(project) + '\u001f' + (getCaptionsVtt() || '');
+  }
+
   // History and other same-document features must not infer identity from a
   // generic DOM refresh. Emit only beside identityGeneration commits.
   function signalDocumentIdentity(origin) {
@@ -1138,11 +1159,16 @@
     const state = gather();
     const dir = await getProjectDir(projectId, true);
     const vtt = getCaptionsVtt();
+    const json = serializeProjectJson(buildProjectJson(state));
     await writeFileTo(dir, filename, JSON.stringify({
-      json: serializeProjectJson(buildProjectJson(state)),
+      json,
       html: state.html,
       captionsVtt: vtt !== '' ? vtt : null,
     }));
+    // Every commit funnels through here (save, project birth, open-seeding),
+    // so this is the one place the clean-state signature is captured — from
+    // the parts actually written, not a re-gather that later edits could skew.
+    if (filename === SAVED_FILE) savedSignature = signatureOfParts(json, vtt);
     return state;
   }
 
@@ -2035,6 +2061,11 @@
     session.hasOriginal = files.originalText !== null;
     session.originalJson = files.originalText;
     session.envelope = project; // §8.1: a save after restore must preserve unknown fields too
+    // Clean restore: what's on screen IS the saved state, so sign it — an
+    // undo can then find its way back to clean. A draft restore leaves the
+    // signature unknown (the saved state is not what's on screen), which
+    // keeps the previous always-dirty behaviour for that case.
+    savedSignature = files.fromDraft ? null : stateSignature();
     signalDocumentIdentity('project-library-open');
   }
 
@@ -2505,6 +2536,41 @@
       // committed v0, not an edit — see birthInProgress
       if (birthInProgress) return;
       scheduleAutosave();
+    });
+    // Undo/redo (#400): a restore that lands the editor EXACTLY back on the
+    // last committed state clears the dirty dot and retires the draft — the
+    // project is the save again, so there is nothing to lose. Compared by
+    // signature, not by step-counting, so a pending NON-transcript edit
+    // (summary, captions, options) keeps the dot on: undo can't revert those,
+    // and the project genuinely differs from the save. Restores that DON'T
+    // land on the save re-dirty through the synthetic input the history
+    // module dispatches, like any other edit.
+    document.addEventListener('hyperaudioTranscriptRestored', () => {
+      if (!session.active || savedSignature === null || !sessionEdited) return;
+      if (stateSignature() !== savedSignature) return;
+      sessionEdited = false;
+      clearTimeout(autosaveTimer);
+      autosaveTimer = null;
+      autosavePending = false;
+      updateSaveIndicator();
+      // The draft predates the undo and now describes a dirtier state than
+      // the screen; left in place it would resurrect as "unsaved edits" on
+      // reload. Ride the snapshot chain so a queued draft write can't
+      // interleave, and re-check the flag there — an edit that lands while
+      // this waits makes the retirement wrong, so it must stand down.
+      if (opfsAvailable && hasProjectLock && session.projectId !== null) {
+        const id = session.projectId;
+        snapshotChain = snapshotChain.then(async () => {
+          if (sessionEdited || id !== session.projectId) return;
+          const dir = await getProjectDir(id, false);
+          await dir.removeEntry(DRAFT_FILE).catch(() => {});
+          await updateLibrary((lib) => {
+            const entry = lib.projects.find((p) => p.id === id);
+            if (entry !== undefined) entry.lastDraftAt = 0;
+          });
+          notifyLibraryChanged(false);
+        }).catch((e) => console.warn('hyperaudio-save: draft retirement failed', e));
+      }
     });
     ['#remove-gaps-enabled', '#remove-gaps-threshold', '#remove-gaps-buffer', '#show-speakers', '#show-timecodes']
       .forEach((selector) => {

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.1.9 — last changed in release 1.1.9
+ * @version 1.2.0 — last changed in release 1.2.0
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -631,6 +631,17 @@
   let editGeneration = 0;      // bumps on every edit signal
   let identityGeneration = 0;  // bumps when a DIFFERENT document commits
   let saveInFlight = false;
+
+  // History and other same-document features must not infer identity from a
+  // generic DOM refresh. Emit only beside identityGeneration commits.
+  function signalDocumentIdentity(origin) {
+    if (window.transcriptLifecycle
+        && typeof window.transcriptLifecycle.signalIdentity === 'function') {
+      window.transcriptLifecycle.signalIdentity(origin, {
+        projectId: session.projectId,
+      });
+    }
+  }
   // Snapshot writes serialize on a promise chain (#448: parallel writes could
   // interleave files from different states); calls landing while one is
   // running or queued coalesce into ONE queued follow-up, which re-gathers —
@@ -1314,6 +1325,7 @@
       // previous project's transcription details
       renderTranscriptionInfo(null, '');
     }
+    signalDocumentIdentity('transcription-or-import');
     try {
       if (opfsAvailable && session.projectId !== null) {
         await acquireProjectLock(session.projectId); // fresh id: always granted
@@ -1764,6 +1776,7 @@
       sessionEdited = false; // the opened file IS the downloaded state
       identityGeneration += 1; // a different document now owns the session
       updateSaveIndicator();
+      signalDocumentIdentity('project-file-open');
 
       if (opfsAvailable && session.projectId !== null) {
         await acquireProjectLock(session.projectId); // fresh id: always granted
@@ -1902,6 +1915,7 @@
     session.hasOriginal = files.originalText !== null;
     session.originalJson = files.originalText;
     session.envelope = project; // §8.1: a save after restore must preserve unknown fields too
+    signalDocumentIdentity('project-library-open');
   }
 
   // Switching asks nothing and loses nothing (#456): flush the outgoing

--- a/js/paragraph-timecodes.js
+++ b/js/paragraph-timecodes.js
@@ -249,6 +249,10 @@
 
     window.addEventListener('resize', trigger);
     document.addEventListener('hyperaudioInit', trigger, false);
+    document.addEventListener('hyperaudioTranscriptRestored', () => {
+      attachToTranscript();
+      trigger();
+    }, false);
 
     attachToTranscript();
 

--- a/js/transcript-gateway.js
+++ b/js/transcript-gateway.js
@@ -1,0 +1,210 @@
+/* Single transaction door for programmatic transcript document mutations. */
+
+(function () {
+  'use strict';
+
+  let mutationDepth = 0;
+  let restoreDepth = 0;
+  let transactionId = 0;
+  let currentTransaction = null;
+  const beforeListeners = new Set();
+  const afterListeners = new Set();
+
+  let auditObserver = null;
+  let auditRoot = null;
+  let nativeInputType = null;
+  const auditEntries = [];
+
+  function transcriptFromEvent(event) {
+    const target = event && event.target;
+    return target && target.closest && target.closest('#hypertranscript');
+  }
+
+  function describeRecord(record) {
+    const target = record.target.nodeType === Node.ELEMENT_NODE
+      ? record.target : record.target.parentElement;
+    return {
+      type: record.type,
+      attributeName: record.attributeName || null,
+      target: target ? target.tagName.toLowerCase()
+        + (target.id ? `#${target.id}` : '')
+        + (target.className && typeof target.className === 'string'
+          ? `.${target.className.trim().replace(/\s+/g, '.')}` : '') : null,
+    };
+  }
+
+  function isSearchViewMutation(record) {
+    if (record.type === 'attributes') {
+      return record.target.nodeType === Node.ELEMENT_NODE
+        && (record.target.matches('mark.search-mark, .search-match')
+          || (record.attributeName === 'class'
+            && /(?:^|\s)search-match(?:\s|$)/.test(record.oldValue || '')));
+    }
+    if (record.target.nodeType === Node.ELEMENT_NODE
+        && record.target.matches('.search-match')) return true;
+    const nodes = Array.from(record.addedNodes).concat(Array.from(record.removedNodes));
+    return nodes.some((node) => node.nodeType === Node.ELEMENT_NODE
+      && (node.matches('mark.search-mark') || node.querySelector('mark.search-mark')));
+  }
+
+  function isSpeakerVisibilityMutation(record) {
+    if (record.type !== 'attributes'
+      || record.attributeName !== 'style'
+      || record.target.nodeType !== Node.ELEMENT_NODE
+      || !record.target.matches('span.speaker')) return false;
+    const before = record.oldValue || '';
+    const after = record.target.getAttribute('style') || '';
+    return !/text-decoration/i.test(before + after);
+  }
+
+  function recordAudit(records, classification, origin) {
+    records.forEach((record) => {
+      let kind = classification;
+      let recordOrigin = origin;
+      if (kind === 'unclassified' && isSearchViewMutation(record)) {
+        kind = 'view';
+        recordOrigin = 'search';
+      } else if (kind === 'unclassified' && isSpeakerVisibilityMutation(record)) {
+        kind = 'view';
+        recordOrigin = 'speaker-visibility';
+      }
+      auditEntries.push(Object.freeze({
+        classification: kind,
+        origin: recordOrigin || 'unknown',
+        record: Object.freeze(describeRecord(record)),
+      }));
+    });
+  }
+
+  function claimAuditRecords(classification, origin) {
+    if (auditObserver === null) return;
+    const records = auditObserver.takeRecords();
+    if (records.length > 0) recordAudit(records, classification, origin);
+  }
+
+  function notify(listeners, transaction) {
+    listeners.forEach((listener) => {
+      try {
+        listener(transaction);
+      } catch (error) {
+        console.error('transcript-gateway: transaction listener failed', error);
+      }
+    });
+  }
+
+  function mutate(fn, options) {
+    if (typeof fn !== 'function') throw new TypeError('transcriptGateway.mutate expects a function');
+    const opts = options || {};
+    if (restoreDepth > 0) return fn();
+
+    if (mutationDepth > 0) {
+      mutationDepth += 1;
+      try {
+        return fn();
+      } finally {
+        mutationDepth -= 1;
+      }
+    }
+
+    const transaction = Object.freeze({
+      id: ++transactionId,
+      origin: opts.origin || 'unknown',
+      foldPolicy: opts.foldPolicy || null,
+    });
+    currentTransaction = transaction;
+    mutationDepth = 1;
+    notify(beforeListeners, transaction);
+    let result;
+    let error = null;
+    try {
+      result = fn();
+      return result;
+    } catch (caught) {
+      error = caught;
+      throw caught;
+    } finally {
+      claimAuditRecords('gateway', transaction.origin);
+      mutationDepth = 0;
+      currentTransaction = null;
+      notify(afterListeners, Object.freeze({
+        id: transaction.id,
+        origin: transaction.origin,
+        foldPolicy: transaction.foldPolicy,
+        error,
+      }));
+    }
+  }
+
+  function restoring(fn) {
+    if (typeof fn !== 'function') throw new TypeError('transcriptGateway.restoring expects a function');
+    restoreDepth += 1;
+    try {
+      return fn();
+    } finally {
+      claimAuditRecords('restore', 'history');
+      restoreDepth -= 1;
+    }
+  }
+
+  function subscribe(listeners, callback) {
+    if (typeof callback !== 'function') throw new TypeError('transcriptGateway listener must be a function');
+    listeners.add(callback);
+    return () => listeners.delete(callback);
+  }
+
+  const audit = Object.freeze({
+    start(root) {
+      if (auditObserver !== null) auditObserver.disconnect();
+      auditEntries.length = 0;
+      auditRoot = root || document.getElementById('hypertranscript');
+      if (auditRoot === null || typeof MutationObserver === 'undefined') return false;
+      auditObserver = new MutationObserver((records) => {
+        recordAudit(records, 'unclassified', null);
+      });
+      auditObserver.observe(auditRoot, {
+        subtree: true,
+        childList: true,
+        characterData: true,
+        attributes: true,
+        attributeOldValue: true,
+      });
+      return true;
+    },
+    stop() {
+      if (auditObserver !== null) {
+        claimAuditRecords('unclassified', null);
+        auditObserver.disconnect();
+      }
+      auditObserver = null;
+      auditRoot = null;
+      nativeInputType = null;
+      return auditEntries.slice();
+    },
+    entries: () => auditEntries.slice(),
+    violations: () => auditEntries.filter((entry) => entry.classification === 'unclassified'),
+    clear: () => { auditEntries.length = 0; },
+  });
+
+  // Native edits mutate between beforeinput and input. Take their records in
+  // the input handler before MutationObserver delivers them as apparent bypasses.
+  document.addEventListener('beforeinput', (event) => {
+    if (transcriptFromEvent(event)) nativeInputType = event.inputType || 'native-input';
+  }, true);
+  document.addEventListener('input', (event) => {
+    if (!transcriptFromEvent(event)) return;
+    if (mutationDepth > 0 || restoreDepth > 0) return;
+    claimAuditRecords('native', nativeInputType || event.inputType || 'native-input');
+    nativeInputType = null;
+  }, true);
+
+  window.transcriptGateway = Object.freeze({
+    mutate,
+    restoring,
+    get isMutating() { return mutationDepth > 0; },
+    get isRestoring() { return restoreDepth > 0; },
+    get currentTransaction() { return currentTransaction; },
+    onBeforeMutate: (callback) => subscribe(beforeListeners, callback),
+    onAfterMutate: (callback) => subscribe(afterListeners, callback),
+    audit,
+  });
+})();

--- a/js/transcript-history.js
+++ b/js/transcript-history.js
@@ -4,7 +4,12 @@
   'use strict';
 
   const MAX_ENTRIES = 100;
-  const MAX_BYTES = 12 * 1024 * 1024;
+  // 48MB, from 12 (#510): entries are proportional to document size, so a
+  // byte cap is really a depth dial — at 12MB a one-hour interview transcript
+  // (~1.4MB per entry once the fingerprint is hashed) kept undo ~8 deep, and
+  // before the hashing, ~3. 48MB holds ~30+ entries there; MAX_ENTRIES still
+  // governs small documents. The durable fix is delta entries — #510.
+  const MAX_BYTES = 48 * 1024 * 1024;
   const COALESCE_MS = 500;
   const gateway = window.transcriptGateway;
   let entries = [];
@@ -49,6 +54,19 @@
     });
     clone.normalize();
     return clone;
+  }
+
+  // FNV-1a over the fingerprint string, suffixed with its length. Equality of
+  // hashes stands in for equality of strings at the fold sites; a collision
+  // would merely fold one normalize pass it shouldn't have (one lost undo
+  // step), and the length guard makes that astronomically unlikely.
+  function fingerprintHash(str) {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < str.length; i++) {
+      h ^= str.charCodeAt(i);
+      h = Math.imul(h, 0x01000193);
+    }
+    return (h >>> 0).toString(36) + ':' + str.length;
   }
 
   function semanticFingerprint(root) {
@@ -147,14 +165,21 @@
     if (!root) return null;
     const clone = cleanClone(root);
     const html = clone.innerHTML;
-    const fingerprint = semanticFingerprint(clone);
+    // The fingerprint is only ever compared for EQUALITY (the fold decisions
+    // below) — never read as content — so it is stored as a hash, not the
+    // string. Measured on a real interview transcript (#510): the fingerprint
+    // string is the same order of magnitude as the HTML, and storing both,
+    // counted as UTF-16, cost ~2.9MB per entry — the 12MB cap then held four
+    // entries, and undo was three steps deep on ordinary content. The length
+    // rides along as a collision guard.
+    const fingerprint = fingerprintHash(semanticFingerprint(clone));
     return Object.freeze({
       html,
       semanticFingerprint: fingerprint,
       selection: captureSelection(root),
       origin: origin || 'unknown',
       timestamp: Date.now(),
-      bytes: (html.length + fingerprint.length) * 2,
+      bytes: html.length * 2,
     });
   }
 

--- a/js/transcript-history.js
+++ b/js/transcript-history.js
@@ -1,0 +1,472 @@
+/* Bounded snapshot undo/redo for the live transcript DOM (#400). */
+
+(function () {
+  'use strict';
+
+  const MAX_ENTRIES = 100;
+  const MAX_BYTES = 12 * 1024 * 1024;
+  const COALESCE_MS = 500;
+  const gateway = window.transcriptGateway;
+  let entries = [];
+  let position = -1;
+  let totalBytes = 0;
+  let gatewayBefore = null;
+  let pendingNative = null;
+  let lastNative = null;
+  let composing = false;
+  let compositionBefore = null;
+  let compositionTimer = null;
+  let shortcutToken = null;
+  let shortcutSerial = 0;
+
+  function transcript() {
+    return document.getElementById('hypertranscript');
+  }
+
+  function validTranscript() {
+    const root = transcript();
+    return root && root.querySelector('span[data-m]') ? root : null;
+  }
+
+  function captionMode() {
+    const button = document.getElementById('caption-editor-btn');
+    return button !== null && button.getAttribute('aria-pressed') === 'true';
+  }
+
+  function inTranscript(node) {
+    return !!(node && node.closest && node.closest('#hypertranscript'));
+  }
+
+  function cleanClone(root) {
+    const clone = root.cloneNode(true);
+    clone.querySelectorAll('mark.search-mark').forEach((mark) => mark.replaceWith(...mark.childNodes));
+    clone.querySelectorAll('.search-match').forEach((node) => node.classList.remove('search-match'));
+    clone.querySelectorAll('.active').forEach((node) => node.classList.remove('active'));
+    clone.querySelectorAll('span.speaker[style]').forEach((speaker) => {
+      const struck = speaker.style.textDecoration.includes('line-through');
+      speaker.removeAttribute('style');
+      if (struck) speaker.style.textDecoration = 'line-through';
+    });
+    clone.normalize();
+    return clone;
+  }
+
+  function semanticFingerprint(root) {
+    function visit(node) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        return node.parentElement && node.parentElement.matches('span[data-m]')
+          ? node.nodeValue : node.nodeValue.replace(/\s+/g, ' ').trim();
+      }
+      if (node.nodeType !== Node.ELEMENT_NODE) return '';
+      const tag = node.tagName.toLowerCase();
+      const children = Array.from(node.childNodes).map(visit).join('');
+      if (tag === 'span' && node.hasAttribute('data-m')) {
+        return `[w m=${JSON.stringify(node.getAttribute('data-m'))}`
+          + ` d=${JSON.stringify(node.getAttribute('data-d'))}`
+          + ` s=${node.classList.contains('speaker') ? 1 : 0}`
+          + ` x=${node.style.textDecoration.includes('line-through') ? 1 : 0}]${children}[/w]`;
+      }
+      if (tag === 'article' || tag === 'section' || tag === 'p') {
+        return `[${tag}]${children}[/${tag}]`;
+      }
+      return children;
+    }
+    return Array.from(root.childNodes).map(visit).join('');
+  }
+
+  function pointOffset(root, node, offset) {
+    if (!node || !root.contains(node)) return null;
+    const range = document.createRange();
+    range.selectNodeContents(root);
+    try {
+      range.setEnd(node, offset);
+      return range.toString().length;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function captureSelection(root) {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0
+        || !root.contains(selection.anchorNode) || !root.contains(selection.focusNode)) return null;
+    const anchor = pointOffset(root, selection.anchorNode, selection.anchorOffset);
+    const focus = pointOffset(root, selection.focusNode, selection.focusOffset);
+    if (anchor === null || focus === null) return null;
+    let backward = false;
+    if (anchor !== focus) {
+      const range = document.createRange();
+      try {
+        range.setStart(selection.anchorNode, selection.anchorOffset);
+        range.setEnd(selection.focusNode, selection.focusOffset);
+        backward = range.collapsed;
+      } catch (error) { backward = anchor > focus; }
+    }
+    return { anchor, focus, backward };
+  }
+
+  function locateOffset(root, wanted) {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let remaining = Math.max(0, wanted || 0);
+    let last = root;
+    while (walker.nextNode()) {
+      last = walker.currentNode;
+      const length = last.nodeValue.length;
+      if (remaining <= length) return { node: last, offset: remaining };
+      remaining -= length;
+    }
+    return last === root
+      ? { node: root, offset: root.childNodes.length }
+      : { node: last, offset: last.nodeValue.length };
+  }
+
+  function restoreSelection(root, saved, focus) {
+    if (!saved) {
+      if (focus) root.focus({ preventScroll: true });
+      return;
+    }
+    const anchor = locateOffset(root, saved.anchor);
+    const end = locateOffset(root, saved.focus);
+    const selection = window.getSelection();
+    if (focus) root.focus({ preventScroll: true });
+    selection.removeAllRanges();
+    if (typeof selection.setBaseAndExtent === 'function') {
+      selection.setBaseAndExtent(anchor.node, anchor.offset, end.node, end.offset);
+      return;
+    }
+    const range = document.createRange();
+    const first = saved.backward ? end : anchor;
+    const last = saved.backward ? anchor : end;
+    range.setStart(first.node, first.offset);
+    range.setEnd(last.node, last.offset);
+    selection.addRange(range);
+  }
+
+  function snapshot(origin) {
+    const root = validTranscript();
+    if (!root) return null;
+    const clone = cleanClone(root);
+    const html = clone.innerHTML;
+    const fingerprint = semanticFingerprint(clone);
+    return Object.freeze({
+      html,
+      semanticFingerprint: fingerprint,
+      selection: captureSelection(root),
+      origin: origin || 'unknown',
+      timestamp: Date.now(),
+      bytes: (html.length + fingerprint.length) * 2,
+    });
+  }
+
+  function sameSelection(a, b) {
+    if (a === null || b === null) return a === b;
+    return a.anchor === b.anchor && a.focus === b.focus && a.backward === b.backward;
+  }
+
+  function updateControls() {
+    const disabled = captionMode() || validTranscript() === null;
+    const undoButton = document.getElementById('transcript-undo');
+    const redoButton = document.getElementById('transcript-redo');
+    if (undoButton) undoButton.disabled = disabled || position <= 0;
+    if (redoButton) redoButton.disabled = disabled || position < 0 || position >= entries.length - 1;
+  }
+
+  function prune() {
+    while (entries.length > 1 && (entries.length > MAX_ENTRIES || totalBytes > MAX_BYTES)) {
+      totalBytes -= entries[0].bytes;
+      entries.shift();
+      position -= 1;
+    }
+  }
+
+  function replaceCurrent(next) {
+    if (position < 0) return;
+    totalBytes += next.bytes - entries[position].bytes;
+    entries[position] = next;
+    prune();
+    updateControls();
+  }
+
+  function rememberPreEditSelection(before) {
+    if (before && position >= 0
+        && entries[position].semanticFingerprint === before.semanticFingerprint
+        && !sameSelection(entries[position].selection, before.selection)) {
+      replaceCurrent(before);
+    }
+  }
+
+  function push(next) {
+    if (!next) return false;
+    const current = entries[position];
+    if (current && current.semanticFingerprint === next.semanticFingerprint) {
+      // Selection is useful even when the document did not change.
+      replaceCurrent(next);
+      return false;
+    }
+    if (position < entries.length - 1) {
+      entries.slice(position + 1).forEach((entry) => { totalBytes -= entry.bytes; });
+      entries.length = position + 1;
+    }
+    entries.push(next);
+    totalBytes += next.bytes;
+    position = entries.length - 1;
+    prune();
+    updateControls();
+    return true;
+  }
+
+  function clearPending() {
+    pendingNative = null;
+    lastNative = null;
+    compositionBefore = null;
+    clearTimeout(compositionTimer);
+    compositionTimer = null;
+  }
+
+  function reset(origin) {
+    clearPending();
+    entries = [];
+    position = -1;
+    totalBytes = 0;
+    const baseline = snapshot(origin || 'identity');
+    if (baseline) {
+      entries.push(baseline);
+      totalBytes = baseline.bytes;
+      position = 0;
+    }
+    updateControls();
+  }
+
+  function inputCategory(inputType) {
+    if (/^insert(?:Text|ReplacementText)$/.test(inputType)) return 'insert';
+    if (/^deleteContent(?:Backward|Forward)$/.test(inputType)) return 'delete';
+    return inputType || 'native';
+  }
+
+  function boundaryInput(inputType) {
+    return !/^insert(?:Text|ReplacementText)$/.test(inputType)
+      && !/^deleteContent(?:Backward|Forward)$/.test(inputType);
+  }
+
+  function commitNative(before, inputType, origin) {
+    const after = snapshot(origin || inputType);
+    if (!after || !before || before.semanticFingerprint === after.semanticFingerprint) return;
+    const category = inputCategory(inputType);
+    const now = Date.now();
+    const coalesce = !boundaryInput(inputType) && lastNative
+      && lastNative.category === category
+      && now - lastNative.at <= COALESCE_MS
+      && lastNative.generation === (window.transcriptLifecycle
+        ? window.transcriptLifecycle.generation() : 0)
+      && sameSelection(lastNative.selection, before.selection)
+      && position === entries.length - 1;
+    if (coalesce) replaceCurrent(after);
+    else push(after);
+    lastNative = {
+      category,
+      at: now,
+      selection: after.selection,
+      generation: window.transcriptLifecycle ? window.transcriptLifecycle.generation() : 0,
+    };
+  }
+
+  function restore(direction, options) {
+    if (composing || captionMode() || validTranscript() === null) return false;
+    clearPending();
+    const nextPosition = position + direction;
+    if (nextPosition < 0 || nextPosition >= entries.length) return false;
+    const target = entries[nextPosition];
+    const root = transcript();
+    const origin = direction < 0 ? 'undo' : 'redo';
+    gateway.restoring(() => {
+      root.innerHTML = target.html;
+      restoreSelection(root, target.selection, !!(options && options.focus));
+      root.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        inputType: origin === 'undo' ? 'historyUndo' : 'historyRedo',
+      }));
+      if (window.transcriptLifecycle) window.transcriptLifecycle.signalRestored(origin);
+    });
+    position = nextPosition;
+    updateControls();
+    if (typeof window.hyperaudioNormalizeAfterHistoryRestore === 'function') {
+      window.hyperaudioNormalizeAfterHistoryRestore();
+    }
+    return true;
+  }
+
+  function performShortcut(action, focus) {
+    shortcutToken = null;
+    return action === 'undo' ? restore(-1, { focus }) : restore(1, { focus });
+  }
+
+  function cancelShortcut(execute) {
+    const token = shortcutToken;
+    if (!token) return;
+    clearTimeout(token.timer);
+    shortcutToken = null;
+    if (execute) performShortcut(token.action, false);
+  }
+
+  function shortcutAction(event) {
+    if (!(event.metaKey || event.ctrlKey) || event.altKey) return null;
+    const key = event.key.toLowerCase();
+    if (key === 'z') return event.shiftKey ? 'redo' : 'undo';
+    if (key === 'y' && event.ctrlKey && !event.metaKey && !event.shiftKey) return 'redo';
+    return null;
+  }
+
+  gateway.onBeforeMutate((transaction) => {
+    clearPending();
+    gatewayBefore = snapshot(`before-${transaction.origin}`);
+    rememberPreEditSelection(gatewayBefore);
+  });
+
+  gateway.onAfterMutate((transaction) => {
+    const before = gatewayBefore;
+    gatewayBefore = null;
+    const after = snapshot(transaction.origin);
+    if (!after || !before || before.semanticFingerprint === after.semanticFingerprint) {
+      updateControls();
+      return;
+    }
+    if (transaction.foldPolicy === 'normalization' && position >= 0
+        && entries[position].semanticFingerprint === before.semanticFingerprint) {
+      replaceCurrent(after); // deliberately preserves redo
+    } else {
+      push(after);
+    }
+  });
+
+  document.addEventListener('beforeinput', (event) => {
+    if (!inTranscript(event.target) || captionMode()) return;
+    if (event.inputType === 'historyUndo' || event.inputType === 'historyRedo') {
+      if (event.isComposing || composing) return;
+      event.preventDefault();
+      const action = event.inputType === 'historyUndo' ? 'undo' : 'redo';
+      if (shortcutToken && shortcutToken.action === action) {
+        clearTimeout(shortcutToken.timer);
+        shortcutToken = null;
+      }
+      performShortcut(action, false);
+      return;
+    }
+    if (gateway.isRestoring || gateway.isMutating || composing || event.isComposing) return;
+    pendingNative = { before: snapshot(`before-${event.inputType}`), inputType: event.inputType || 'native' };
+    rememberPreEditSelection(pendingNative.before);
+    if (boundaryInput(pendingNative.inputType)) lastNative = null;
+  }, true);
+
+  document.addEventListener('input', (event) => {
+    if (!inTranscript(event.target) || gateway.isRestoring || gateway.isMutating || captionMode()) return;
+    if (composing || event.isComposing) return;
+    if (compositionBefore) {
+      clearTimeout(compositionTimer);
+      compositionTimer = null;
+      const before = compositionBefore;
+      compositionBefore = null;
+      commitNative(before, 'insertCompositionText', 'composition');
+      lastNative = null;
+      return;
+    }
+    const pending = pendingNative;
+    pendingNative = null;
+    commitNative(pending ? pending.before : entries[position],
+      pending ? pending.inputType : (event.inputType || 'native'), event.inputType || 'native');
+  }, true);
+
+  document.addEventListener('compositionstart', (event) => {
+    if (!inTranscript(event.target) || captionMode()) return;
+    composing = true;
+    clearPending();
+    compositionBefore = snapshot('before-composition');
+    rememberPreEditSelection(compositionBefore);
+  }, true);
+
+  document.addEventListener('compositionend', (event) => {
+    if (!inTranscript(event.target)) return;
+    composing = false;
+    // WebKit may emit the final input before or after compositionend.
+    clearTimeout(compositionTimer);
+    compositionTimer = setTimeout(() => {
+      if (!compositionBefore) return;
+      const before = compositionBefore;
+      compositionBefore = null;
+      commitNative(before, 'insertCompositionText', 'composition');
+      lastNative = null;
+    }, 0);
+  }, true);
+
+  document.addEventListener('keydown', (event) => {
+    const action = shortcutAction(event);
+    if (!action || event.isComposing || composing || captionMode() || !inTranscript(event.target)) return;
+    event.preventDefault();
+    cancelShortcut(false);
+    const id = ++shortcutSerial;
+    shortcutToken = {
+      id,
+      action,
+      timer: setTimeout(() => {
+        if (shortcutToken && shortcutToken.id === id) performShortcut(action, false);
+      }, 0),
+    };
+  }, true);
+
+  document.addEventListener('keyup', (event) => {
+    if (shortcutAction(event)) cancelShortcut(true);
+  }, true);
+  window.addEventListener('blur', () => cancelShortcut(true));
+
+  document.addEventListener('focusout', (event) => {
+    if (inTranscript(event.target)) lastNative = null;
+  }, true);
+
+  document.addEventListener('hyperaudioDocumentIdentityChanged', (event) => {
+    reset(event.detail && event.detail.origin);
+  });
+  // Contract-level fallback also clears stale history when the identity DOM is
+  // empty and an older integration has not installed transcriptLifecycle.
+  document.addEventListener('hyperaudioInit', () => reset('hyperaudioInit'));
+
+  function injectControls() {
+    if (document.getElementById('transcript-undo')) return;
+    const strike = document.getElementById('strikethrough');
+    if (!strike || !strike.parentNode) return;
+    const undo = document.createElement('button');
+    undo.id = 'transcript-undo';
+    undo.type = 'button';
+    undo.className = 'btn btn-square btn-outline tooltip';
+    undo.dataset.tip = 'Undo';
+    undo.setAttribute('aria-label', 'Undo transcript edit');
+    undo.style.marginRight = '4px';
+    undo.textContent = '↶';
+    const redo = document.createElement('button');
+    redo.id = 'transcript-redo';
+    redo.type = 'button';
+    redo.className = 'btn btn-square btn-outline tooltip';
+    redo.dataset.tip = 'Redo';
+    redo.setAttribute('aria-label', 'Redo transcript edit');
+    redo.style.marginRight = '4px';
+    redo.textContent = '↷';
+    strike.parentNode.insertBefore(redo, strike);
+    strike.parentNode.insertBefore(undo, redo);
+    undo.addEventListener('click', () => restore(-1, { focus: true }));
+    redo.addEventListener('click', () => restore(1, { focus: true }));
+    document.getElementById('caption-editor-btn').addEventListener('click', updateControls);
+    document.getElementById('transcript-editor-btn').addEventListener('click', updateControls);
+  }
+
+  injectControls();
+  reset('initial');
+
+  window.transcriptHistory = Object.freeze({
+    undo: (options) => restore(-1, options),
+    redo: (options) => restore(1, options),
+    canUndo: () => !captionMode() && position > 0,
+    canRedo: () => !captionMode() && position >= 0 && position < entries.length - 1,
+    reset,
+    flushPending: clearPending,
+    // Diagnostics used by bounded-history and cross-engine protocol tests.
+    inspect: () => ({ length: entries.length, position, totalBytes }),
+  });
+})();

--- a/js/transcript-lifecycle.js
+++ b/js/transcript-lifecycle.js
@@ -1,0 +1,65 @@
+/* Transcript lifecycle contract for same-document restores and identity changes. */
+
+(function () {
+  'use strict';
+
+  const IDENTITY_EVENT = 'hyperaudioDocumentIdentityChanged';
+  const RESTORED_EVENT = 'hyperaudioTranscriptRestored';
+  const MAX_AUDIT_ENTRIES = 50;
+  let generation = 0;
+  const audit = [];
+
+  function liveTimedTranscript() {
+    const transcript = document.getElementById('hypertranscript');
+    return transcript !== null && transcript.querySelector('span[data-m]') !== null
+      ? transcript : null;
+  }
+
+  function record(type, detail) {
+    audit.push({ type, detail, at: Date.now() });
+    if (audit.length > MAX_AUDIT_ENTRIES) audit.shift();
+  }
+
+  function signalIdentity(origin, extra) {
+    if (liveTimedTranscript() === null) {
+      console.warn('transcript-lifecycle: ignored identity signal without a timed transcript');
+      return false;
+    }
+    generation += 1;
+    const detail = Object.freeze(Object.assign({}, extra || {}, {
+      generation,
+      origin: origin || 'unknown',
+    }));
+    record('identity', detail);
+    document.dispatchEvent(new CustomEvent(IDENTITY_EVENT, { detail }));
+    return true;
+  }
+
+  function signalRestored(origin, extra) {
+    if (liveTimedTranscript() === null) {
+      console.warn('transcript-lifecycle: ignored restore signal without a timed transcript');
+      return false;
+    }
+    const detail = Object.freeze(Object.assign({}, extra || {}, {
+      generation,
+      origin: origin || 'unknown',
+    }));
+    record('restore', detail);
+    document.dispatchEvent(new CustomEvent(RESTORED_EVENT, { detail }));
+    return true;
+  }
+
+  window.transcriptLifecycle = Object.freeze({
+    IDENTITY_EVENT,
+    RESTORED_EVENT,
+    signalIdentity,
+    signalRestored,
+    generation: () => generation,
+    // Read-only copy for diagnostics and lifecycle regression tests.
+    auditLog: () => audit.map((entry) => ({
+      type: entry.type,
+      detail: Object.assign({}, entry.detail),
+      at: entry.at,
+    })),
+  });
+})();

--- a/js/transcript-lifecycle.js
+++ b/js/transcript-lifecycle.js
@@ -21,10 +21,9 @@
   }
 
   function signalIdentity(origin, extra) {
-    if (liveTimedTranscript() === null) {
-      console.warn('transcript-lifecycle: ignored identity signal without a timed transcript');
-      return false;
-    }
+    // Identity is unconditional: loader/error/empty documents must still end
+    // the previous document's history. Consumers decide whether the new DOM is
+    // eligible for a timed-transcript baseline.
     generation += 1;
     const detail = Object.freeze(Object.assign({}, extra || {}, {
       generation,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "node --test \"__TEST__/unit/**/*.test.mjs\"",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:soak": "playwright test --config playwright.soak.config.mjs"
   }
 }

--- a/playwright.soak.config.mjs
+++ b/playwright.soak.config.mjs
@@ -1,0 +1,24 @@
+// Soak tests (see __TEST__/soak/) — long-running leak detection, kept out of the
+// e2e project deliberately: each spec drives one flow hundreds of times, so it
+// runs in minutes rather than seconds and belongs in a nightly/on-demand run,
+// not on every push. Serial and retry-free: a soak result is a measurement, and
+// re-running a "failure" until it passes would defeat the point.
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '__TEST__/soak',
+  testMatch: '**/*.soak.spec.mjs',
+  timeout: 15 * 60 * 1000,
+  retries: 0,
+  workers: 1,
+  fullyParallel: false,
+  use: {
+    baseURL: 'http://localhost:4173',
+    viewport: { width: 1280, height: 800 },
+  },
+  webServer: {
+    command: 'python3 -m http.server 4173',
+    port: 4173,
+    reuseExistingServer: true,
+  },
+});


### PR DESCRIPTION
Fixes #400
Fixes #511

## Transcript undo/redo (#400)

The `400-undo-redo` branch, phases 0–2: a lifecycle contract (`hyperaudioTranscriptRestored`, identity signals from the save module), a mutation gateway (every programmatic transcript mutation through one door, with origin labels and fold policies), and live snapshot history — ⌘Z/⇧⌘Z owned by the editor in the transcript, native undo nowhere in the path. Engine probes on the issue show why native undo could not be kept: the normalize passes kill the entries covering the user's own keystrokes in both Chromium and WebKit, and a later ⌘Z reverts an unrelated older edit.

Merged and reconciled with 1.1.9's save-path rework, plus follow-ups:

- **Independent second witness**: `undo-independent.spec.mjs`, written blind against the engine probes before this implementation was known to the session that wrote it; passes unchanged bar one API name.
- **Buttons leave the top bar**: ↶/↷ are touch-only, floated on the transcript card's top edge (the ⓘ/copy pattern) — CSS only, the history module untouched. Fine-pointer devices use the keyboard; iOS system undo gestures reach the history module via `beforeinput`.
- **Undo back to the last save clears the dirty dot** (VS Code / NSDocument semantics), compared by state signature so a pending non-transcript edit keeps the dot honest; the stale draft retires so a reload cannot resurrect it.
- **Undo depth on long transcripts** (#510): entries cost ~2.9MB on a real interview transcript, so the 12MB byte cap held four — undo three steps deep. The fold fingerprint is stored as a hash (it is only ever compared for equality) and the cap rises to 48MB → depth ~30+ there. Delta entries remain tracked in #510.

## The caret no longer jumps after a typing pause (#511)

Present in 1.1.9 and independent of undo: the debounced sanitise pass ran its nbsp rewrite *before* saving the caret, and rewriting `nodeValue` on the caret's own text node collapses the selection — the guard recorded the corpse and restored it, parking the caret before the word being typed at every natural pause, with the next keystrokes landing there. The caret is now measured first (both pre-steps preserve character count, so the offsets stay valid), and the pre-steps count as changes so the restore also covers the previously-missed nbsp-only pass. Both regression tests verified failing against the old ordering.

## Tests

145 in the tree; 143 were green on this tree this morning before the #510 depth fix. That fix passed its full targeted surface (transcript-history, gateway, lifecycle, undo-independent — 28 tests) and was verified by hand at depth on the transcript that exposed it. The final whole-suite run is currently blocked by an environmental failure on the dev machine (the static test server dying mid-run; failures are identical with the change stashed), to be re-verified after release.

Editor version 1.2.0 is unrelated to `.hyperaudio` **format** version 1.2 (the container spec, unchanged this release; current format 1.3).

Phases 3–5 of the undo plan are tracked in #508, #509, #510.
