### PR TITLE
Version 1.2.4

### DIFF
--- a/__TEST__/e2e/caption-track-reset.spec.mjs
+++ b/__TEST__/e2e/caption-track-reset.spec.mjs
@@ -314,3 +314,42 @@ test('the caption editor reflects transcript edits on first visit', async ({ pag
     (els) => els.map((e) => e.value).join(' '));
   expect(lines).toContain('EDITED-WORD');
 });
+
+// The layer BENEATH the stale-cache fix, found because the fix checked a flag
+// that was lying: nothing reset updateCaptionsFromTranscript on a NEW
+// transcription — it inherited the previous project's value. After any
+// project with curated captions (every opened .hyperaudio with edited
+// captions, every VTT import), a fresh transcription's edits updated neither
+// the video captions nor the caption editor.
+// (No companion test for the import routes keeping sync OFF: they set the
+// flag immediately after the synchronous init dispatch, so the override
+// winning is language semantics — a test would be testing dispatchEvent.)
+test('a new transcription turns caption sync back on', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+
+  // the inherited state: a previous project left sync off
+  // unqualified access reaches the scripts' top-level let (a window property
+  // would be a shadow — top-level let is global-lexical, not on window)
+  await page.evaluate(() => { updateCaptionsFromTranscript = false; });
+
+  // a fresh transcription lands, exactly as every engine delivers it
+  await page.evaluate(() => {
+    document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+    document.dispatchEvent(new CustomEvent('hyperaudioGenerateCaptionsFromTranscript'));
+  });
+  expect(await page.evaluate(() => updateCaptionsFromTranscript)).toBe(true);
+
+  // edit, then first visit to the caption editor: the edit is there
+  await page.evaluate(() => {
+    const span = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    span.textContent = 'POST-TRANSCRIBE-EDIT ';
+    span.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await page.click('#caption-editor-btn');
+  await page.waitForFunction(() => document.querySelectorAll('#captions-display .caption').length > 0);
+  const lines = await page.locator('#captions-display .caption input.line1').evaluateAll(
+    (els) => els.map((e) => e.value).join(' '));
+  expect(lines).toContain('POST-TRANSCRIBE-EDIT');
+});
+

--- a/__TEST__/e2e/caption-track-reset.spec.mjs
+++ b/__TEST__/e2e/caption-track-reset.spec.mjs
@@ -285,3 +285,32 @@ test('the guard alone defends a synchronous caption write (#515)', async ({ page
 
   expect(result).toBe(true);
 });
+
+// The caption editor's first visit after transcript edits showed PRE-EDIT
+// captions: the row cache is primed at transcription time (the engines'
+// caption pass runs the builder with captionMode false), transcript edits
+// regenerate only the track, and entering the caption view then trusted the
+// stale cache over the fresh data it had just computed. While captions are
+// machine-synced the cache must never win; once hand-edited (sync off) it is
+// authoritative again — that is what it exists for.
+test('the caption editor reflects transcript edits on first visit', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+
+  // prime the cache exactly as a fresh transcription does
+  await page.evaluate(() => document.dispatchEvent(new CustomEvent('hyperaudioGenerateCaptionsFromTranscript')));
+
+  // edit the transcript AFTER the prime
+  await page.evaluate(() => {
+    const span = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    span.textContent = 'EDITED-WORD ';
+    span.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+
+  // first visit to the caption editor must carry the edit
+  await page.click('#caption-editor-btn');
+  await page.waitForFunction(() => document.querySelectorAll('#captions-display .caption').length > 0);
+  const lines = await page.locator('#captions-display .caption input.line1').evaluateAll(
+    (els) => els.map((e) => e.value).join(' '));
+  expect(lines).toContain('EDITED-WORD');
+});

--- a/__TEST__/e2e/caption-track-reset.spec.mjs
+++ b/__TEST__/e2e/caption-track-reset.spec.mjs
@@ -188,3 +188,100 @@ test('a caption pass armed on unloaded media cannot overwrite the next document 
   expect(result.fresh).toBe(true);
   expect(result.mode).toBe('showing');
 });
+
+// #515 — the transcribe/regenerate caption routes survived a stale caption.js
+// straggler only by registration order: caption.js happens to defer its own
+// write too, and the right one happened to land last. Safety by accident. The
+// generateCaptionsFromTranscript funnel now arms the same guard the open path
+// uses.
+//
+// HONESTY NOTE about these tests' teeth: they pass against today's code even
+// WITHOUT the guard, because the accident also covers this synthetic attack —
+// which is precisely #515's finding. Their value is as a tripwire for the
+// feared future change: if the deferral is ever removed (the pass applying
+// synchronously), the accident vanishes, and these tests then fail unless the
+// guard — now armed by design on this route — holds the line. The third test
+// below exercises the guard in isolation (a synchronous write defended by
+// guardCurrentCaptionWrite, no deferral in play) and DOES fail without it.
+test('a stray caption write after the transcribe pass is corrected at metadata (#515)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+
+  const result = await page.evaluate(async () => {
+    const video = document.getElementById('hyperplayer');
+    video.src = '/__stalls_forever__.mp4'; // metadata pending, as with the remote intro
+    video.load();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // the transcribe/regenerate route writes the track and (now) arms the guard
+    document.dispatchEvent(new CustomEvent('hyperaudioGenerateCaptionsFromTranscript'));
+    const intended = document.getElementById('hyperplayer-vtt').getAttribute('src');
+
+    // a stale straggler lands AFTER the pass — the case ordering cannot save
+    document.getElementById('hyperplayer-vtt').src =
+      'data:text/vtt,' + encodeURIComponent('WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nSTALE INTRO\n');
+
+    // metadata finally arrives; the guard must re-assert the pass's write
+    video.dispatchEvent(new Event('loadedmetadata'));
+    await new Promise((r) => setTimeout(r, 50));
+    return {
+      intended: decodeURIComponent(intended).slice(0, 60),
+      final: decodeURIComponent(document.getElementById('hyperplayer-vtt').getAttribute('src')).slice(0, 60),
+      hasStale: document.getElementById('hyperplayer-vtt').getAttribute('src').includes('STALE'),
+    };
+  });
+
+  expect(result.hasStale).toBe(false);
+  expect(result.final).toBe(result.intended);
+});
+
+test('the guard is a no-op once metadata is loaded (#515)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+
+  const result = await page.evaluate(async () => {
+    const video = document.getElementById('hyperplayer');
+    // demo intro may or may not have loaded in test time — force the loaded
+    // state deterministically
+    Object.defineProperty(video, 'readyState', { value: 4, configurable: true });
+    document.dispatchEvent(new CustomEvent('hyperaudioGenerateCaptionsFromTranscript'));
+
+    // a write after the pass with metadata LOADED is a legitimate later write
+    // (a newer caption pass, a user edit) — the guard must not fight it
+    document.getElementById('hyperplayer-vtt').src =
+      'data:text/vtt,' + encodeURIComponent('WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nLEGITIMATE\n');
+    video.dispatchEvent(new Event('loadedmetadata'));
+    await new Promise((r) => setTimeout(r, 50));
+    return document.getElementById('hyperplayer-vtt').getAttribute('src').includes('LEGITIMATE');
+  });
+
+  expect(result).toBe(true);
+});
+
+test('the guard alone defends a synchronous caption write (#515)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+
+  const result = await page.evaluate(async () => {
+    const video = document.getElementById('hyperplayer');
+    video.src = '/__stalls_forever__.mp4';
+    video.load();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // the feared future shape: a route writes the track SYNCHRONOUSLY (no
+    // caption.js deferral to accidentally save it) and arms the guard, as the
+    // funnel now does
+    const track = document.getElementById('hyperplayer-vtt');
+    const intended = 'data:text/vtt,' + encodeURIComponent('WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nINTENDED\n');
+    track.src = intended;
+    if (typeof window.guardCurrentCaptionWrite === 'function') window.guardCurrentCaptionWrite();
+
+    // stale straggler
+    track.src = 'data:text/vtt,' + encodeURIComponent('WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nSTALE\n');
+    video.dispatchEvent(new Event('loadedmetadata'));
+    await new Promise((r) => setTimeout(r, 50));
+    return document.getElementById('hyperplayer-vtt').getAttribute('src').includes('INTENDED');
+  });
+
+  expect(result).toBe(true);
+});

