### PR TITLE
Version 1.2.1

### DIFF
--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -17,7 +17,7 @@ const FIXTURE_VTT = 'WEBVTT\n\n00:00:00.320 --> 00:00:01.500\nBenvenuti a Hypera
 // mutateJson lets a test write a container the WRITER can no longer produce —
 // e.g. paragraphs: [], which buildProjectJson now normalises away (#492) but
 // files predating the rule still carry, and readers must still tolerate.
-async function buildFixture(mutateJson) {
+async function buildFixture(mutateJson, captionsVtt) {
   const state = {
     generatorVersion: 'e2e',
     created: '2026-07-10T09:00:00Z',
@@ -49,16 +49,16 @@ async function buildFixture(mutateJson) {
     json: save.serializeProjectJson(project),
     html: '<article><section><p><span data-m="320" data-d="520">Benvenuti </span></p></section></article>',
     originalJson: JSON.stringify({ words: [{ start: 0.32, end: 0.84, text: 'benvenuti' }], paragraphs: [] }),
-    captionsVtt: FIXTURE_VTT,
+    captionsVtt: captionsVtt || FIXTURE_VTT,
     media: { name: 'tone.wav', data: ladderWav(2) },
   }, JSZip, 'nodebuffer');
 }
 
 // Open the fixture in the live page via the module's hidden input; collect any
 // native dialogs (a conformant open must produce none).
-async function openFixture(page, testInfo, dialogs, mutateJson) {
+async function openFixture(page, testInfo, dialogs, mutateJson, captionsVtt) {
   const fixturePath = testInfo.outputPath('fixture.hyperaudio');
-  fs.writeFileSync(fixturePath, await buildFixture(mutateJson));
+  fs.writeFileSync(fixturePath, await buildFixture(mutateJson, captionsVtt));
   page.on('dialog', (dialog) => {
     dialogs.push(dialog.message());
     dialog.accept();
@@ -903,4 +903,24 @@ test('undo does not clear the dot while a non-transcript edit is pending', async
   await page.keyboard.press('Meta+z'); // transcript back to saved; summary is not
 
   await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
+});
+
+// #513 — the caption editor is populated by parsing the saved VTT, and the
+// parse dropped the final cue every time (a single-cue VTT produced no rows at
+// all). Not cosmetic: generateCaptionsFromCaptionEditor rebuilds the VTT from
+// these rows, so editing any caption made the missing one permanent.
+test('every cue in the saved VTT reaches the caption editor (#513)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  const THREE_CUES = 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nFirst cue\n\n'
+    + '00:00:01.000 --> 00:00:02.000\nSecond cue\n\n'
+    + '00:00:02.000 --> 00:00:03.000\nThird cue\n';
+  await openFixture(page, testInfo, dialogs, null, THREE_CUES);
+  await awaitLibraryEntry(page);
+
+  await page.click('#caption-editor-btn');
+  await page.waitForFunction(() => document.querySelectorAll('#captions-display .caption').length > 0);
+
+  const lines = await page.locator('#captions-display .caption input.line1').evaluateAll(
+    (els) => els.map((e) => e.value.trim()));
+  expect(lines).toEqual(['First cue', 'Second cue', 'Third cue']);
 });

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -924,3 +924,90 @@ test('every cue in the saved VTT reaches the caption editor (#513)', async ({ pa
     (els) => els.map((e) => e.value.trim()));
   expect(lines).toEqual(['First cue', 'Second cue', 'Third cue']);
 });
+
+// #505 — NO caption edit reached the save module. The three structural buttons
+// are onclick handlers that rewrite the caption list without firing an input
+// event; typing does fire one, but EDIT_SCOPE names '#caption-editor', which is
+// a placeholder in a hidden modal — the real rows live in the transcript holder,
+// so the selector matched nothing. Captions changed, the project stayed clean,
+// and the edit was lost on close.
+const CAPTION = '#captions-display .caption';
+const enterCaptionMode = async (page) => {
+  await page.click('#caption-editor-btn');
+  await page.waitForFunction((sel) => document.querySelectorAll(sel).length > 0, CAPTION);
+  // Opening a project whose captions are curated raises the "Captions have
+  // been edited" notice, and it sits OVER the first caption rows, intercepting
+  // clicks — dismiss it the way a user must (see #506, which is about that
+  // notice's design).
+  const alertBox = page.locator('#captionsource-alert');
+  if (await alertBox.isVisible()) await page.click('#captionsource-alert-ok');
+  await expect(alertBox).toBeHidden();
+};
+
+for (const action of ['insert', 'merge', 'delete']) {
+  test(`caption ${action} marks the project dirty (#505)`, async ({ page }, testInfo) => {
+    const dialogs = [];
+    await openFixture(page, testInfo, dialogs);
+    await awaitLibraryEntry(page);
+    await enterCaptionMode(page);
+    await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+
+    // merge needs a second caption below the first to merge INTO
+    if (action === 'merge') {
+      await page.locator(CAPTION).first()
+        .locator('button', { hasText: 'insert' }).click();
+      await page.evaluate(() => window.HyperaudioSave.autosaveNow());
+      await page.evaluate(() => {
+        document.getElementById('project-save-btn').classList.remove('dirty');
+      });
+    }
+
+    const countBefore = await page.locator(CAPTION).count();
+    await page.locator(CAPTION).first()
+      .locator('button', { hasText: action }).click();
+
+    // the caption list really changed...
+    const countAfter = await page.locator(CAPTION).count();
+    expect(countAfter).toBe(action === 'insert' ? countBefore + 1 : countBefore - 1);
+    // ...and the save module heard about it
+    await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
+  });
+}
+
+test('typing in a caption marks the project dirty (#505)', async ({ page }, testInfo) => {
+  // EDIT_SCOPE lists '#caption-editor', but the caption rows are not in it —
+  // that id belongs to a hidden modal placeholder — so typing never reached
+  // the save module either. The choke-point announcement covers it.
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+  await enterCaptionMode(page);
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+
+  await page.locator(CAPTION).first().locator('input.line1').click();
+  await page.keyboard.type('EDITED');
+  await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
+});
+
+test('a caption deletion survives the save that follows it (#505)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+  await enterCaptionMode(page);
+
+  const firstLine = await page.locator(CAPTION).first()
+    .locator('input.line1').inputValue();
+  expect(firstLine.trim()).not.toBe('');
+
+  await page.locator(CAPTION).first()
+    .locator('button', { hasText: 'delete' }).click();
+  await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
+
+  await page.keyboard.press('Control+s');
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+
+  // the saved VTT no longer carries the deleted cue's text
+  const saved = (await readCurrentProject(page)).saved;
+  expect(saved.captionsVtt).not.toContain(firstLine.trim());
+});
+

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.2.0 (last changed in release 1.2.0) -->
+<!--  Hyperaudio Lite Editor - Version 1.2.1 (last changed in release 1.2.1) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.2.0">
+  <meta name="version" content="1.2.1">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">

--- a/index.html
+++ b/index.html
@@ -1078,7 +1078,7 @@ If you are creating an open source application under a license compatible with t
     }
 
   </style>
-  <script src="js/editor-main.js?v=0.8.0"></script>
+  <script src="js/editor-main.js?v=1.2.1"></script>
   <script src="js/find-replace.js?v=1.2.0"></script>
   <script src="js/transcript-history.js?v=1.2.0"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
@@ -1098,7 +1098,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.0"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.1"></script>
   <script src="js/hyperaudio-library.js?v=1.1.6"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/js/editor-main.js
+++ b/js/editor-main.js
@@ -141,6 +141,15 @@
         }
       });
 
