### PR TITLE
Version 1.2.2

### DIFF
--- a/__TEST__/e2e/library.spec.mjs
+++ b/__TEST__/e2e/library.spec.mjs
@@ -322,11 +322,12 @@ test('deleting the CURRENT project keeps it on screen and Restore re-homes it', 
   }, after.current);
 });
 
-test('boot restores the most recently EDITED project, not the last opened', async ({ page }, testInfo) => {
+test('boot restores the project you were last ON, not the last written', async ({ page }, testInfo) => {
   await openProject(page, testInfo, 'Project A');
   await openProject(page, testInfo, 'Project B');
 
-  // go back to A and edit it — A becomes the most recently edited
+  // Edit A, then switch to B and leave it alone. A is the most recently
+  // WRITTEN (its draft flushes on the way out), B is the one being looked at.
   await row(page, 'Project A').click();
   await expect(activeRow(page)).toHaveText('Project A');
   await page.evaluate(() => {
@@ -334,25 +335,50 @@ test('boot restores the most recently EDITED project, not the last opened', asyn
     span.textContent = 'LAST-EDIT ';
     span.dispatchEvent(new Event('input', { bubbles: true }));
   });
-  // Wait for the INDEX to carry the edit (snapshot lands first, then the
-  // entry) — boot orders by the index, so that's the durable signal.
   const idA = await page.evaluate(() => window.HyperaudioSave.library.currentId());
   await pollPage(page, async (id) => {
     const root = await navigator.storage.getDirectory();
     const dir = await (await root.getDirectoryHandle('work')).getDirectoryHandle(id);
-    let text = null;
-    try { text = await (await (await dir.getFileHandle('draft.json')).getFile()).text(); }
-    catch (e) { return false; }
-    if (text.indexOf('LAST-EDIT') === -1) return false;
-    const lib = JSON.parse(await (await (await root.getFileHandle('library.json')).getFile()).text());
-    const edited = lib.projects.find((p) => p.id === id);
-    return lib.projects.every((p) => p.id === id || (p.modifiedAt || 0) < (edited.modifiedAt || 0));
+    try {
+      const text = await (await (await dir.getFileHandle('draft.json')).getFile()).text();
+      return text.indexOf('LAST-EDIT') !== -1;
+    } catch (e) { return false; }
   }, idA);
+
+  await row(page, 'Project B').click();
+  await expect(activeRow(page)).toHaveText('Project B');
+  await pollPage(page, async () => {
+    const root = await navigator.storage.getDirectory();
+    const lib = JSON.parse(await (await (await root.getFileHandle('library.json')).getFile()).text());
+    const id = window.HyperaudioSave.library.currentId();
+    const b = lib.projects.find((p) => p.id === id);
+    return !!(b && b.lastActiveAt);
+  });
 
   await page.reload();
   await page.waitForSelector('#hypertranscript [data-m]');
-  await expect(page.locator('#hypertranscript')).toContainText('LAST-EDIT');
-  await expect(activeRow(page)).toHaveText('Project A');
+  await expect(activeRow(page)).toHaveText('Project B');
+});
+
+test('a library written before lastActiveAt still boots to its newest entry', async ({ page }, testInfo) => {
+  await openProject(page, testInfo, 'Project A');
+  await openProject(page, testInfo, 'Project B');
+
+  // strip the field, as an existing user's library has it
+  await page.evaluate(async () => {
+    const root = await navigator.storage.getDirectory();
+    const handle = await root.getFileHandle('library.json');
+    const lib = JSON.parse(await (await handle.getFile()).text());
+    lib.projects.forEach((p) => { delete p.lastActiveAt; });
+    const w = await handle.createWritable();
+    await w.write(JSON.stringify(lib));
+    await w.close();
+  });
+
+  await page.reload();
+  await page.waitForSelector('#hypertranscript [data-m]');
+  // falls back to modifiedAt — B was opened last, so it is the newest write
+  await expect(activeRow(page)).toHaveText('Project B');
 });
 
 test('reload never flashes the demo transcript over a saved project (#473)', async ({ page }, testInfo) => {

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1016,6 +1016,14 @@ test('a caption deletion survives the save that follows it (#505)', async ({ pag
 // and packs the whole thing into a blob: seconds to minutes on real media,
 // during which the app showed nothing at all. The only prior signal was a
 // confirm dialog above 500MB, so an ordinary 100MB interview got none.
+// openFixture resolves as soon as the transcript paints, but the open keeps
+// running (draft flush, OPFS seeding). Waiting for the progress pill to clear
+// is the precise signal that openFromFile's finally has run — without it a
+// following open is legitimately refused by the #504 guard.
+const awaitOpenIdle = (page) => pollPage(page, async () =>
+  document.getElementById('project-progress') === null
+  && window.HyperaudioSave.library.currentId() !== null);
+
 const watchProgress = async (page) => {
   const seen = [];
   await page.exposeFunction('__recordProgress', (t) => { seen.push(t); });
@@ -1083,3 +1091,77 @@ test('a second export while one is running says so rather than nothing (#502)', 
   expect(result.box).toEqual({ onScreen: true, clearsPlaybar: true, visible: true });
 });
 
+
+// #504 — the open path had no in-flight guard, where export has refused
+// concurrent runs since #448. Note what this does NOT claim: two concurrent
+// opens were measured (including with slow, large media) and produced no
+// duplicate library entries and no inconsistent session state — the harm the
+// issue predicted did not reproduce. The guard earns its place by bounding the
+// concurrency explicitly rather than leaving it to be reasoned about, and by
+// telling the user why their second attempt did nothing.
+test('the in-flight open explains itself rather than doing nothing (#504)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+
+  // Two opens started back to back. What the file contains does not matter —
+  // the guard is set synchronously before the first await, so the second call
+  // takes the refusal path regardless of whether the first ultimately succeeds.
+  const text = await page.evaluate(async () => {
+    const dummy = () => new File(['not a zip'], 'x.hyperaudio');
+    const first = window.HyperaudioSave.openFromFile(dummy());
+    const second = window.HyperaudioSave.openFromFile(dummy());
+    const el = document.getElementById('project-progress');
+    const t = el ? el.textContent : null;
+    await Promise.allSettled([first, second]);
+    return t;
+  });
+
+  expect(text).toMatch(/one at a time/);
+});
+
+// #503 — the mirror of #502 on the way in. Opening a real project unzips the
+// media into memory, wraps it in a File (a second full copy) and seeds OPFS
+// with it, all before the first visible change: seconds of nothing.
+test('opening a project reports progress and clears it (#503)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);      // one open to get a File in the input
+  await awaitOpenIdle(page);
+
+  // Sample the pill from inside the page while the open runs: the record-to-node
+  // bridge is asynchronous and was losing entries against a fast open.
+  const result = await page.evaluate(async () => {
+    const seen = [];
+    const sample = () => {
+      const el = document.getElementById('project-progress');
+      if (el && seen[seen.length - 1] !== el.textContent) seen.push(el.textContent);
+    };
+    const timer = setInterval(sample, 5);
+    const file = document.getElementById('project-open-input').files[0];
+    const p = window.HyperaudioSave.openFromFile(file);
+    sample();
+    await p;
+    clearInterval(timer);
+    return { seen, pillLeft: !!document.getElementById('project-progress') };
+  });
+
+  expect(result.seen.some((t) => /Opening the project file/.test(t))).toBe(true);
+  expect(result.seen.some((t) => /Loading the project/.test(t))).toBe(true);
+  expect(result.pillLeft).toBe(false);   // cleared when the work is done
+  expect(dialogs).toEqual([]);
+});
+
+test('reading a large media reports a percentage while opening (#503)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  // big enough that JSZip streams the extraction rather than finishing in one tick
+  await openFixture(page, testInfo, dialogs, null, null, 600);
+  await awaitOpenIdle(page);
+  const seen = await watchProgress(page);
+
+  await page.evaluate(async () => {
+    const file = document.getElementById('project-open-input').files[0];
+    await window.HyperaudioSave.openFromFile(file);
+  });
+  await page.waitForTimeout(300);
+
+  expect(seen.some((t) => /Reading the media… \d+%/.test(t))).toBe(true);
+});

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -17,7 +17,7 @@ const FIXTURE_VTT = 'WEBVTT\n\n00:00:00.320 --> 00:00:01.500\nBenvenuti a Hypera
 // mutateJson lets a test write a container the WRITER can no longer produce —
 // e.g. paragraphs: [], which buildProjectJson now normalises away (#492) but
 // files predating the rule still carry, and readers must still tolerate.
-async function buildFixture(mutateJson, captionsVtt) {
+async function buildFixture(mutateJson, captionsVtt, mediaSeconds) {
   const state = {
     generatorVersion: 'e2e',
     created: '2026-07-10T09:00:00Z',
@@ -50,15 +50,15 @@ async function buildFixture(mutateJson, captionsVtt) {
     html: '<article><section><p><span data-m="320" data-d="520">Benvenuti </span></p></section></article>',
     originalJson: JSON.stringify({ words: [{ start: 0.32, end: 0.84, text: 'benvenuti' }], paragraphs: [] }),
     captionsVtt: captionsVtt || FIXTURE_VTT,
-    media: { name: 'tone.wav', data: ladderWav(2) },
+    media: { name: 'tone.wav', data: ladderWav(mediaSeconds || 2) },
   }, JSZip, 'nodebuffer');
 }
 
 // Open the fixture in the live page via the module's hidden input; collect any
 // native dialogs (a conformant open must produce none).
-async function openFixture(page, testInfo, dialogs, mutateJson, captionsVtt) {
+async function openFixture(page, testInfo, dialogs, mutateJson, captionsVtt, mediaSeconds) {
   const fixturePath = testInfo.outputPath('fixture.hyperaudio');
-  fs.writeFileSync(fixturePath, await buildFixture(mutateJson, captionsVtt));
+  fs.writeFileSync(fixturePath, await buildFixture(mutateJson, captionsVtt, mediaSeconds));
   page.on('dialog', (dialog) => {
     dialogs.push(dialog.message());
     dialog.accept();
@@ -1009,5 +1009,77 @@ test('a caption deletion survives the save that follows it (#505)', async ({ pag
   // the saved VTT no longer carries the deleted cue's text
   const saved = (await readCurrentProject(page)).saved;
   expect(saved.captionsVtt).not.toContain(firstLine.trim());
+});
+
+
+// #502 — building a container reads the media out of OPFS, may download it,
+// and packs the whole thing into a blob: seconds to minutes on real media,
+// during which the app showed nothing at all. The only prior signal was a
+// confirm dialog above 500MB, so an ordinary 100MB interview got none.
+const watchProgress = async (page) => {
+  const seen = [];
+  await page.exposeFunction('__recordProgress', (t) => { seen.push(t); });
+  await page.evaluate(() => {
+    new MutationObserver(() => {
+      const el = document.getElementById('project-progress');
+      if (el) window.__recordProgress(el.textContent);
+    }).observe(document.body, { childList: true, subtree: true, characterData: true });
+  });
+  return seen;
+};
+
+test('exporting reports progress, and clears it when the download arrives (#502)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  const seen = await watchProgress(page);
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.evaluate(() => document.getElementById('project-export-hyperaudio').click());
+  await downloadPromise;
+
+  expect(seen.some((t) => /Preparing/.test(t))).toBe(true);   // click acknowledged
+  expect(seen.some((t) => /Packaging.*\d+%/.test(t))).toBe(true); // real percentage
+  await expect(page.locator('#project-progress')).toHaveCount(0); // gone when done
+  expect(dialogs).toEqual([]);
+});
+
+test('a second export while one is running says so rather than nothing (#502)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  // 10 minutes of audio: packing has to still be running when the hold is
+  // checked, which is the whole condition the hold exists for
+  await openFixture(page, testInfo, dialogs, null, null, 600);
+
+  const result = await page.evaluate(async () => {
+    const first = window.HyperaudioSave.exportProject();   // deliberately not awaited
+    const secondPromise = window.HyperaudioSave.exportProject();
+    // Read the pill SYNCHRONOUSLY: the refusal path has no await before it
+    // shows its message, so the text is correct right now — awaiting first
+    // would let the running export overwrite it with its own next stage.
+    const el = document.getElementById('project-progress');
+    const text = el ? el.textContent : null;
+    // the pill is guaranteed on screen at this instant — pin its placement
+    const bar = document.getElementById('playbar').getBoundingClientRect();
+    const r = el ? el.getBoundingClientRect() : null;
+    const box = r ? {
+      onScreen: r.top >= 0 && r.left >= 0
+        && r.right <= window.innerWidth && r.bottom <= window.innerHeight,
+      clearsPlaybar: r.bottom <= bar.top,
+      visible: getComputedStyle(el).display !== 'none' && r.width > 0,
+    } : null;
+    const second = await secondPromise;
+    await new Promise((r) => setTimeout(r, 400)); // packing is streaming updates
+    const stillEl = document.getElementById('project-progress');
+    const textAfterDelay = stillEl ? stillEl.textContent : null;
+    await first;
+    return { second, text, box, textAfterDelay };
+  });
+
+  expect(result.second).toBe(false);                 // still one build at a time
+  expect(result.text).toMatch(/Still building/);     // but it explains itself
+  // and it STAYS readable: packing fires progress updates every few ms, which
+  // used to overwrite this before anyone could read it
+  expect(result.textAfterDelay).toMatch(/Still building/);
+  // and it is actually visible, fully on screen, clear of the play bar
+  expect(result.box).toEqual({ onScreen: true, clearsPlaybar: true, visible: true });
 });
 

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -1487,3 +1487,37 @@ label[data-a11y-wired]:focus-visible {
   background: transparent;
   opacity: 0.7;
 }
+
+/* Export progress pill (#502). Fixed above the play bar rather than in
+   #side-notices, which is an off-canvas drawer on the small-screen layout —
+   invisible on exactly the devices where building a container takes longest.
+   Right-aligned so it does not cover the transcript's left reading edge, and
+   below the corner buttons' z-index band so it never fights them. */
+#project-progress {
+  position: fixed;
+  right: 16px;
+  bottom: 64px;               /* play bar (52px) + 12px */
+  z-index: 30;
+  max-width: calc(100vw - 32px);
+  padding: 8px 14px;
+  border-radius: 9999px;
+  background: oklch(var(--n, 0.2 0 0));
+  color: oklch(var(--nc, 0.98 0 0));
+  font-size: 0.85rem;
+  line-height: 1.4;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+@media screen and (max-width: 948px) {
+  #project-progress {
+    right: 12px;
+    left: 12px;
+    bottom: 60px;
+    text-align: center;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  #project-progress { transition: none; }
+}

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.2.0">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.2.2">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1098,7 +1098,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.1"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.2"></script>
   <script src="js/hyperaudio-library.js?v=1.1.6"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.2.1 (last changed in release 1.2.1) -->
+<!--  Hyperaudio Lite Editor - Version 1.2.2 (last changed in release 1.2.2) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.2.1">
+  <meta name="version" content="1.2.2">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -344,7 +344,7 @@
   // htmlText, ...} when hyperaudio.json is missing/unreadable but the HTML
   // compatibility copy can be used (spec § 4 recovery). Throws {code, message}
   // on rejection (version-major, media-kind, unreadable, entry-too-large).
-  async function unzipProject(data, JSZipImpl) {
+  async function unzipProject(data, JSZipImpl, onMediaProgress) {
     const rejection = (code, message) => {
       const err = new Error(message);
       err.code = code;
@@ -447,7 +447,10 @@
         if (comp && comp.magic && comp.magic !== '\x00\x00') {
           throw rejection('media-compressed', 'the media entry is compressed; the format requires STORE');
         }
-        mediaData = await mediaEntry.async('uint8array');
+        // Extracting the media is the long pole on the way in, and the only
+        // step that can report a real percentage (#503).
+        mediaData = await mediaEntry.async('uint8array',
+          typeof onMediaProgress === 'function' ? onMediaProgress : undefined);
         mediaEntryName = project.media.path.slice(MEDIA_DIR.length);
       }
     }
@@ -1760,19 +1763,20 @@
       return false;
     }
     exportInFlight = true;
+    const token = beginProgress();
     try {
-      return await exportProjectInner(!!(opts && opts.asSave));
+      return await exportProjectInner(!!(opts && opts.asSave), token);
     } finally {
       exportInFlight = false;
-      hideProgress();
+      hideProgress(token);
     }
   }
 
-  async function exportProjectInner(asSave) {
+  async function exportProjectInner(asSave, token) {
     const identityAtStart = identityGeneration;
     // Before the first await: the click is acknowledged even if resolving the
     // media out of OPFS takes a moment.
-    showProgress('Preparing the project file…');
+    showProgress('Preparing the project file…', 0, token);
     let mediaFile = await resolveMediaFile();
     const player = document.querySelector('#hyperplayer');
     const remoteSrc = player !== null && /^https?:/i.test(player.src) ? player.src : null;
@@ -1785,7 +1789,7 @@
         try {
           // a full media download over the network — the one step that can
           // take longer than the packing, so it gets its own message
-          showProgress('Downloading the media…');
+          showProgress('Downloading the media…', 0, token);
           mediaFile = await fetchRemoteMediaFile(remoteSrc);
           session.mediaFile = mediaFile;
           session.mediaFileFromUrl = remoteSrc;
@@ -1828,7 +1832,7 @@
     }
     state.hasOriginal = originalJson !== null;
 
-    showProgress('Packaging the project file…');
+    showProgress('Packaging the project file…', 0, token);
     const JSZipImpl = await loadJSZip();
     let lastPercent = -1;
     const blob = await zipProject({
@@ -1842,7 +1846,7 @@
       const percent = Math.floor(meta.percent);
       if (percent === lastPercent) return;
       lastPercent = percent;
-      showProgress('Packaging the project file… ' + percent + '%');
+      showProgress('Packaging the project file… ' + percent + '%', 0, token);
     });
 
     const safeTitle = (state.texts.title || 'project')
@@ -1883,15 +1887,48 @@
     return true;
   }
 
+  // One open at a time (#504). openFromFile is await-heavy — unzip, draft
+  // flush, apply, OPFS seeding — and the file input called it directly, so a
+  // second open starting mid-flight interleaved with the first at every await
+  // point: two library entries, and session.projectId, the OPFS lock and the
+  // media write left in an order neither call controlled. The export path has
+  // refused concurrent runs since #448; this is the same guard for the way in.
+  let openInFlight = false;
+
   async function openFromFile(file) {
+    if (openInFlight) {
+      showProgress('Still opening a project — one at a time.', 2000);
+      return;
+    }
+    openInFlight = true;
+    const token = beginProgress();
+    try {
+      return await openFromFileInner(file, token);
+    } finally {
+      openInFlight = false;
+      hideProgress(token);
+    }
+  }
+
+  async function openFromFileInner(file, token) {
     // Parse and validate BEFORE the replace-confirmation: asking permission
     // to replace the current project and THEN refusing the file meant the
     // user consented to a replacement that never happened (prepare → confirm
     // → apply, the #448 ordering).
     let loaded;
     try {
+      // Before the first await: opening a real project reads the whole media
+      // into memory twice (unzip, then the File wrapper) and seeds OPFS with
+      // it, which is seconds of nothing on screen (#503).
+      showProgress('Opening the project file…', 0, token);
       const JSZipImpl = await loadJSZip();
-      loaded = await unzipProject(file, JSZipImpl);
+      let lastPercent = -1;
+      loaded = await unzipProject(file, JSZipImpl, (meta) => {
+        const percent = Math.floor(meta.percent);
+        if (percent === lastPercent) return;
+        lastPercent = percent;
+        showProgress('Reading the media… ' + percent + '%', 0, token);
+      });
     } catch (e) {
       const messages = {
         'version-major': 'This project was saved by a newer version of the editor and cannot be opened here. Please update the editor.',
@@ -1905,6 +1942,7 @@
       return;
     }
 
+    showProgress('Loading the project…', 0, token);
     // No discard dialog (#456): the outgoing project's pending draft flushes
     // to its own directory and stays in the library — opening loses nothing.
     // The dialog existed only because there was one work slot.
@@ -2633,14 +2671,25 @@
    * ----------------------------------------------------------------------- */
   let progressEl = null;
   let progressHoldUntil = 0;
+  // Operations overlap — an open can still be seeding OPFS when an export
+  // starts — and they share one pill. Without ownership the older operation's
+  // cleanup wiped the newer one's message (caught by a full-suite run, where
+  // a slow open's finally landed mid-export and cleared a held message).
+  // beginProgress hands out a token; stale tokens are ignored.
+  let progressToken = 0;
+  function beginProgress() {
+    progressToken += 1;
+    return progressToken;
+  }
 
   // holdMs pins a message for a moment against the routine progress stream.
   // Needed because packing fires onUpdate every few milliseconds: a message
   // answering something the USER just did ("still building", after a second
   // click) was overwritten before it could be read — the test caught nothing
   // because it read the text synchronously, which a human cannot do.
-  function showProgress(message, holdMs) {
+  function showProgress(message, holdMs, token) {
     if (typeof document === 'undefined') return;
+    if (token !== undefined && token !== progressToken) return; // superseded
     const now = Date.now();
     if (!holdMs && now < progressHoldUntil) return; // a held message is on screen
     if (progressEl === null) {
@@ -2654,7 +2703,8 @@
     progressHoldUntil = holdMs ? now + holdMs : 0;
   }
 
-  function hideProgress() {
+  function hideProgress(token) {
+    if (token !== undefined && token !== progressToken) return; // not ours to clear
     progressHoldUntil = 0;
     if (progressEl !== null) {
       progressEl.remove();

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.2.1 — last changed in release 1.2.1
+ * @version 1.2.2 — last changed in release 1.2.2
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind
@@ -317,7 +317,7 @@
   // media?: {name, data}}. The mimetype entry goes FIRST and STORED so the MIME
   // type sits at byte offset 38 (EPUB convention, § 2.1); the media entry is
   // STORED because media formats are already compressed.
-  function zipProject(files, JSZipImpl, outType) {
+  function zipProject(files, JSZipImpl, outType, onUpdate) {
     const zip = new JSZipImpl();
     zip.file(ENTRY.mimetype, CONTAINER_MIMETYPE, { compression: 'STORE' });
     zip.file(ENTRY.json, files.json);
@@ -327,11 +327,15 @@
     if (files.media) {
       zip.file(MEDIA_DIR + sanitizeMediaFilename(files.media.name), files.media.data, { compression: 'STORE', binary: true });
     }
+    // onUpdate is JSZip's own progress callback (second argument to
+    // generateAsync) — optional so the node pure-layer tests call this
+    // unchanged. Packing the media dominates the wait, so this is the only
+    // step that can report a real percentage rather than a spinner (#502).
     return zip.generateAsync({
       type: outType || 'uint8array',
       compression: 'DEFLATE',
       streamFiles: true,
-    });
+    }, typeof onUpdate === 'function' ? onUpdate : undefined);
   }
 
   // Whitelist-read of a container (spec § 10.1): only entries with known names
@@ -1748,17 +1752,27 @@
   // touches it.
   let exportInFlight = false;
   async function exportProject(opts) {
-    if (exportInFlight) return false; // one container build at a time (#448)
+    if (exportInFlight) {
+      // Returning false silently (as this did) is the same dead end that makes
+      // a user click again in the first place — the build is slow and, before
+      // #502, invisible. Say what is happening instead.
+      showProgress('Still building the project file…', 2000);
+      return false;
+    }
     exportInFlight = true;
     try {
       return await exportProjectInner(!!(opts && opts.asSave));
     } finally {
       exportInFlight = false;
+      hideProgress();
     }
   }
 
   async function exportProjectInner(asSave) {
     const identityAtStart = identityGeneration;
+    // Before the first await: the click is acknowledged even if resolving the
+    // media out of OPFS takes a moment.
+    showProgress('Preparing the project file…');
     let mediaFile = await resolveMediaFile();
     const player = document.querySelector('#hyperplayer');
     const remoteSrc = player !== null && /^https?:/i.test(player.src) ? player.src : null;
@@ -1769,6 +1783,9 @@
         mediaFile = session.mediaFile; // already embedded by a previous save of this project
       } else {
         try {
+          // a full media download over the network — the one step that can
+          // take longer than the packing, so it gets its own message
+          showProgress('Downloading the media…');
           mediaFile = await fetchRemoteMediaFile(remoteSrc);
           session.mediaFile = mediaFile;
           session.mediaFileFromUrl = remoteSrc;
@@ -1811,14 +1828,22 @@
     }
     state.hasOriginal = originalJson !== null;
 
+    showProgress('Packaging the project file…');
     const JSZipImpl = await loadJSZip();
+    let lastPercent = -1;
     const blob = await zipProject({
       json: serializeProjectJson(buildProjectJson(state)),
       html: state.html,
       originalJson,
       captionsVtt: getCaptionsVtt() || null,
       media: mediaFile !== null ? { name: mediaFile.name, data: mediaFile } : null,
-    }, JSZipImpl, 'blob');
+    }, JSZipImpl, 'blob', (meta) => {
+      // JSZip fires this very frequently; only repaint on a whole percent
+      const percent = Math.floor(meta.percent);
+      if (percent === lastPercent) return;
+      lastPercent = percent;
+      showProgress('Packaging the project file… ' + percent + '%');
+    });
 
     const safeTitle = (state.texts.title || 'project')
       .replace(/\.hyperaudio$/i, '')
@@ -2592,6 +2617,49 @@
           el.addEventListener('input', scheduleAutosave);
         }
       });
+  }
+
+  /* --------------------------------------------------------------------------
+   * Export progress (#502). Building a container reads the media out of OPFS,
+   * may download it over the network, and packs the whole thing into a blob —
+   * seconds to minutes on real media, during which the app looked completely
+   * inert. The only pre-existing signal was a confirm dialog above 500MB, so
+   * an ordinary 100MB interview got nothing at all.
+   *
+   * A fixed pill rather than a notice in #side-notices: that panel is an
+   * off-canvas drawer on the small-screen layout, so a notice there is
+   * invisible on exactly the devices where the wait is longest. role=status +
+   * aria-live announces each stage without stealing focus.
+   * ----------------------------------------------------------------------- */
+  let progressEl = null;
+  let progressHoldUntil = 0;
+
+  // holdMs pins a message for a moment against the routine progress stream.
+  // Needed because packing fires onUpdate every few milliseconds: a message
+  // answering something the USER just did ("still building", after a second
+  // click) was overwritten before it could be read — the test caught nothing
+  // because it read the text synchronously, which a human cannot do.
+  function showProgress(message, holdMs) {
+    if (typeof document === 'undefined') return;
+    const now = Date.now();
+    if (!holdMs && now < progressHoldUntil) return; // a held message is on screen
+    if (progressEl === null) {
+      progressEl = document.createElement('div');
+      progressEl.id = 'project-progress';
+      progressEl.setAttribute('role', 'status');
+      progressEl.setAttribute('aria-live', 'polite');
+      document.body.appendChild(progressEl);
+    }
+    progressEl.textContent = message;
+    progressHoldUntil = holdMs ? now + holdMs : 0;
+  }
+
+  function hideProgress() {
+    progressHoldUntil = 0;
+    if (progressEl !== null) {
+      progressEl.remove();
+      progressEl = null;
+    }
   }
 
   function showTabGuardBanner() {

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -291,10 +291,34 @@
       (b.modifiedAt || b.createdAt || 0) - (a.modifiedAt || a.createdAt || 0));
   }
 
+  // Boot restores the project you were last LOOKING AT, which is not the same
+  // as the last one written. modifiedAt is stamped by writes, so simply
+  // opening a project to read it left it invisible to the boot order — and
+  // switching away from A to B flushes A's pending draft, stamping A as the
+  // newest, so a reload landed back on the project you had just left.
+  // lastActiveAt is stamped when a project BECOMES current. Entries written
+  // before this field fall back to modifiedAt, so an existing library keeps
+  // its previous ordering rather than jumping to the bottom.
+  function sortByLastActive(entries) {
+    const key = (e) => e.lastActiveAt || e.modifiedAt || e.createdAt || 0;
+    return entries.slice().sort((a, b) => key(b) - key(a));
+  }
+
   // The deterministic per-project "dirty" rule (#456, Glider-matched): a
   // draft has been written since the last manual Save. A never-saved project
   // (fresh transcription) is dirty; an opened .hyperaudio starts clean (the
   // file IS the saved state).
+  // Best-effort: a project the library has no entry for yet (a birth, before
+  // its first write) gets its stamp when that write creates the entry.
+  function markProjectActive(id) {
+    if (!opfsAvailable || id === null) return;
+    const now = Date.now();
+    updateLibrary((lib) => {
+      const entry = lib.projects.find((p) => p.id === id);
+      if (entry !== undefined) entry.lastActiveAt = now;
+    }).catch((e) => console.warn('hyperaudio-save: marking the project active failed', e));
+  }
+
   function isEntryDirty(entry) {
     return (entry.lastDraftAt || 0) > (entry.lastSavedAt || 0);
   }
@@ -1215,6 +1239,7 @@
           createdAt: Date.parse(state.created) || now,
           lastDraftAt: 0,
           lastSavedAt: 0,
+          lastActiveAt: now, // a project being written IS the current one
         };
         lib.projects.push(entry);
       }
@@ -2114,6 +2139,7 @@
     apply({ recovered: false, project, captionsVtt: files.captionsVtt, mediaFile: files.mediaFile });
     session.active = true;
     session.projectId = id;
+    markProjectActive(id);   // this is now the project you are looking at
     identityGeneration += 1; // a different document owns the session now
     session.created = project.created || nowIso();
     session.provenance = project.provenance || null;
@@ -2366,9 +2392,9 @@
       await migrateSingleSlotWork();
       const lib = await readLibrary();
       syncProjectsHint(lib); // self-heal a cleared/stale hint (#473)
-      // Most recently edited first; a corrupt head entry falls through to the
+      // Most recently ACTIVE first; a corrupt head entry falls through to the
       // next rather than abandoning the boot (the demo stays for none).
-      for (const entry of sortLibraryEntries(lib.projects)) {
+      for (const entry of sortByLastActive(lib.projects)) {
         if (await switchToProject(entry.id)) break;
       }
     } catch (e) {


### PR DESCRIPTION
Fixes #502
Fixes #503
Fixes #504

Feedback for the two operations that made the app look dead, the guard the import path never had, and a reload that lands where you left off.

## Progress while a project is built or opened (#502, #503)

Exporting reads the media out of OPFS, sometimes downloads it, and packs the whole thing into a blob. Opening does the mirror: unzips the media into memory, wraps it in a File (a second full copy) and seeds OPFS with it. Both took seconds to minutes on real media with **nothing on screen at all** — the only prior signal was a confirm dialog above 500MB, so an ordinary 100MB interview got none.

A fixed pill above the play bar now carries the stages. The click is acknowledged before the first await; the network fetch names itself because it can dominate everything else; and both the packing and the media extraction report a real percentage from JSZip's own callbacks, threaded through `zipProject`/`unzipProject` as optional arguments so the node pure-layer tests call them unchanged.

A pill rather than a notice in `#side-notices`: that panel is an off-canvas drawer on the small-screen layout, invisible on exactly the devices where the wait is longest. `role=status` + `aria-live` announces each stage without stealing focus.

Two things manual testing forced that the tests had not:

- **Held messages.** A second export answered with "Still building the project file…" — and packing's progress stream overwrote it within milliseconds. The test read the text synchronously, which a human cannot, so it passed on a technicality. Explicitly-requested messages now pin the pill for two seconds.
- **Ownership.** Operations overlap: an open can still be seeding OPFS when an export begins, and they share one pill, so the older operation's cleanup wiped the newer one's message. Found only under a full-suite run, where the open is slow enough for its `finally` to land mid-export. Each operation now takes a token; stale tokens are ignored.

## One open at a time (#504)

`openFromFile` had no in-flight guard, where export has refused concurrent runs since #448.

Honest note, also recorded on the issue: **the harm #504 predicted did not reproduce.** Two genuinely concurrent opens, including with slow large media, produced no duplicate library entries and no inconsistent session state; the test asserting otherwise passed with and without the guard and was dropped rather than kept as decoration. The guard earns its place by bounding the concurrency explicitly and by letting the second attempt say why nothing happened — and it proved itself immediately, refusing an overlap a test of mine created by accident.

## Reload restores the project you were last on

Boot picked the entry with the newest `modifiedAt`, but that field is stamped by **writes**, not by looking at something. Opening a project to read it left it invisible to the boot order — and switching from A to B flushes A's pending draft on the way out, stamping A as newest, so a reload landed back on the project you had just left. Since Recents sorts by the same field, it read as "reload always shows the top of Recents".

Entries now carry `lastActiveAt`, stamped when a project becomes current, and boot orders by it. Recents is unchanged. Entries predating the field fall back to `modifiedAt`, so an existing library keeps its ordering rather than jumping to the bottom.

This reverses what a #456-era test asserted ("the most recently EDITED project, not the last opened"). That framing avoided a stale pointer, but the switch-flush interaction made it actively choose the wrong project.

## Tests

155 passing, up from 151. New: export progress and its held refusal message, open progress and the media percentage, the in-flight open refusal, boot restoring the last-active project, and a legacy library with the field stripped. Each verified failing without its fix.