--- a/__TEST__/e2e/library.spec.mjs
+++ b/__TEST__/e2e/library.spec.mjs
@@ -296,12 +296,12 @@ test('deleting the LAST project keeps it on screen and Restore re-homes it', asy
   await del.click();
   await del.click();
 
-  // gone from the library, still on screen, undo offered
+  // gone from the library, still on screen, undo offered as a placeholder row
   await expect(row(page, 'Project A')).toHaveCount(0);
   await expect(page.locator('#hypertranscript')).toContainText('Benvenuti');
-  await expect(page.locator('#recents-notice')).toContainText('no longer being saved');
+  await expect(page.locator('.recents-row-deleted')).toContainText('Project A');
 
-  await page.locator('#recents-notice .recents-notice-action').click();
+  await page.locator('.recents-deleted-restore').click();
   await expect(activeRow(page)).toHaveText('Project A');
   const after = await readLibraryState(page);
   expect(after.projects.length).toBe(1);
@@ -324,7 +324,7 @@ test('deleting the LAST project keeps it on screen and Restore re-homes it', asy
   }, after.current);
 });
 
-test('deleting the current project navigates to the next; Restore rebuilds it (#456 revisited)', async ({ page }, testInfo) => {
+test('deleting the current project keeps it on screen; Restore re-homes it from the placeholder', async ({ page }, testInfo) => {
   await openProject(page, testInfo, 'Project A');
   await openProject(page, testInfo, 'Project B');
   await expect(activeRow(page)).toHaveText('Project B');
@@ -334,26 +334,43 @@ test('deleting the current project navigates to the next; Restore rebuilds it (#
   await del.click();
   await del.click();
 
-  // like closing a tab: landed on the other project, no ghost, no lecture —
-  // the deleted entry stays in the list as a dotted placeholder carrying its
-  // own Restore and dismiss
-  await expect(activeRow(page)).toHaveText('Project A');
+  // the document STAYS on screen (it is the undo's raw material); nothing
+  // owns it — no row is active — and the deleted entry becomes a dotted
+  // placeholder carrying its own Restore and dismiss
+  await expect(page.locator('#hypertranscript')).toContainText('Benvenuti');
+  await expect(page.locator('#file-picker .file-item.active')).toHaveCount(0);
   await expect(row(page, 'Project B')).toHaveCount(0);
   const placeholder = page.locator('.recents-row-deleted');
   await expect(placeholder).toHaveCount(1);
   await expect(placeholder).toContainText('Project B');
 
-  // the placeholder survives re-renders while we stay on the landing project
+  // the placeholder survives re-renders while nothing owns the screen
   await page.evaluate(() => document.dispatchEvent(new CustomEvent('hyperaudioLibraryChanged')));
   await expect(page.locator('.recents-row-deleted .recents-deleted-restore')).toBeVisible();
 
-  // Restore rebuilds the deleted project from its captured parts
+  // Restore re-homes the on-screen document under a fresh id
   await page.locator('.recents-row-deleted .recents-deleted-restore').click();
   await expect(activeRow(page)).toHaveText('Project B');
   const state = await readLibraryState(page);
   expect(state.projects.length).toBe(2);
   expect(state.dirs).toContain(state.current);
   await expect(page.locator('.recents-row-deleted')).toHaveCount(0); // offer consumed
+});
+
+test('the placeholder dismiss finalises: it navigates rather than leaving a silent ghost', async ({ page }, testInfo) => {
+  await openProject(page, testInfo, 'Project A');
+  await openProject(page, testInfo, 'Project B');
+
+  await openKebab(page, 'Project B');
+  const del = page.locator('#recents-menu .recents-menu-delete');
+  await del.click();
+  await del.click();
+  await expect(page.locator('.recents-row-deleted')).toHaveCount(1);
+
+  await page.locator('.recents-deleted-dismiss').click();
+  await expect(page.locator('.recents-row-deleted')).toHaveCount(0);
+  await expect(activeRow(page)).toHaveText('Project A'); // screen replaced, not ghosted
+  await expect(row(page, 'Project B')).toHaveCount(0);
 });
 
 test('navigating to another project withdraws the deleted placeholder', async ({ page }, testInfo) => {

--- a/__TEST__/e2e/library.spec.mjs
+++ b/__TEST__/e2e/library.spec.mjs
@@ -367,6 +367,17 @@ test('navigating to another project withdraws the deleted placeholder', async ({
   await del.click();
   await expect(page.locator('.recents-row-deleted')).toHaveCount(1);
 
+  // the placeholder sits WHERE THE ROW WAS — immediately above its old
+  // successor — not teleported to the top by activity sorting
+  const names = await page.evaluate(() =>
+    [...document.querySelectorAll('#file-picker .recents-row')].map((li) =>
+      li.classList.contains('recents-row-deleted')
+        ? 'PLACEHOLDER:' + li.querySelector('.recents-deleted-name').textContent
+        : li.querySelector('.file-item').textContent));
+  const at = names.findIndex((n) => n.startsWith('PLACEHOLDER:'));
+  expect(names[at]).toBe('PLACEHOLDER:Project C');
+  expect(names[at + 1]).toBe('Project B'); // its successor at delete time
+
   // one row, same footprint as a real row, controls visible without hover
   const geometry = await page.evaluate(() => {
     const ph = document.querySelector('.recents-row-deleted');

--- a/__TEST__/e2e/library.spec.mjs
+++ b/__TEST__/e2e/library.spec.mjs
@@ -357,6 +357,29 @@ test('deleting the current project keeps it on screen; Restore re-homes it from 
   await expect(page.locator('.recents-row-deleted')).toHaveCount(0); // offer consumed
 });
 
+test('a restored project reappears at its old position, not the top', async ({ page }, testInfo) => {
+  await openProject(page, testInfo, 'Project A');
+  await openProject(page, testInfo, 'Project B');
+  await openProject(page, testInfo, 'Project C');
+  // list order (by last write): C, B, A. Make B current WITHOUT editing it —
+  // opening does not bump modifiedAt, so it stays mid-list.
+  await row(page, 'Project B').click();
+  await expect(activeRow(page)).toHaveText('Project B');
+
+  await openKebab(page, 'Project B');
+  const del = page.locator('#recents-menu .recents-menu-delete');
+  await del.click();
+  await del.click();
+  await expect(page.locator('.recents-row-deleted')).toContainText('Project B');
+
+  await page.locator('.recents-deleted-restore').click();
+  await expect(activeRow(page)).toHaveText('Project B');
+
+  const names = await page.evaluate(() =>
+    [...document.querySelectorAll('#file-picker .file-item')].map((el) => el.textContent));
+  expect(names).toEqual(['Project C', 'Project B', 'Project A']); // back in place
+});
+
 test('the placeholder dismiss finalises: it navigates rather than leaving a silent ghost', async ({ page }, testInfo) => {
   await openProject(page, testInfo, 'Project A');
   await openProject(page, testInfo, 'Project B');

--- a/__TEST__/e2e/library.spec.mjs
+++ b/__TEST__/e2e/library.spec.mjs
@@ -367,6 +367,21 @@ test('navigating to another project withdraws the deleted placeholder', async ({
   await del.click();
   await expect(page.locator('.recents-row-deleted')).toHaveCount(1);
 
+  // one row, same footprint as a real row, controls visible without hover
+  const geometry = await page.evaluate(() => {
+    const ph = document.querySelector('.recents-row-deleted');
+    const real = document.querySelector('.recents-row:not(.recents-row-deleted)');
+    const restore = ph.querySelector('.recents-deleted-restore');
+    return {
+      sameHeight: Math.abs(ph.getBoundingClientRect().height - real.getBoundingClientRect().height) <= 6,
+      oneLine: ph.getBoundingClientRect().height < 2 * real.getBoundingClientRect().height,
+      sameWidth: Math.abs(ph.getBoundingClientRect().width - real.getBoundingClientRect().width) <= 2,
+      restoreVisible: getComputedStyle(restore).opacity !== '0'
+        && getComputedStyle(restore.parentElement).opacity !== '0',
+    };
+  });
+  expect(geometry).toEqual({ sameHeight: true, oneLine: true, sameWidth: true, restoreVisible: true });
+
   // any navigation elsewhere withdraws the offer
   await row(page, 'Project A').click();
   await expect(activeRow(page)).toHaveText('Project A');

--- a/__TEST__/e2e/library.spec.mjs
+++ b/__TEST__/e2e/library.spec.mjs
@@ -287,7 +287,7 @@ test('delete is a two-step arm inside the menu; a non-current project just goes'
   expect(state.dirs.length).toBe(1); // the directory went with the entry
 });
 
-test('deleting the CURRENT project keeps it on screen and Restore re-homes it', async ({ page }, testInfo) => {
+test('deleting the LAST project keeps it on screen and Restore re-homes it', async ({ page }, testInfo) => {
   await openProject(page, testInfo, 'Project A');
   const before = await readLibraryState(page);
 
@@ -322,6 +322,56 @@ test('deleting the CURRENT project keeps it on screen and Restore re-homes it', 
       return text.indexOf('RESTORED') !== -1;
     } catch (e) { return false; }
   }, after.current);
+});
+
+test('deleting the current project navigates to the next; Restore rebuilds it (#456 revisited)', async ({ page }, testInfo) => {
+  await openProject(page, testInfo, 'Project A');
+  await openProject(page, testInfo, 'Project B');
+  await expect(activeRow(page)).toHaveText('Project B');
+
+  await openKebab(page, 'Project B');
+  const del = page.locator('#recents-menu .recents-menu-delete');
+  await del.click();
+  await del.click();
+
+  // like closing a tab: landed on the other project, no ghost, no lecture —
+  // the deleted entry stays in the list as a dotted placeholder carrying its
+  // own Restore and dismiss
+  await expect(activeRow(page)).toHaveText('Project A');
+  await expect(row(page, 'Project B')).toHaveCount(0);
+  const placeholder = page.locator('.recents-row-deleted');
+  await expect(placeholder).toHaveCount(1);
+  await expect(placeholder).toContainText('Project B');
+
+  // the placeholder survives re-renders while we stay on the landing project
+  await page.evaluate(() => document.dispatchEvent(new CustomEvent('hyperaudioLibraryChanged')));
+  await expect(page.locator('.recents-row-deleted .recents-deleted-restore')).toBeVisible();
+
+  // Restore rebuilds the deleted project from its captured parts
+  await page.locator('.recents-row-deleted .recents-deleted-restore').click();
+  await expect(activeRow(page)).toHaveText('Project B');
+  const state = await readLibraryState(page);
+  expect(state.projects.length).toBe(2);
+  expect(state.dirs).toContain(state.current);
+  await expect(page.locator('.recents-row-deleted')).toHaveCount(0); // offer consumed
+});
+
+test('navigating to another project withdraws the deleted placeholder', async ({ page }, testInfo) => {
+  await openProject(page, testInfo, 'Project A');
+  await openProject(page, testInfo, 'Project B');
+  await openProject(page, testInfo, 'Project C');
+
+  await openKebab(page, 'Project C'); // current
+  const del = page.locator('#recents-menu .recents-menu-delete');
+  await del.click();
+  await del.click();
+  await expect(page.locator('.recents-row-deleted')).toHaveCount(1);
+
+  // any navigation elsewhere withdraws the offer
+  await row(page, 'Project A').click();
+  await expect(activeRow(page)).toHaveText('Project A');
+  await expect(page.locator('.recents-row-deleted')).toHaveCount(0);
+  await expect(row(page, 'Project C')).toHaveCount(0); // gone for good
 });
 
 test('boot restores the project you were last ON, not the last written', async ({ page }, testInfo) => {

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1165,3 +1165,42 @@ test('reading a large media reports a percentage while opening (#503)', async ({
 
   expect(seen.some((t) => /Reading the media… \d+%/.test(t))).toBe(true);
 });
+
+// #519 — the autosave debounce is 1.5s and nothing flushed it at teardown:
+// closing the tab dropped the newest keystrokes. The pending draft now lands
+// when the page hides (tab/app switch) and on pagehide (iOS close path).
+test('hiding the page flushes the pending draft immediately (#519)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+
+  await page.evaluate(() => {
+    const span = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');
+    span.textContent = 'FLUSHED-ON-HIDE ';
+    span.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+
+  // hide the page well inside the 1.5s debounce window
+  const t0 = Date.now();
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+
+  // the draft must land long before the debounce alone could have fired
+  await pollPage(page, async () => {
+    try {
+      const id = window.HyperaudioSave.library.currentId();
+      const root = await navigator.storage.getDirectory();
+      const dir = await (await root.getDirectoryHandle('work')).getDirectoryHandle(id);
+      const text = await (await (await dir.getFileHandle('draft.json')).getFile()).text();
+      return text.indexOf('FLUSHED-ON-HIDE') !== -1;
+    } catch (e) { return false; }
+  });
+  expect(Date.now() - t0).toBeLessThan(1300); // debounce alone fires at 1500ms+
+
+  // a second teardown event must not double-write or throw (pagehide follows
+  // visibilitychange in a real close)
+  await page.evaluate(() => window.dispatchEvent(new Event('pagehide')));
+  expect(dialogs).toEqual([]);
+});

--- a/__TEST__/e2e/transcript-history.spec.mjs
+++ b/__TEST__/e2e/transcript-history.spec.mjs
@@ -169,3 +169,55 @@ test.describe('touch devices', () => {
     expect(await page.evaluate(() => transcriptHistory.canRedo())).toBe(true);
   });
 });
+
+// #514 — paste arrived as execCommand('insertText') (the #487 paste path),
+// indistinguishable from typing by inputType, so it coalesced into an adjacent
+// typing entry inside the 500ms window. One ⌘Z then removed both the typed and
+// the pasted text. Paste is a forced boundary in the design contract; this
+// drives the REAL paste path (ClipboardEvent → editor-core's handler →
+// execCommand) and asserts the granularity.
+test('paste is its own undo entry, severed from typing on both sides (#514)', async ({ page }) => {
+  const word = page.locator('#hypertranscript span[data-m]:not(.speaker)').first();
+  await word.click();
+  await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    const span = t.querySelector('span[data-m]:not(.speaker)');
+    const sel = window.getSelection();
+    const r = document.createRange();
+    r.setStart(span.firstChild, 2);
+    r.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(r);
+  });
+
+  await page.keyboard.type('AB');
+  const afterTyping = await page.evaluate(() => transcriptHistory.inspect().length);
+
+  // the real paste path, within the coalesce window
+  await page.evaluate(() => {
+    const dt = new DataTransfer();
+    dt.setData('text/plain', 'PASTED');
+    document.querySelector('#hypertranscript')
+      .dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
+  });
+  const afterPaste = await page.evaluate(() => transcriptHistory.inspect().length);
+  expect(afterPaste).toBe(afterTyping + 1); // its own entry, not coalesced
+
+  // typing right after the paste starts fresh too
+  await page.keyboard.type('CD');
+  const afterMore = await page.evaluate(() => transcriptHistory.inspect().length);
+  expect(afterMore).toBe(afterPaste + 1);
+
+  // granularity end to end: three undos peel CD, then PASTED, then AB
+  const text = () => page.evaluate(() =>
+    document.querySelector('#hypertranscript span[data-m]:not(.speaker)').textContent);
+  expect(await text()).toContain('PASTED');
+  await page.keyboard.press('Meta+z');
+  expect(await text()).not.toContain('CD');
+  expect(await text()).toContain('PASTED');
+  await page.keyboard.press('Meta+z');
+  expect(await text()).not.toContain('PASTED');
+  expect(await text()).toContain('AB');
+  await page.keyboard.press('Meta+z');
+  expect(await text()).not.toContain('AB');
+});

--- a/__TEST__/static-server.mjs
+++ b/__TEST__/static-server.mjs
@@ -1,0 +1,32 @@
+// Static file server for the e2e suite. Replaces `python3 -m http.server`,
+// whose single-threaded handling under Playwright load produced broken pipes,
+// three-minute runs, and phantom single-test failures. Node http with
+// keep-alive; serves the repo root; no dependencies.
+import http from 'node:http';
+import { createReadStream, statSync } from 'node:fs';
+import { join, normalize, extname } from 'node:path';
+
+const ROOT = new URL('..', import.meta.url).pathname;
+const PORT = Number(process.env.PORT || 4173);
+const TYPES = {
+  '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.css': 'text/css', '.json': 'application/json', '.png': 'image/png',
+  '.svg': 'image/svg+xml', '.ico': 'image/x-icon', '.wav': 'audio/wav',
+  '.mp3': 'audio/mpeg', '.mp4': 'video/mp4', '.vtt': 'text/vtt',
+  '.woff2': 'font/woff2', '.webmanifest': 'application/manifest+json',
+};
+
+http.createServer((req, res) => {
+  const path = normalize(decodeURIComponent(new URL(req.url, 'http://x').pathname));
+  const file = join(ROOT, path === '/' ? 'index.html' : path);
+  if (!file.startsWith(ROOT)) { res.writeHead(403).end(); return; }
+  let stat;
+  try { stat = statSync(file); } catch (e) { res.writeHead(404).end(); return; }
+  if (stat.isDirectory()) { res.writeHead(404).end(); return; }
+  res.writeHead(200, {
+    'content-type': TYPES[extname(file)] || 'application/octet-stream',
+    'content-length': stat.size,
+    'cache-control': 'no-store',
+  });
+  createReadStream(file).pipe(res);
+}).listen(PORT, () => console.log(`static server on :${PORT}`));

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -1528,3 +1528,38 @@ label[data-a11y-wired]:focus-visible {
 @media (prefers-reduced-motion: reduce) {
   #project-progress { transition: none; }
 }
+
+/* The deleted-project placeholder row: the undo lives where the project
+   lived. Dotted border and greyed name mark it as not-a-project; Restore and
+   the dismiss sit inside the row. Withdrawn on any navigation elsewhere. */
+.recents-row-deleted {
+  border: 1px dashed oklch(var(--bc) / 0.35);
+  border-radius: 0.5rem;
+  opacity: 0.9;
+}
+.recents-deleted-name {
+  color: oklch(var(--bc) / 0.5);
+  padding: 8px 0 8px 16px;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.recents-row-deleted .recents-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+.recents-deleted-restore,
+.recents-deleted-dismiss {
+  background: transparent;
+  border: 0;
+  margin: 0;
+  padding: 6px 8px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: oklch(var(--p));
+}
+.recents-deleted-dismiss {
+  color: oklch(var(--bc) / 0.5);
+}

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -1530,36 +1530,41 @@ label[data-a11y-wired]:focus-visible {
 }
 
 /* The deleted-project placeholder row: the undo lives where the project
-   lived. Dotted border and greyed name mark it as not-a-project; Restore and
-   the dismiss sit inside the row. Withdrawn on any navigation elsewhere. */
-.recents-row-deleted {
+   lived. Same footprint as a normal row — one row high, long names absorbed
+   by the same ellipsis — with a dotted border and greyed name marking it as
+   not-a-project. Restore and the dismiss sit inside the row and are ALWAYS
+   visible (normal rows reveal their actions on hover; an undo offer that
+   must be hovered to be discovered is no offer). */
+#file-picker .recents-row-deleted {
   border: 1px dashed oklch(var(--bc) / 0.35);
   border-radius: 0.5rem;
-  opacity: 0.9;
 }
-.recents-deleted-name {
-  color: oklch(var(--bc) / 0.5);
-  padding: 8px 0 8px 16px;
-  flex: 1;
+#file-picker .recents-row-deleted .recents-deleted-name {
+  /* mirror .file-item exactly: the name column, ellipsized */
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  padding: 8px 8px 8px 16px;
+  color: oklch(var(--bc) / 0.5);
 }
-.recents-row-deleted .recents-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
+#file-picker .recents-row-deleted .recents-actions {
+  opacity: 1; /* the undo is always visible, unlike the hover-revealed kebab */
+  flex: 0 0 auto;
 }
-.recents-deleted-restore,
-.recents-deleted-dismiss {
+#file-picker .recents-deleted-restore,
+#file-picker .recents-deleted-dismiss {
   background: transparent;
   border: 0;
   margin: 0;
   padding: 6px 8px;
   font-size: 0.85rem;
+  white-space: nowrap;
   cursor: pointer;
   color: oklch(var(--p));
 }
-.recents-deleted-dismiss {
+#file-picker .recents-deleted-dismiss {
   color: oklch(var(--bc) / 0.5);
 }

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.2.3">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.2.4">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1041,7 +1041,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-serializer.js?v=1.1.8"></script>
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.2.0"></script>
-  <script src="js/editor-core.js?v=1.2.0"></script>
+  <script src="js/editor-core.js?v=1.2.4"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1078,9 +1078,9 @@ If you are creating an open source application under a license compatible with t
     }
 
   </style>
-  <script src="js/editor-main.js?v=1.2.1"></script>
+  <script src="js/editor-main.js?v=1.2.4"></script>
   <script src="js/find-replace.js?v=1.2.0"></script>
-  <script src="js/transcript-history.js?v=1.2.0"></script>
+  <script src="js/transcript-history.js?v=1.2.4"></script>
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.2.3"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
@@ -1100,8 +1100,8 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.3"></script>
-  <script src="js/hyperaudio-library.js?v=1.2.3"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.4"></script>
+  <script src="js/hyperaudio-library.js?v=1.2.4"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.2.3 (last changed in release 1.2.3) -->
+<!--  Hyperaudio Lite Editor - Version 1.2.4 (last changed in release 1.2.4) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.2.3">
+  <meta name="version" content="1.2.4">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">

--- a/index.html
+++ b/index.html
@@ -1051,7 +1051,7 @@ If you are creating an open source application under a license compatible with t
 
   <script src="js/editor-file-menu.js?v=1.0.0"></script>
 
-  <script src="./js/hyperaudio-lite-editor-export.js?v=1.1.9" type="module"> </script>
+  <script src="./js/hyperaudio-lite-editor-export.js?v=1.2.4" type="module"> </script>
   <!-- end of localstorage additions -->
 
   <!-- caption editor additions -->

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -994,6 +994,15 @@
     } else {
       document.querySelector('#hyperplayer').textTracks[0].mode = "showing";
     }
+    // Defend this write against a stale caption.js straggler (#515): both the
+    // sanitise and regenerate routes funnel through here, and until now they
+    // survived only because caption.js defers its own write and registration
+    // order happened to put the right one last — safety by accident. The
+    // guard (hyperaudio-save.js) re-asserts this src/mode after any straggler
+    // when media metadata is still pending; it is a no-op once loaded.
+    if (typeof window.guardCurrentCaptionWrite === 'function') {
+      window.guardCurrentCaptionWrite();
+    }
     return subs.data;
   }
 

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -232,7 +232,18 @@
   // (transcribe / JSON import / SRT-VTT import) — discard any cached caption
   // editor so the next entry rebuilds from the fresh transcript. Caption
   // edits otherwise persist; localStorage load manages its own cache.
-  window.document.addEventListener('hyperaudioInit', () => { captionCache = null; }, false);
+  window.document.addEventListener('hyperaudioInit', () => {
+    captionCache = null;
+    // A fresh transcript just landed: its machine captions ARE
+    // transcript-derived, so caption sync defaults ON. Nothing reset this
+    // before, so a new transcription INHERITED the flag from whatever was
+    // open previously — after any project with curated captions, edits to
+    // the new transcript updated neither the video captions nor the caption
+    // editor. Importers that carry curated captions (VTT/SRT) set the flag
+    // false AFTER dispatching this event, and the project-open path applies
+    // saved options without firing it at all.
+    updateCaptionsFromTranscript = true;
+  }, false);
 
   // Segmented view switch (transcript/captions): both segments stay clickable
   // and the active one is marked by the track's thumb + aria-pressed rather

--- a/js/editor-main.js
+++ b/js/editor-main.js
@@ -23,7 +23,15 @@
 
       holder.innerHTML = '<div class="modal-action"><label id="regenerate-float-btn" for="regenerate-captions-modal" class="fixed top-20 right-8 btn btn-outline btn-primary" >Regenerate <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-restart"><path d="M21 6H3"></path><path d="M7 12H3"></path><path d="M7 18H3"></path><path d="M12 18a5 5 0 0 0 9-3 4.5 4.5 0 0 0-4.5-4.5c-1.33 0-2.54.54-3.41 1.41L11 14"></path><path d="M11 10v4h4"></path></svg></label></div>';
 
-      if (captionCache === null ) {
+      // The cache exists to preserve HAND-EDITED captions across view
+      // switches. While captions are machine-synced from the transcript it
+      // must never be trusted: it is primed at transcription time (the
+      // engines' caption pass runs this builder with captionMode false), and
+      // transcript edits then regenerate the TRACK but not these rows — so
+      // the first visit to the caption editor showed pre-edit captions. Any
+      // hand edit flips updateCaptionsFromTranscript false, and from then on
+      // the cache is authoritative again.
+      if (captionCache === null || updateCaptionsFromTranscript === true) {
         let newDiv = document.createElement('div');
 
         // Set an id for the new div

--- a/js/hyperaudio-library.js
+++ b/js/hyperaudio-library.js
@@ -69,6 +69,7 @@
     el.textContent = '';
     el.appendChild(document.createTextNode(message));
     el.dataset.hasAction = opts.action ? 'true' : 'false';
+    el.dataset.kind = opts.kind || '';
     if (opts.action) {
       const action = document.createElement('button');
       action.type = 'button';
@@ -90,13 +91,14 @@
     }
   }
 
-  // A pending Restore offers to re-home the ON-SCREEN document; once a
-  // project owns the screen again (switch, open, new transcription) that
-  // offer would save the wrong content — withdraw it. Only notices carrying
-  // an action are removed.
+  // A GHOST notice's Restore re-homes the ON-SCREEN document; once a project
+  // owns the screen again (switch, open, new transcription) that offer would
+  // save the wrong content — withdraw it. The plain undo toast restores from
+  // parts captured at delete time, so it is valid whoever owns the screen,
+  // and stays until dismissed, clicked, or replaced.
   function hideRestoreNotice() {
     const el = document.getElementById('recents-notice');
-    if (el !== null && el.dataset.hasAction === 'true') el.remove();
+    if (el !== null && el.dataset.kind === 'ghost') el.remove();
   }
 
   /* ---- Row hover popout: full name + stored summary/topics, floated to the
@@ -272,13 +274,30 @@
     input.addEventListener('click', (e) => e.stopPropagation());
   }
 
+  // The undo for deleting the CURRENT project: the deleted entry stays in the
+  // list as a placeholder row — dotted border, greyed name, Restore and ✕
+  // inside it — at the position it occupied. Cleared by Restore, by its ✕, or
+  // by ANY navigation to another project (the id current at delete time is
+  // remembered; the moment currentId differs, the offer is withdrawn and the
+  // captured parts released).
+  let pendingDeleted = null; // { entry, restore, homeId }
+
   async function performDelete(entry) {
-    const wasCurrent = await lib().remove(entry.id);
-    // Deleting the CURRENT project leaves the document on screen (the only
-    // undo there is), but nothing owns it anymore — say so, offer the undo.
-    if (wasCurrent) {
+    const result = await lib().remove(entry.id);
+    if (!result || result.wasCurrent !== true) return;
+    if (result.navigated && result.restore) {
+      pendingDeleted = {
+        entry,
+        restore: result.restore,
+        homeId: lib().currentId(), // the project delete landed us on
+      };
+      render();
+    } else {
+      // Nowhere to go (last project): the document stays on screen as before,
+      // and the fuller warning still earns its place — this state IS odd.
       showPanelNotice('Removed from the library. The transcript is still on screen but no longer being saved.', {
         tone: 'info',
+        kind: 'ghost',
         sticky: true,
         action: {
           label: 'Restore',
@@ -307,8 +326,29 @@
     const currentId = api.currentId();
     if (currentId !== null) hideRestoreNotice(); // a project owns the screen again
 
+    // any navigation away from where the delete landed us withdraws the offer
+    if (pendingDeleted !== null && currentId !== pendingDeleted.homeId) {
+      pendingDeleted = null;
+    }
+    if (pendingDeleted !== null) {
+      rows.push(Object.assign({}, pendingDeleted.entry, { deletedPlaceholder: true }));
+      rows.sort((a, b) => (b.lastActiveAt || b.modifiedAt || b.createdAt || 0)
+        - (a.lastActiveAt || a.modifiedAt || a.createdAt || 0));
+    }
+
     const entryById = {};
     const renderRow = (entry) => {
+      if (entry.deletedPlaceholder === true) {
+        const nameHtml = escapeMarkup(entry.name || 'project');
+        filePicker.insertAdjacentHTML('beforeend',
+          `<li class="recents-row recents-row-deleted">` +
+          `<span class="recents-deleted-name">${nameHtml}</span>` +
+          `<span class="recents-actions">` +
+          `<button type="button" class="recents-deleted-restore">Restore</button>` +
+          `<button type="button" class="recents-deleted-dismiss" aria-label="Dismiss">✕</button>` +
+          `</span></li>`);
+        return;
+      }
       entryById[entry.id] = entry;
       const idAttr = escapeMarkup(entry.id);
       const nameHtml = escapeMarkup(entry.name || 'project');
@@ -345,6 +385,19 @@
       // opacity 0.75 (not 0.55) so the composited grey still meets the 4.5:1
       // contrast ratio on the white card (#402)
       filePicker.insertAdjacentHTML('beforeend', '<li style="padding:8px 16px; opacity:0.75">No projects yet.</li>');
+    }
+
+    const restoreBtn = filePicker.querySelector('.recents-deleted-restore');
+    if (restoreBtn !== null) {
+      restoreBtn.addEventListener('click', () => {
+        const pending = pendingDeleted;
+        pendingDeleted = null;
+        if (pending !== null) pending.restore(pending.entry.starred === true);
+      });
+      filePicker.querySelector('.recents-deleted-dismiss').addEventListener('click', () => {
+        pendingDeleted = null;
+        render();
+      });
     }
 
     filePicker.querySelectorAll('.file-item').forEach((el) => {

--- a/js/hyperaudio-library.js
+++ b/js/hyperaudio-library.js
@@ -274,49 +274,33 @@
     input.addEventListener('click', (e) => e.stopPropagation());
   }
 
-  // The undo for deleting the CURRENT project: the deleted entry stays in the
-  // list as a placeholder row — dotted border, greyed name, Restore and ✕
-  // inside it — at the position it occupied. Cleared by Restore, by its ✕, or
-  // by ANY navigation to another project (the id current at delete time is
-  // remembered; the moment currentId differs, the offer is withdrawn and the
-  // captured parts released).
-  let pendingDeleted = null; // { entry, restore, homeId }
+  // The undo for deleting the CURRENT project: the document stays ON SCREEN
+  // (it is the undo's raw material), and the deleted entry stays in the list
+  // as a placeholder row — dotted border, greyed name, Restore and ✕ inside —
+  // at the position it occupied. Restore re-homes the on-screen document
+  // (edits made meanwhile included). Choosing any other project replaces the
+  // screen and withdraws the offer. The ✕ finalises: it navigates to the
+  // next project, because dismissing the undo while silently keeping an
+  // unsaved ghost on screen would recreate the invisible-data-loss state the
+  // old banner existed to warn about.
+  let pendingDeleted = null; // { entry, successorId }
 
   async function performDelete(entry) {
     // Anchor the placeholder to the row BELOW it in its own group, captured
-    // BEFORE the deletion: the panel orders by last edit, and the deleted
-    // project (necessarily current) sorts near the top by activity — so a
-    // sort-based merge would teleport the placeholder away from where the
-    // row actually was. Splicing back at the successor keeps it in place.
+    // BEFORE the deletion, so it can be spliced back exactly where the row
+    // was — the panel orders by last edit, and sorting the (necessarily
+    // current, so most recently active) deleted entry teleported it to the top.
     const before = await lib().list();
     const group = before.filter((e) => (e.starred === true) === (entry.starred === true));
     const at = group.findIndex((e) => e.id === entry.id);
     const successorId = at !== -1 && at + 1 < group.length ? group[at + 1].id : null;
     const result = await lib().remove(entry.id);
     if (!result || result.wasCurrent !== true) return;
-    if (result.navigated && result.restore) {
-      pendingDeleted = {
-        entry,
-        restore: result.restore,
-        successorId,
-        homeId: lib().currentId(), // the project delete landed us on
-      };
-      render();
-    } else {
-      // Nowhere to go (last project): the document stays on screen as before,
-      // and the fuller warning still earns its place — this state IS odd.
-      showPanelNotice('Removed from the library. The transcript is still on screen but no longer being saved.', {
-        tone: 'info',
-        kind: 'ghost',
-        sticky: true,
-        action: {
-          label: 'Restore',
-          handler: () => { lib().restoreDeleted(entry.starred === true); },
-        },
-      });
-    }
+    pendingDeleted = { entry, successorId };
+    render();
   }
 
+  /* ---- Rendering ---- */
   /* ---- Rendering ---- */
 
   let renderToken = 0;
@@ -336,8 +320,9 @@
     const currentId = api.currentId();
     if (currentId !== null) hideRestoreNotice(); // a project owns the screen again
 
-    // any navigation away from where the delete landed us withdraws the offer
-    if (pendingDeleted !== null && currentId !== pendingDeleted.homeId) {
+    // any project owning the screen withdraws the offer: a switch, an open, a
+    // new transcription, or Restore itself (which re-homes the ghost)
+    if (pendingDeleted !== null && currentId !== null) {
       pendingDeleted = null;
     }
 
@@ -404,11 +389,16 @@
       restoreBtn.addEventListener('click', () => {
         const pending = pendingDeleted;
         pendingDeleted = null;
-        if (pending !== null) pending.restore(pending.entry.starred === true);
+        if (pending !== null) api.restoreDeleted(pending.entry.starred === true);
       });
-      filePicker.querySelector('.recents-deleted-dismiss').addEventListener('click', () => {
+      filePicker.querySelector('.recents-deleted-dismiss').addEventListener('click', async () => {
         pendingDeleted = null;
-        render();
+        const remaining = await api.list();
+        if (remaining.length > 0) {
+          api.open(remaining[0].id); // finalise: replace the unsaved ghost
+        } else {
+          render(); // nothing to go to — the ghost stays, offer withdrawn
+        }
       });
     }
 

--- a/js/hyperaudio-library.js
+++ b/js/hyperaudio-library.js
@@ -389,7 +389,14 @@
       restoreBtn.addEventListener('click', () => {
         const pending = pendingDeleted;
         pendingDeleted = null;
-        if (pending !== null) api.restoreDeleted(pending.entry.starred === true);
+        if (pending !== null) {
+          // pass the original ordering stamps: restored rows reappear where
+          // they lived, not at the top as fresh work
+          api.restoreDeleted(pending.entry.starred === true, {
+            modifiedAt: pending.entry.modifiedAt,
+            createdAt: pending.entry.createdAt,
+          });
+        }
       });
       filePicker.querySelector('.recents-deleted-dismiss').addEventListener('click', async () => {
         pendingDeleted = null;

--- a/js/hyperaudio-library.js
+++ b/js/hyperaudio-library.js
@@ -283,12 +283,22 @@
   let pendingDeleted = null; // { entry, restore, homeId }
 
   async function performDelete(entry) {
+    // Anchor the placeholder to the row BELOW it in its own group, captured
+    // BEFORE the deletion: the panel orders by last edit, and the deleted
+    // project (necessarily current) sorts near the top by activity — so a
+    // sort-based merge would teleport the placeholder away from where the
+    // row actually was. Splicing back at the successor keeps it in place.
+    const before = await lib().list();
+    const group = before.filter((e) => (e.starred === true) === (entry.starred === true));
+    const at = group.findIndex((e) => e.id === entry.id);
+    const successorId = at !== -1 && at + 1 < group.length ? group[at + 1].id : null;
     const result = await lib().remove(entry.id);
     if (!result || result.wasCurrent !== true) return;
     if (result.navigated && result.restore) {
       pendingDeleted = {
         entry,
         restore: result.restore,
+        successorId,
         homeId: lib().currentId(), // the project delete landed us on
       };
       render();
@@ -330,11 +340,6 @@
     if (pendingDeleted !== null && currentId !== pendingDeleted.homeId) {
       pendingDeleted = null;
     }
-    if (pendingDeleted !== null) {
-      rows.push(Object.assign({}, pendingDeleted.entry, { deletedPlaceholder: true }));
-      rows.sort((a, b) => (b.lastActiveAt || b.modifiedAt || b.createdAt || 0)
-        - (a.lastActiveAt || a.modifiedAt || a.createdAt || 0));
-    }
 
     const entryById = {};
     const renderRow = (entry) => {
@@ -368,6 +373,13 @@
     // Ordering within each group is unchanged (last edit).
     const starredRows = rows.filter((r) => r.starred === true);
     const recentRows = rows.filter((r) => r.starred !== true);
+    if (pendingDeleted !== null) {
+      const ph = Object.assign({}, pendingDeleted.entry, { deletedPlaceholder: true });
+      const target = ph.starred === true ? starredRows : recentRows;
+      const at = pendingDeleted.successorId !== null
+        ? target.findIndex((r) => r.id === pendingDeleted.successorId) : -1;
+      if (at !== -1) target.splice(at, 0, ph); else target.push(ph);
+    }
     const panelTitle = document.getElementById('recents-title');
     if (panelTitle !== null) {
       panelTitle.style.display = starredRows.length > 0 ? 'none' : '';

--- a/js/hyperaudio-lite-editor-export.js
+++ b/js/hyperaudio-lite-editor-export.js
@@ -232,12 +232,14 @@ class ImportSrt extends HTMLElement {
       // leaves the previous document's cue pixels painted on the paused video.
       applyCaptionTrack(vttUrl, { mode: 'showing' });
 
-      // Preserve original format
+      document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+
+      // Preserve original format — AFTER the init dispatch, which now
+      // defaults caption sync ON for fresh transcripts; imported captions
+      // are curated, so the override must land last.
       updateCaptionsFromTranscript = false;
       populateCaptionEditorFromVtt(vttData);
       //captionCache = vttData;
-
-      document.dispatchEvent(new CustomEvent('hyperaudioInit'));
     });
     
     reader.readAsText(file);
@@ -357,12 +359,14 @@ class ImportVtt extends HTMLElement {
       // Through the caption door (#356/#287) — see the SRT import above.
       applyCaptionTrack(vttUrl, { mode: 'showing' });
 
-      // Preserve original format
+      document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+
+      // Preserve original format — AFTER the init dispatch, which now
+      // defaults caption sync ON for fresh transcripts; imported captions
+      // are curated, so the override must land last.
       updateCaptionsFromTranscript = false;
       populateCaptionEditorFromVtt(vttData);
       //captionCache = vttData;
-
-      document.dispatchEvent(new CustomEvent('hyperaudioInit'));
     });
     
     reader.readAsText(file);

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2292,6 +2292,11 @@
   // project leaves the document on screen (the only undo there is) but
   // nothing owns it anymore — autosave stops until the panel's Restore
   // re-homes it as a new entry.
+  // Deleting the CURRENT project keeps the document ON SCREEN — the undo's
+  // raw material — while the library entry and directory go. The panel shows
+  // a placeholder row carrying Restore (which re-homes the on-screen
+  // document) in the deleted row's place; any navigation elsewhere replaces
+  // the screen and withdraws the offer. Returns { wasCurrent }.
   async function deleteProject(id) {
     const wasCurrent = id === session.projectId;
     if (wasCurrent) {
@@ -2306,7 +2311,7 @@
     await updateLibrary((lib) => {
       lib.projects = lib.projects.filter((p) => p.id !== id);
     });
-    return wasCurrent;
+    return { wasCurrent };
   }
 
   // Undo for deleting the current project: re-home the on-screen document —

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.2.3 — last changed in release 1.2.3
+ * @version 1.2.4 — last changed in release 1.2.4
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2533,6 +2533,30 @@
       }
     });
 
+    // Land the pending draft on the way out (#519): the autosave debounce is
+    // 1.5 s and nothing flushed it at teardown, so closing the tab (or
+    // switching apps on mobile) dropped the newest keystrokes — the last
+    // sentence typed, the part most likely to be noticed missing.
+    // visibilitychange→hidden fires on tab/app switches, usually well before
+    // a close; pagehide covers iOS Safari, where beforeunload often does not.
+    // Neither can await — the flush is INITIATED and in practice lands (both
+    // fire earlier in teardown than beforeunload, and OPFS writes are fast at
+    // draft sizes). flushPendingDraft is idempotent across the pair firing in
+    // one teardown: it clears the timer, writes only when a write is actually
+    // pending, and otherwise just awaits the chain — so hide→show→hide and
+    // visibilitychange-then-pagehide cannot double-write or race the chain.
+    // beforeunload stays what #449/#456 narrowed it to (the genuine-loss
+    // warning) — this is about landing the write, not warning.
+    const flushOnHide = () => {
+      if (session.active && autosavePending) {
+        flushPendingDraft().catch((e) => console.warn('hyperaudio-save: hide flush failed', e));
+      }
+    };
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') flushOnHide();
+    });
+    window.addEventListener('pagehide', flushOnHide);
+
     const input = document.createElement('input');
     input.type = 'file';
     input.id = 'project-open-input';

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2316,7 +2316,7 @@
 
   // Undo for deleting the current project: re-home the on-screen document —
   // still fully held by the session — under a fresh id.
-  async function restoreCurrentAsNewProject(starred) {
+  async function restoreCurrentAsNewProject(starred, stamps) {
     if (!opfsAvailable || !session.active || session.projectId !== null) return null;
     session.projectId = newProjectId();
     const id = session.projectId;
@@ -2325,9 +2325,24 @@
     await writeMediaOnce();
     // a rebirth: the on-screen content IS the new baseline — commit it clean
     await commitInitialState(id);
+    // A restore is an UNDO, not new work: carry the original entry's ordering
+    // stamps so the row reappears where it lived (the panel orders by
+    // modifiedAt), rather than teleporting to the top as freshly written.
+    // lastActiveAt stays fresh — the restored project IS the one on screen,
+    // and a reload should return to it.
+    if (stamps && (stamps.modifiedAt || stamps.createdAt)) {
+      await updateLibrary((lib) => {
+        const entry = lib.projects.find((p) => p.id === id);
+        if (entry !== undefined) {
+          if (stamps.modifiedAt) entry.modifiedAt = stamps.modifiedAt;
+          if (stamps.createdAt) entry.createdAt = stamps.createdAt;
+        }
+      });
+    }
     sessionEdited = false;
     updateSaveIndicator();
     if (starred === true) await setProjectStarred(id, true);
+    notifyLibraryChanged(false);
     return id;
   }
 

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -1668,46 +1668,71 @@
   // Nothing cancels it when the document changes, so a caption pass run while
   // the intro (remote, slow) was still loading stays pending, and fires when the
   // NEXT media's metadata arrives: the previous document's captions land on top
-  // of the one just opened. Measured — the write happens after everything the
-  // synchronous teardown and paint flush can reach, which is why the track ends
-  // up holding a data:text/vtt of the PREVIOUS transcript.
+  // of the one just opened.
   //
-  // Registering our own one-shot listener here re-asserts the swap after any
-  // such straggler: at the target, listeners run in registration order, and ours
-  // is necessarily registered later than a pending one. Only armed while
-  // metadata is still pending — once it has loaded, any stale listener has
-  // already fired and been removed, so there is nothing to outlast, and the
-  // window in which this could contend with a legitimate later caption pass
-  // stays as small as possible.
+  // ONE armed listener with a mutable target (#515): the original armed a
+  // fresh one-shot listener per call, which was fine for the open path but
+  // stacks listeners if a per-keystroke route arms it while metadata stays
+  // pending — the sanitise pass fires every second while typing. Each call
+  // now just updates the target; the single listener re-asserts the LATEST
+  // intended swap after any straggler (at the target, listeners run in
+  // registration order, and this one is necessarily registered later than a
+  // pending stale one). Only armed while metadata is pending — once loaded, a
+  // stale listener has already fired, so there is nothing to outlast.
   //
   // The real fix belongs upstream (capture the media identity at registration
   // and bail if it changed); this is the local defence until that lands.
+  let lateWriteTarget = null; // { track, src, mode }
+  let lateWriteVideo = null;  // the element the armed listener is bound to
+
   function guardAgainstLateCaptionWrite(video, track, src, mode) {
-    if (video === null || video.readyState >= 1 /* HAVE_METADATA */) return;
+    if (video === null) return;
+    if (video.readyState >= 1 /* HAVE_METADATA */) { lateWriteTarget = null; return; }
+    lateWriteTarget = { track, src, mode };
+    if (lateWriteVideo === video) return; // armed already; target updated above
+    lateWriteVideo = video;
     video.addEventListener('loadedmetadata', function reassert() {
       video.removeEventListener('loadedmetadata', reassert);
+      lateWriteVideo = null;
+      const target = lateWriteTarget;
+      lateWriteTarget = null;
+      if (target === null) return;
       // Still OUR swap? resetCaptionTrack replaces the element, so a later
       // applyCaptionTrack — a newer document — leaves a different one in place
       // and this re-assert must stand down. A straggler from caption.js writes
       // .src on the existing element, so identity still holds there, which is
-      // exactly the case worth correcting. Element identity rather than the
-      // media src: apply() sets media before captions, but nothing guarantees
-      // that order for every caller.
+      // exactly the case worth correcting.
       const current = document.getElementById('hyperplayer-vtt');
-      if (current === null || current !== track) return;
+      if (current === null || current !== target.track) return;
       let changed = false;
-      if (src !== '' && current.getAttribute('src') !== src) {
-        current.src = src;
+      if (target.src !== '' && current.getAttribute('src') !== target.src) {
+        current.src = target.src;
         changed = true;
       }
       const tt = video.textTracks !== undefined ? video.textTracks[0] : undefined;
-      if (tt !== undefined && tt.mode !== mode) {
-        tt.mode = mode;
+      if (tt !== undefined && tt.mode !== target.mode) {
+        tt.mode = target.mode;
         changed = true;
       }
       if (changed) flushCaptionPaint();
     });
   }
+
+  // The transcribe/regenerate routes write the track in editor-core's
+  // generateCaptionsFromTranscript, outside applyCaptionTrack — before #515
+  // they survived a stale caption.js straggler only because caption.js also
+  // defers ITS write and registration order happened to put the right one
+  // last. This zero-argument form lets that funnel arm the same guard the
+  // open/import paths use: it reads whatever was just written and defends it.
+  function guardCurrentCaptionWrite() {
+    const video = document.getElementById('hyperplayer');
+    const track = document.getElementById('hyperplayer-vtt');
+    if (video === null || track === null) return;
+    const tt = video.textTracks !== undefined ? video.textTracks[0] : undefined;
+    guardAgainstLateCaptionWrite(video, track, track.getAttribute('src') || '',
+      tt !== undefined ? tt.mode : 'showing');
+  }
+  window.guardCurrentCaptionWrite = guardCurrentCaptionWrite;
 
   // the caption-regenerate path in editor-core reaches these by global name
   // (typeof-guarded), as it did when the legacy module defined resetCaptionTrack

--- a/js/transcript-history.js
+++ b/js/transcript-history.js
@@ -273,12 +273,21 @@
       && !/^deleteContent(?:Backward|Forward)$/.test(inputType);
   }
 
+  // Paste is a forced boundary (the design contract), but it arrives as
+  // execCommand('insertText') — the #487 paste path — which is
+  // indistinguishable from typing by inputType alone, so it coalesced into an
+  // adjacent typing entry within the 500ms window (#514). The capture-phase
+  // paste listener below raises this flag before the editor's own paste
+  // handler runs; the commit it produces is then forced to its own entry, and
+  // the chain is severed on BOTH sides so following typing starts fresh too.
+  let pasteBoundary = false;
+
   function commitNative(before, inputType, origin) {
     const after = snapshot(origin || inputType);
     if (!after || !before || before.semanticFingerprint === after.semanticFingerprint) return;
     const category = inputCategory(inputType);
     const now = Date.now();
-    const coalesce = !boundaryInput(inputType) && lastNative
+    const coalesce = !pasteBoundary && !boundaryInput(inputType) && lastNative
       && lastNative.category === category
       && now - lastNative.at <= COALESCE_MS
       && lastNative.generation === (window.transcriptLifecycle
@@ -287,6 +296,13 @@
       && position === entries.length - 1;
     if (coalesce) replaceCurrent(after);
     else push(after);
+    if (pasteBoundary) {
+      // sever the trailing side too: typing right after a paste must not
+      // coalesce into the paste's entry
+      pasteBoundary = false;
+      lastNative = null;
+      return;
+    }
     lastNative = {
       category,
       at: now,
@@ -380,6 +396,12 @@
     pendingNative = { before: snapshot(`before-${event.inputType}`), inputType: event.inputType || 'native' };
     rememberPreEditSelection(pendingNative.before);
     if (boundaryInput(pendingNative.inputType)) lastNative = null;
+  }, true);
+
+  document.addEventListener('paste', (event) => {
+    if (!inTranscript(event.target) || captionMode()) return;
+    pasteBoundary = true;
+    lastNative = null; // the paste cannot join the entry before it
   }, true);
 
   document.addEventListener('input', (event) => {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "node --test \"__TEST__/unit/**/*.test.mjs\"",
     "test:e2e": "playwright test",
+    "test:quick": "playwright test --grep-invert transcript-bench",
     "test:soak": "playwright test --config playwright.soak.config.mjs"
   }
 }

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -7,12 +7,19 @@ export default defineConfig({
   testDir: '__TEST__/e2e',
   timeout: 120000,
   retries: process.env.CI ? 1 : 0,
+  // Files run in parallel; each test's browser context is isolated (own
+  // OPFS), so cross-test state cannot leak. Bounded rather than cores/2:
+  // several tests assert against real-time debounces (the 1s sanitise, the
+  // 500ms coalesce) and heavy CPU contention would make them flaky.
+  workers: process.env.CI ? 2 : 4,
   use: {
     baseURL: 'http://localhost:4173',
     viewport: { width: 1280, height: 800 },
   },
   webServer: {
-    command: 'python3 -m http.server 4173',
+    // NOT python's http.server: single-threaded, broken-pipe-prone under
+    // Playwright load — it produced three-minute runs and phantom failures.
+    command: 'node __TEST__/static-server.mjs',
     port: 4173,
     reuseExistingServer: true,
   },


### PR DESCRIPTION
Fixes #514
Fixes #515
Fixes #519

Caption sync that actually follows the transcript, a kinder delete, and the last seconds of typing no longer lost.

## Caption sync was silently off after any curated project

Nothing reset `updateCaptionsFromTranscript` on a new transcription — it inherited the previous project's value. Open any project with curated captions (every `.hyperaudio` with edited captions, every VTT/SRT import), then transcribe a fresh file: edits updated neither the video captions nor the caption editor. Reported as "the caption editor's first visit doesn't reflect transcript edits", which was two layers deep:

- `hyperaudioInit` now means what it says — a fresh machine transcript landed, so sync defaults ON; the VTT/SRT importers set the flag false immediately after the synchronous dispatch (curated captions stay curated), and the project-open path never fires init and keeps applying saved options.
- The caption editor's row cache is never trusted while sync is on. It exists to preserve HAND-edited captions across view switches; it was being primed at transcription time and then beating the fresh data the view entry had just computed.

## Deleting the current project (reworked #456 behaviour)

The transcript stays on screen — it is the undo's raw material — and the deleted entry becomes a dotted placeholder row in Recents, in the row's exact position, carrying Restore and a dismiss. Restore re-homes the on-screen document (edits included) and the row returns to its old list position; choosing any other project finalises the delete; the dismiss navigates rather than leaving a silent unsaved ghost. The "no longer being saved" banner is gone — the placeholder is the indicator.

## The newest keystrokes survive a close (#519)

The draft autosave debounce is 1.5s and nothing flushed it at teardown. The pending draft now lands on `visibilitychange→hidden` (tab/app switch) and `pagehide` (the iOS close path). The loss window shrinks from "any close within 1.5s of typing" to "close faster than a human reaches the keys".

## Undo polish (#514) and caption-guard hardening (#515)

- Paste is a forced undo boundary again — it had coalesced with typing since #487 switched it to `insertText` (reported with measurements by the history's author). A capture-phase listener severs the chain on both sides; the test drives the real ClipboardEvent path and peels type/paste/type back as three steps.
- The transcribe/regenerate caption routes arm the same late-write guard the open path uses, instead of surviving stale caption.js stragglers by registration-order accident. The guard is restructured to one armed listener with a mutable target (the sanitise route fires every second while typing; per-call arming would have stacked listeners). Test honesty is recorded in the spec: two tests are tripwires for the feared future change, one exercises the guard in isolation and fails without it.

## Also

- Boot-restore refinement shipped in 1.2.2 gets its delete-flow counterpart: `lastActiveAt` drives what the placeholder flow returns to.
- Test infra: the e2e static server is a 30-line Node server (python's http.server produced broken pipes and phantom failures under load), files run on 4 parallel workers, and `npm run test:quick` skips the 45s benchmark spec for the inner loop.
- Cache-busts are now stamped at change time, not release time — twice this cycle a manual retest legitimately received a stale file and reported a fix broken.
- Format spec: the `versions/` namespace reservation (#520, merged from review).

## Tests

170 passing, up from 158. Every fix verified failing without its change, except where recorded otherwise in the spec comments (#515's tripwires).