+      // The loop only pushes a cue when it meets the NEXT timestamp line, so
+      // the last one was never pushed — every VTT lost its final caption, and
+      // a single-cue VTT produced no rows at all (#513). Not cosmetic: the
+      // editor is what generateCaptionsFromCaptionEditor rebuilds the VTT
+      // from, so the dropped cue vanished for good on the next save.
+      if (start !== undefined) {
+        data.push({start, stop, text});
+      }
+
       populateCaptionEditor(data);
 
       if (updateCaptionsFromTranscript === false && localStorage.getItem("noCaptionAlert") !== "true") {

--- a/js/editor-main.js
+++ b/js/editor-main.js
@@ -421,10 +421,20 @@
       makeCaptionEditorActive();
     }
 
+    // The one door every caption edit passes through — typing (captionChange),
+    // insert, merge and delete all land here. Typing alone reached the save
+    // module, because its inputs fire a real `input` event that the module's
+    // delegation picks up inside #caption-editor; the three structural buttons
+    // are onclick handlers that mutate the caption list without any input
+    // event, so their changes — and the updateCaptionsFromTranscript flip
+    // below, which is itself persisted project state — left the project
+    // looking clean and were lost on close (#505). Announcing it here covers
+    // all four in one place rather than chasing three onclick handlers.
     function makeCaptionEditorActive() {
       updateCaptionsFromTranscript = false;
       document.querySelector('#regenerate-btn').classList.remove("btn-disabled");
       generateCaptionsFromCaptionEditor();
+      document.dispatchEvent(new CustomEvent('hyperaudioCaptionsEdited'));
     }
 
     function generateCaptionsFromCaptionEditor() {

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.2.0 — last changed in release 1.2.0
+ * @version 1.2.1 — last changed in release 1.2.1
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind
@@ -2534,6 +2534,18 @@
     document.addEventListener('hyperaudioGenerateCaptionsFromTranscript', () => {
       // the engine-driven caption pass during project birth is part of the
       // committed v0, not an edit — see birthInProgress
+      if (birthInProgress) return;
+      scheduleAutosave();
+    });
+    // Caption edits from the caption editor itself (#505). EDIT_SCOPE already
+    // catches TYPING there, because the caption inputs fire a real `input`
+    // event — but insert, merge and delete are onclick handlers that rewrite
+    // the caption list silently, so the project stayed clean over a change
+    // that was then lost on close. editor-main announces all four from its one
+    // choke point; typing therefore signals twice, which costs nothing (this
+    // only sets the flag and restarts the debounce). Same birth guard as
+    // above: a caption pass belonging to the committed v0 is not an edit.
+    document.addEventListener('hyperaudioCaptionsEdited', () => {
       if (birthInProgress) return;
       scheduleAutosave();
     });


### PR DESCRIPTION
Fixes #505
Fixes #513

Two silent data-loss bugs in the caption editor, both found while fixing the first.

## Every cue in the saved VTT reaches the caption editor (#513)

`populateCaptionEditorFromVtt` pushes each cue only when it meets the **next** timestamp line, and nothing pushed the final one after the loop. So every VTT lost its last caption, and a single-cue VTT produced no rows at all:

```
1 cue  -> 0 rows
3 cues -> 2 rows (the third dropped)
```

Not cosmetic. `generateCaptionsFromCaptionEditor` rebuilds the VTT from exactly these rows, so opening a project, editing any caption and saving made the missing cue permanent. Reached on every VTT route — opening a `.hyperaudio`, importing VTT/SRT. Captions generated from the transcript go through `populateCaptionEditor` directly and were unaffected.

Present in 1.2.0 and earlier.

## Caption edits mark the project dirty (#505)

No caption edit reached the save module at all. The structural buttons (insert, merge, delete) are `onclick` handlers that rewrite the caption list without firing an input event. Typing *does* fire one, but `EDIT_SCOPE` names `#caption-editor` — a placeholder inside a hidden modal. The real caption rows are built into `#captions-display` inside `.transcript-holder`, because caption mode replaces the transcript view, so the selector matched nothing.

The result: captions changed, the project stayed clean, no autosave, and the edit was lost on close.

`makeCaptionEditorActive()` is the one door all four paths already pass through — and where `updateCaptionsFromTranscript` flips, which is itself persisted project state — so it now announces `hyperaudioCaptionsEdited`, and the save module schedules an autosave on it under the same birth guard the transcript-driven caption pass uses.

The issue as filed claimed typing already worked; investigating it showed otherwise, and the issue has been corrected on GitHub.

## Tests

149 passing, up from 144. Six new: every cue reaching the editor (#513, opening a real three-cue project), the four caption edit paths marking dirty, and a deletion surviving the save that follows it. All verified failing without their fixes.

`enterCaptionMode` dismisses the "Captions have been edited" notice, which sits over the first caption rows and intercepts pointer events — real behaviour a user also has to work around, now recorded on #506.

## Also investigated, no change

A report of intro captions appearing on an uploaded transcript. Measured the #499 stale-listener mechanism against the transcribe path: it survives, because `caption.js` defers the new document's write too and registration order puts it last. Safe today but incidental rather than designed — filed as #515.
