### PR TITLE
Version 1.2.5

### DIFF
--- a/__TEST__/e2e/caption-track-reset.spec.mjs
+++ b/__TEST__/e2e/caption-track-reset.spec.mjs
@@ -353,3 +353,33 @@ test('a new transcription turns caption sync back on', async ({ page }) => {
   expect(lines).toContain('POST-TRANSCRIBE-EDIT');
 });
 
+
+// Regenerate means "give me transcript-derived captions": sync resumes until
+// the next hand edit. Before, regenerated captions stayed marked curated and
+// silently stopped following further transcript edits.
+test('Regenerate turns caption sync back on until the next caption edit', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+
+  // curated state: a caption was hand-edited at some point
+  await page.evaluate(() => { updateCaptionsFromTranscript = false; });
+
+  // the caption view's Regenerate confirm
+  await page.click('#caption-editor-btn');
+  await page.waitForFunction(() => document.querySelectorAll('#captions-display .caption').length > 0);
+  // entering with sync off raises the "Captions have been edited" notice,
+  // which sits over the first rows and intercepts clicks (#506)
+  const alertBox = page.locator('#captionsource-alert');
+  if (await alertBox.isVisible()) await page.click('#captionsource-alert-ok');
+  // the real flow: the floating Regenerate opens the confirm modal, Confirm
+  // fires the handler and closes it (both are modal-toggle labels)
+  await page.click('#regenerate-float-btn');
+  await page.click('#regenerate-captions');
+  await expect(page.locator('#regenerate-captions-modal')).not.toBeChecked();
+  expect(await page.evaluate(() => updateCaptionsFromTranscript)).toBe(true);
+
+  // and a hand edit flips it right back off
+  await page.locator('#captions-display .caption input.line1').first().click();
+  await page.keyboard.type('X');
+  expect(await page.evaluate(() => updateCaptionsFromTranscript)).toBe(false);
+});

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1321,9 +1321,11 @@ test('an engine error takes the in-progress row with it (#525)', async ({ page }
 // #525 — one transcription at a time: the engines share one transcript
 // element and one busy flag, so a second start mid-run interleaved into
 // errors. The entry points grey out while busy.
-test('the NEW button is inert while a transcription runs (#525)', async ({ page }) => {
-  await page.goto('/index.html');
-  await page.waitForSelector('#hypertranscript [data-m]');
+test('the NEW button is inert while a transcription runs — even from another project (#525)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+  const homeId = await page.evaluate(() => window.HyperaudioSave.library.currentId());
 
   await page.evaluate(() => {
     document.querySelector('#hypertranscript').innerHTML =
@@ -1335,6 +1337,14 @@ test('the NEW button is inert while a transcription runs (#525)', async ({ page 
   // and the modal genuinely cannot be opened through it
   await newBtn.click({ force: true }).catch(() => {});
   expect(await page.evaluate(() => document.getElementById('transcribe-modal').checked)).toBe(false);
+
+  // the hole this test exists for: switch AWAY (which clears the view's busy
+  // attribute) — the engine still runs, so the gate must hold
+  await page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
+  await expect(page.locator('#hypertranscript')).toContainText('Benvenuti');
+  expect(await page.evaluate(() =>
+    document.querySelector('#hypertranscript').getAttribute('aria-busy'))).toBeNull();
+  await expect(newBtn).toHaveCSS('pointer-events', 'none'); // STILL gated
 
   // engine ends: the door reopens
   await page.evaluate(() => {

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1282,6 +1282,13 @@ test('a transcription appears in Recents while it runs, and resolves on completi
   const row = page.locator('.recents-row-transcribing');
   await expect(row).toHaveCount(1);
   await expect(row).toContainText('brand-new-recording.wav'); // named after ITS file
+  await expect(row.locator('.recents-transcribing-spinner')).toBeVisible(); // wordless in-progress signal
+  // same footprint as a real row
+  const widths = await page.evaluate(() => ({
+    pending: document.querySelector('.recents-row-transcribing').getBoundingClientRect().width,
+    real: document.querySelector('.recents-row:not(.recents-row-transcribing)').getBoundingClientRect().width,
+  }));
+  expect(Math.abs(widths.pending - widths.real)).toBeLessThanOrEqual(2);
   // the transcribing row IS the selection while the loader owns the screen —
   // and the previous project's row stands down
   await expect(row.locator('.recents-transcribing-item')).toHaveClass(/active/);

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1226,33 +1226,16 @@ test('switching back to your project mid-transcription rescues it from the loade
   await startFakeTranscription(page);
   await expect(page.locator('#hypertranscript')).toContainText('Transcribing…');
 
-  // click your own project's row: previously a silent no-op
-  const openPromise = page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
-  await awaitModal(page);
-  await page.click('#project-dialog-confirm');
-  await openPromise;
+  // click your own project's row: previously a silent no-op, now an
+  // immediate switch — no consent dialog (#525: the in-progress row is the
+  // way back, so leaving needs no ceremony)
+  await page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
 
   await expect(page.locator('#hypertranscript')).toContainText('Benvenuti'); // the project is back
   expect(await page.evaluate(() =>
     document.querySelector('#hypertranscript').getAttribute('aria-busy'))).toBeNull(); // busy cleared
 });
 
-test('staying puts keeps the transcription untouched (#525)', async ({ page }, testInfo) => {
-  const dialogs = [];
-  await openFixture(page, testInfo, dialogs);
-  await awaitLibraryEntry(page);
-  const homeId = await page.evaluate(() => window.HyperaudioSave.library.currentId());
-
-  await startFakeTranscription(page);
-  const openPromise = page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
-  await awaitModal(page);
-  await page.click('#project-dialog-cancel');
-  expect(await openPromise).toBe(false);
-
-  await expect(page.locator('#hypertranscript')).toContainText('Transcribing…'); // untouched
-  expect(await page.evaluate(() =>
-    document.querySelector('#hypertranscript').getAttribute('aria-busy'))).toBe('true');
-});
 
 test('the engine file inputs clear on click so the same file can be re-picked (#525)', async ({ page }, testInfo) => {
   await page.goto('/index.html');
@@ -1291,11 +1274,8 @@ test('a transcription appears in Recents while it runs, and resolves on completi
   await expect(row).toHaveCount(1);
   await expect(row).toContainText('transcribing…');
 
-  // switch away to the existing project (consent), the row stays
-  const openPromise = page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
-  await awaitModal(page);
-  await page.click('#project-dialog-confirm');
-  await openPromise;
+  // switch away to the existing project — immediate, the row stays
+  await page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
   await expect(page.locator('#hypertranscript')).toContainText('Benvenuti');
   await expect(row).toHaveCount(1);
 

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1337,3 +1337,31 @@ test('an engine error takes the in-progress row with it (#525)', async ({ page }
   });
   await expect(page.locator('.recents-row-transcribing')).toHaveCount(0);
 });
+
+// #525 — one transcription at a time: the engines share one transcript
+// element and one busy flag, so a second start mid-run interleaved into
+// errors. The entry points grey out while busy.
+test('the NEW button is inert while a transcription runs (#525)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+
+  await page.evaluate(() => {
+    document.querySelector('#hypertranscript').innerHTML =
+      '<div class="vertically-centre"><center><span class="transcribing-msg">Transcribing…</span></center></div>';
+    setTranscriptBusy(true);
+  });
+  const newBtn = page.locator('#new-transcription-btn');
+  await expect(newBtn).toHaveCSS('pointer-events', 'none');
+  // and the modal genuinely cannot be opened through it
+  await newBtn.click({ force: true }).catch(() => {});
+  expect(await page.evaluate(() => document.getElementById('transcribe-modal').checked)).toBe(false);
+
+  // engine ends: the door reopens
+  await page.evaluate(() => {
+    document.querySelector('#hypertranscript').innerHTML = '<p>err</p>';
+    setTranscriptBusy(false);
+  });
+  await expect(newBtn).not.toHaveCSS('pointer-events', 'none');
+  await newBtn.click();
+  expect(await page.evaluate(() => document.getElementById('transcribe-modal').checked)).toBe(true);
+});

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1267,22 +1267,29 @@ test('a transcription appears in Recents while it runs, and resolves on completi
   // an engine starts, exactly as they all do: loader markup, then busy(true)
   await page.evaluate(() => {
     document.querySelector('#hypertranscript').innerHTML =
-      '<div class="vertically-centre"><center><span class="transcribing-msg">Transcribing…</span></center></div>';
+      '<div class="vertically-centre"><center><span class="transcribing-msg">Preparing model…</span></center></div>';
     setTranscriptBusy(true);
   });
   const row = page.locator('.recents-row-transcribing');
   await expect(row).toHaveCount(1);
   await expect(row).toContainText('transcribing…');
 
+  // the engine progresses past the initial message, as its interval does
+  await page.evaluate(() => {
+    document.querySelector('#hypertranscript .transcribing-msg').textContent = 'Transcribing… (0m 42s)';
+  });
+
   // switch away to the existing project — immediate, the row stays
   await page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
   await expect(page.locator('#hypertranscript')).toContainText('Benvenuti');
   await expect(row).toHaveCount(1);
 
-  // click the row: back to the live loader, and the engines' null-guarded
-  // progress lookup finds its element again
+  // click the row: back to the live loader AT THE DEPARTURE-TIME message —
+  // not the stale 'Preparing model' captured when the engine started
   await row.locator('.recents-transcribing-item').click();
-  await expect(page.locator('#hypertranscript')).toContainText('Transcribing…');
+  await expect(page.locator('#hypertranscript')).toContainText('Transcribing… (0m 42s)');
+  expect(await page.evaluate(() =>
+    document.querySelector('#hypertranscript').textContent.includes('Preparing model'))).toBe(false);
   expect(await page.evaluate(() =>
     document.querySelector('#hypertranscript .transcribing-msg') !== null)).toBe(true);
 

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1312,6 +1312,8 @@ test('a transcription appears in Recents while it runs, and resolves on completi
   await row.locator('.recents-transcribing-item').click();
   await expect(page.locator('#hypertranscript')).toContainText('Transcribing… (0m 42s)');
   await expect(row.locator('.recents-transcribing-item')).toHaveClass(/active/); // selected again on return
+  // and the player carries the TRANSCRIPTION's media, not the previous project's
+  expect(await page.evaluate(() => document.getElementById('hyperplayer').src)).toBe(engineSrc);
   expect(await page.evaluate(() =>
     document.querySelector('#hypertranscript').textContent.includes('Preparing model'))).toBe(false);
 

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1204,3 +1204,68 @@ test('hiding the page flushes the pending draft immediately (#519)', async ({ pa
   await page.evaluate(() => window.dispatchEvent(new Event('pagehide')));
   expect(dialogs).toEqual([]);
 });
+
+// #525 — a transcription in flight owns the screen with loader markup and
+// aria-busy, and three things went wrong around it: switching "back" to the
+// project the session still points at was a silent no-op (the user stared at
+// the loader with no way out), switching to another project carried the busy
+// state with it, and re-picking the same media file fired no change event so
+// a retry after interruption did nothing.
+const startFakeTranscription = (page) => page.evaluate(() => {
+  document.querySelector('#hypertranscript').innerHTML =
+    '<div class="vertically-centre"><center>Transcribing…</center></div>';
+  setTranscriptBusy(true);
+});
+
+test('switching back to your project mid-transcription rescues it from the loader (#525)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+  const homeId = await page.evaluate(() => window.HyperaudioSave.library.currentId());
+
+  await startFakeTranscription(page);
+  await expect(page.locator('#hypertranscript')).toContainText('Transcribing…');
+
+  // click your own project's row: previously a silent no-op
+  const openPromise = page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
+  await awaitModal(page);
+  await page.click('#project-dialog-confirm');
+  await openPromise;
+
+  await expect(page.locator('#hypertranscript')).toContainText('Benvenuti'); // the project is back
+  expect(await page.evaluate(() =>
+    document.querySelector('#hypertranscript').getAttribute('aria-busy'))).toBeNull(); // busy cleared
+});
+
+test('staying puts keeps the transcription untouched (#525)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+  const homeId = await page.evaluate(() => window.HyperaudioSave.library.currentId());
+
+  await startFakeTranscription(page);
+  const openPromise = page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
+  await awaitModal(page);
+  await page.click('#project-dialog-cancel');
+  expect(await openPromise).toBe(false);
+
+  await expect(page.locator('#hypertranscript')).toContainText('Transcribing…'); // untouched
+  expect(await page.evaluate(() =>
+    document.querySelector('#hypertranscript').getAttribute('aria-busy'))).toBe('true');
+});
+
+test('the engine file inputs clear on click so the same file can be re-picked (#525)', async ({ page }, testInfo) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  const wavPath = testInfo.outputPath('tone.wav');
+  const fsm = await import('node:fs');
+  fsm.writeFileSync(wavPath, ladderWav(1));
+  await page.setInputFiles('#file-input', wavPath);
+  expect(await page.evaluate(() => document.querySelector('#file-input').files.length)).toBe(1);
+
+  // the user clicks the input again to re-pick the SAME file: the value must
+  // clear so the browser fires change for the identical selection
+  await page.evaluate(() => document.querySelector('#file-input')
+    .dispatchEvent(new MouseEvent('click')));
+  expect(await page.evaluate(() => document.querySelector('#file-input').value)).toBe('');
+});

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1299,6 +1299,18 @@ test('a transcription appears in Recents while it runs, and resolves on completi
   await expect(page.locator('#hypertranscript')).toContainText('Transcribing… (0m 42s)');
   expect(await page.evaluate(() =>
     document.querySelector('#hypertranscript').textContent.includes('Preparing model'))).toBe(false);
+
+  // SECOND hop: progress advances, leave from the PENDING view this time,
+  // return again — the snapshot must track every departure, not just the first
+  await page.evaluate(() => {
+    document.querySelector('#hypertranscript .transcribing-msg').textContent = 'Transcribing… (1m 30s)';
+  });
+  await page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
+  await expect(page.locator('#hypertranscript')).toContainText('Benvenuti');
+  await row.locator('.recents-transcribing-item').click();
+  await expect(page.locator('#hypertranscript')).toContainText('Transcribing… (1m 30s)');
+  expect(await page.evaluate(() =>
+    document.querySelector('#hypertranscript').textContent.includes('0m 42s'))).toBe(false);
   expect(await page.evaluate(() =>
     document.querySelector('#hypertranscript .transcribing-msg') !== null)).toBe(true);
 

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1456,3 +1456,33 @@ test('the NEW button is inert while a transcription runs — even from another p
   await newBtn.click();
   expect(await page.evaluate(() => document.getElementById('transcribe-modal').checked)).toBe(true);
 });
+
+// Swapping the player's src (every project switch) stops playback without a
+// pause event; the playbar synced only on play/pause/ended, so switching away
+// from a playing video showed the pause button over a video that wasn't
+// playing. 'emptied' is the event the load algorithm actually fires.
+test('the play button state survives a project switch away from a playing video', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+  const firstId = await page.evaluate(() => window.HyperaudioSave.library.currentId());
+  const p2 = testInfo.outputPath('second.hyperaudio');
+  (await import('node:fs')).writeFileSync(p2, await buildFixture());
+  await page.setInputFiles('#project-open-input', p2);
+  await pollPage(page, async (prev) => window.HyperaudioSave.library.currentId() !== prev
+    && document.getElementById('project-progress') === null, firstId);
+
+  // play the second project's media (muted, so headless allows it)
+  await page.evaluate(async () => {
+    const v = document.getElementById('hyperplayer');
+    v.muted = true;
+    await v.play();
+  });
+  await expect(page.locator('#playbar-play-icon')).toBeHidden(); // pause icon showing
+
+  // switch to the first project: not playing there — the button must say so
+  await page.evaluate((id) => window.HyperaudioSave.library.open(id), firstId);
+  await expect(page.locator('#hypertranscript')).toContainText('Benvenuti');
+  expect(await page.evaluate(() => document.getElementById('hyperplayer').paused)).toBe(true);
+  await expect(page.locator('#playbar-play-icon')).toBeVisible(); // play icon back
+});

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1282,21 +1282,29 @@ test('a transcription appears in Recents while it runs, and resolves on completi
   const row = page.locator('.recents-row-transcribing');
   await expect(row).toHaveCount(1);
   await expect(row).toContainText('brand-new-recording.wav'); // named after ITS file
+  // the transcribing row IS the selection while the loader owns the screen —
+  // and the previous project's row stands down
+  await expect(row.locator('.recents-transcribing-item')).toHaveClass(/active/);
+  await expect(page.locator('#file-picker .file-item[data-id].active')).toHaveCount(0);
 
   // the engine progresses past the initial message, as its interval does
   await page.evaluate(() => {
     document.querySelector('#hypertranscript .transcribing-msg').textContent = 'Transcribing… (0m 42s)';
   });
 
-  // switch away to the existing project — immediate, the row stays
+  // switch away to the existing project — immediate, the row stays but the
+  // selection moves to the project actually on screen
   await page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
   await expect(page.locator('#hypertranscript')).toContainText('Benvenuti');
   await expect(row).toHaveCount(1);
+  await expect(row.locator('.recents-transcribing-item')).not.toHaveClass(/active/);
+  await expect(page.locator('#file-picker .file-item[data-id].active')).toHaveCount(1);
 
   // click the row: back to the live loader AT THE DEPARTURE-TIME message —
   // not the stale 'Preparing model' captured when the engine started
   await row.locator('.recents-transcribing-item').click();
   await expect(page.locator('#hypertranscript')).toContainText('Transcribing… (0m 42s)');
+  await expect(row.locator('.recents-transcribing-item')).toHaveClass(/active/); // selected again on return
   expect(await page.evaluate(() =>
     document.querySelector('#hypertranscript').textContent.includes('Preparing model'))).toBe(false);
 

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1348,6 +1348,58 @@ test('a transcription appears in Recents while it runs, and resolves on completi
   expect(born.playerSrc).toBe(engineSrc);
 });
 
+test('a phantom engine error does not let the birth steal another project\'s identity (#529 × #525)', async ({ page }, testInfo) => {
+  // The measured Parakeet failure mode: handleError fires (error markup +
+  // busy(false)) — then the worker recovers and completes anyway. The row
+  // dies with the error signal, correctly; the transcription's identity must
+  // not, or the recovered birth is named after and paired with whatever
+  // project the user was viewing.
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+  const homeId = await page.evaluate(() => window.HyperaudioSave.library.currentId());
+
+  const newWav = testInfo.outputPath('phantom-recording.wav');
+  (await import('node:fs')).writeFileSync(newWav, ladderWav(1));
+  await page.setInputFiles('#file-input', newWav);
+  await page.evaluate(() => {
+    const player = document.getElementById('hyperplayer');
+    player.src = URL.createObjectURL(new Blob([new Uint8Array(4)], { type: 'audio/wav' }));
+    document.querySelector('#hypertranscript').innerHTML =
+      '<div class="vertically-centre"><center><span class="transcribing-msg">Preparing model…</span></center></div>';
+    setTranscriptBusy(true);
+  });
+  const engineSrc = await page.evaluate(() => document.getElementById('hyperplayer').src);
+
+  // the user is viewing another project when the phantom error hits
+  await page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
+  await page.evaluate(() => {
+    document.querySelector('#hypertranscript').innerHTML =
+      '<div class="vertically-centre"><center>Sorry. Transcription failed.</center></div>';
+    setTranscriptBusy(false); // handleError's signal — the row goes
+  });
+  await expect(page.locator('.recents-row-transcribing')).toHaveCount(0);
+
+  // ...and then the worker recovers and completes
+  await page.evaluate(() => {
+    document.querySelector('#hypertranscript').innerHTML =
+      '<article><section><p><span data-m="0" data-d="500">RECOVERED </span></p></section></article>';
+    setTranscriptBusy(false);
+    document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+  });
+  await pollPage(page, async () => (await window.HyperaudioSave.library.list()).length === 2);
+
+  const born = await page.evaluate(async () => {
+    const list = await window.HyperaudioSave.library.list();
+    const entry = list.find((e) => e.name !== 'E2E Project');
+    return { name: entry.name, mediaFile: entry.media && entry.media.filename,
+      playerSrc: document.getElementById('hyperplayer').src };
+  });
+  expect(born.name).toBe('phantom-recording.wav');      // not the fixture's name
+  expect(born.mediaFile).toBe('phantom-recording.wav'); // not the fixture's media
+  expect(born.playerSrc).toBe(engineSrc);               // not the fixture's video
+});
+
 test('an engine error takes the in-progress row with it (#525)', async ({ page }) => {
   await page.goto('/index.html');
   await page.waitForSelector('#hypertranscript [data-m]');

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1264,15 +1264,24 @@ test('a transcription appears in Recents while it runs, and resolves on completi
   await awaitLibraryEntry(page);
   const homeId = await page.evaluate(() => window.HyperaudioSave.library.currentId());
 
-  // an engine starts, exactly as they all do: loader markup, then busy(true)
+  // the user picks a NEW file to transcribe (the capture listener records it)
+  const newWav = testInfo.outputPath('brand-new-recording.wav');
+  (await import('node:fs')).writeFileSync(newWav, ladderWav(1));
+  await page.setInputFiles('#file-input', newWav);
+
+  // an engine starts, exactly as they all do: its own media on the player,
+  // loader markup, then busy(true)
   await page.evaluate(() => {
+    const player = document.getElementById('hyperplayer');
+    player.src = URL.createObjectURL(new Blob([new Uint8Array(4)], { type: 'audio/wav' }));
     document.querySelector('#hypertranscript').innerHTML =
       '<div class="vertically-centre"><center><span class="transcribing-msg">Preparing model…</span></center></div>';
     setTranscriptBusy(true);
   });
+  const engineSrc = await page.evaluate(() => document.getElementById('hyperplayer').src);
   const row = page.locator('.recents-row-transcribing');
   await expect(row).toHaveCount(1);
-  await expect(row).toContainText('transcribing…');
+  await expect(row).toContainText('brand-new-recording.wav'); // named after ITS file
 
   // the engine progresses past the initial message, as its interval does
   await page.evaluate(() => {
@@ -1304,6 +1313,19 @@ test('a transcription appears in Recents while it runs, and resolves on completi
   await expect(page.locator('.recents-row-transcribing')).toHaveCount(0);
   await pollPage(page, async () =>
     (await window.HyperaudioSave.library.list()).length === 2); // fixture + birth
+
+  // The birth carries the TRANSCRIPTION's identity, not the project the user
+  // happened to be viewing: its name and media are the new recording's, and
+  // the player is back on the transcription's own source.
+  const born = await page.evaluate(async () => {
+    const list = await window.HyperaudioSave.library.list();
+    const entry = list.find((e) => e.name !== 'E2E Project');
+    return { name: entry.name, mediaFile: entry.media && entry.media.filename,
+      playerSrc: document.getElementById('hyperplayer').src };
+  });
+  expect(born.name).toBe('brand-new-recording.wav');
+  expect(born.mediaFile).toBe('brand-new-recording.wav');
+  expect(born.playerSrc).toBe(engineSrc);
 });
 
 test('an engine error takes the in-progress row with it (#525)', async ({ page }) => {

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1103,13 +1103,19 @@ test('the in-flight open explains itself rather than doing nothing (#504)', asyn
   const dialogs = [];
   await openFixture(page, testInfo, dialogs);
 
-  // Two opens started back to back. What the file contains does not matter —
-  // the guard is set synchronously before the first await, so the second call
-  // takes the refusal path regardless of whether the first ultimately succeeds.
+  // Two opens started back to back. The first must GENUINELY still be in
+  // flight when the second arrives — an instantly-failing dummy could finish
+  // first under CPU contention and the refusal never fire (it did, in full-
+  // suite runs on a loaded machine). A real container with long media keeps
+  // the first open busy well past the second call.
+  const bigPath = testInfo.outputPath('big.hyperaudio');
+  fs.writeFileSync(bigPath, await buildFixture(null, null, 600));
+  await page.setInputFiles('#project-open-input', bigPath); // lands a File we can reuse
+  await awaitOpenIdle(page);
   const text = await page.evaluate(async () => {
-    const dummy = () => new File(['not a zip'], 'x.hyperaudio');
-    const first = window.HyperaudioSave.openFromFile(dummy());
-    const second = window.HyperaudioSave.openFromFile(dummy());
+    const file = document.getElementById('project-open-input').files[0];
+    const first = window.HyperaudioSave.openFromFile(file);
+    const second = window.HyperaudioSave.openFromFile(file);
     const el = document.getElementById('project-progress');
     const t = el ? el.textContent : null;
     await Promise.allSettled([first, second]);

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1269,3 +1269,71 @@ test('the engine file inputs clear on click so the same file can be re-picked (#
     .dispatchEvent(new MouseEvent('click')));
   expect(await page.evaluate(() => document.querySelector('#file-input').value)).toBe('');
 });
+
+// #525 follow-up — the transcription is a first-class Recents citizen from the
+// moment it starts: an in-progress row appears (virtual, in-memory — a reload
+// kills the engine, so nothing persists to get stuck), clicking it hands the
+// screen back to the live loader, completion replaces it with the real project
+// entry, and an engine error takes the row away with it.
+test('a transcription appears in Recents while it runs, and resolves on completion (#525)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+  const homeId = await page.evaluate(() => window.HyperaudioSave.library.currentId());
+
+  // an engine starts, exactly as they all do: loader markup, then busy(true)
+  await page.evaluate(() => {
+    document.querySelector('#hypertranscript').innerHTML =
+      '<div class="vertically-centre"><center><span class="transcribing-msg">Transcribing…</span></center></div>';
+    setTranscriptBusy(true);
+  });
+  const row = page.locator('.recents-row-transcribing');
+  await expect(row).toHaveCount(1);
+  await expect(row).toContainText('transcribing…');
+
+  // switch away to the existing project (consent), the row stays
+  const openPromise = page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
+  await awaitModal(page);
+  await page.click('#project-dialog-confirm');
+  await openPromise;
+  await expect(page.locator('#hypertranscript')).toContainText('Benvenuti');
+  await expect(row).toHaveCount(1);
+
+  // click the row: back to the live loader, and the engines' null-guarded
+  // progress lookup finds its element again
+  await row.locator('.recents-transcribing-item').click();
+  await expect(page.locator('#hypertranscript')).toContainText('Transcribing…');
+  expect(await page.evaluate(() =>
+    document.querySelector('#hypertranscript .transcribing-msg') !== null)).toBe(true);
+
+  // completion: transcript lands, busy false, init births — the virtual row
+  // resolves into the real project entry
+  await page.evaluate(() => {
+    document.querySelector('#hypertranscript').innerHTML =
+      '<article><section><p><span data-m="0" data-d="500">DONE </span></p></section></article>';
+    setTranscriptBusy(false);
+    document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+  });
+  await expect(page.locator('.recents-row-transcribing')).toHaveCount(0);
+  await pollPage(page, async () =>
+    (await window.HyperaudioSave.library.list()).length === 2); // fixture + birth
+});
+
+test('an engine error takes the in-progress row with it (#525)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  await page.evaluate(() => {
+    document.querySelector('#hypertranscript').innerHTML =
+      '<div class="vertically-centre"><center><span class="transcribing-msg">Transcribing…</span></center></div>';
+    setTranscriptBusy(true);
+  });
+  await expect(page.locator('.recents-row-transcribing')).toHaveCount(1);
+
+  // the engines' error path: error markup, busy(false), no init ever
+  await page.evaluate(() => {
+    document.querySelector('#hypertranscript').innerHTML =
+      '<div class="vertically-centre"><center>Sorry. An unexpected error has occurred.</center></div>';
+    setTranscriptBusy(false);
+  });
+  await expect(page.locator('.recents-row-transcribing')).toHaveCount(0);
+});

--- a/__TEST__/e2e/transcript-bench.spec.mjs
+++ b/__TEST__/e2e/transcript-bench.spec.mjs
@@ -2,6 +2,18 @@ import { test, expect } from '@playwright/test';
 import fs from 'node:fs';
 import { ladderWav } from './helpers.mjs';
 
+// The benchmark runs in its own project (#517 follow-up), which needs OPFS.
+// Playwright's WebKit ships the OPFS API surface without a working backend
+// (navigator.storage.getDirectory() throws UnknownError — see #510), so the
+// library-dependent tests skip there. Real Safari has working OPFS; this is
+// a harness limitation, not a product one.
+const skipWithoutOpfs = async (page) => {
+  const works = await page.evaluate(async () => {
+    try { await navigator.storage.getDirectory(); return true; } catch (e) { return false; }
+  });
+  test.skip(!works, 'OPFS non-functional in this harness (Playwright WebKit)');
+};
+
 test('bench is inert without the flag', async ({ page }) => {
   await page.goto('/index.html');
   await page.waitForSelector('#hypertranscript span[data-m]');
@@ -12,6 +24,7 @@ test('bench panel appears with ?bench=1 and produces measurements', async ({ pag
   test.setTimeout(240000);
   await page.goto('/index.html?bench=1');
   await page.waitForSelector('#hypertranscript span[data-m]');
+  await skipWithoutOpfs(page);
   const panel = page.locator('[aria-label="HLE Benchmark"]');
   await expect(panel).toBeVisible();
   await expect(panel).toContainText('local ASR');
@@ -46,8 +59,8 @@ test('the benchmark runs in its own project and returns you to yours', async ({ 
   test.setTimeout(240000);
   await page.goto('/index.html?bench=1');
   await page.waitForSelector('#hypertranscript span[data-m]');
+  await skipWithoutOpfs(page);
 
-  // give the user a project to be returned to (a birth, as every engine does it)
   // A file captured for the user's own work — the state in which the
   // Benchmark project used to claim this file as ITS media.
   const wavPath = testInfo.outputPath('tone.wav');

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -1590,3 +1590,15 @@ label[data-a11y-wired]:focus-visible {
 @media (prefers-reduced-motion: reduce) {
   #file-picker .recents-transcribing-badge { animation: none; }
 }
+
+/* One transcription at a time (#525): the engines share one transcript
+   element, one player and one busy flag — starting a second while one runs
+   produced interleaved errors. The entry points grey out while the
+   transcript is busy (same :has pattern as the corner buttons); the modal's
+   own submit labels need no gating because starting closes the modal and
+   reopening goes through these. Batch transcription is its own feature. */
+html:has(#hypertranscript[aria-busy="true"]) #new-transcription-btn,
+html:has(#hypertranscript[aria-busy="true"]) #upload-transcribe-btn {
+  pointer-events: none;
+  opacity: 0.4;
+}

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -1568,3 +1568,25 @@ label[data-a11y-wired]:focus-visible {
 #file-picker .recents-deleted-dismiss {
   color: oklch(var(--bc) / 0.5);
 }
+
+/* The in-progress transcription row (#525): visibly alive, not a normal
+   project. The pulsing badge is the "something is happening" signal. */
+#file-picker .recents-row-transcribing .file-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+#file-picker .recents-transcribing-badge {
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  color: oklch(var(--p));
+  animation: ha-transcribing-pulse 1.6s ease-in-out infinite;
+}
+@keyframes ha-transcribing-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+@media (prefers-reduced-motion: reduce) {
+  #file-picker .recents-transcribing-badge { animation: none; }
+}

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -1569,26 +1569,30 @@ label[data-a11y-wired]:focus-visible {
   color: oklch(var(--bc) / 0.5);
 }
 
-/* The in-progress transcription row (#525): visibly alive, not a normal
-   project. The pulsing badge is the "something is happening" signal. */
-#file-picker .recents-row-transcribing .file-item {
-  display: flex;
+/* The in-progress transcription row (#525): the same anatomy and widths as a
+   normal row, with a spinner in the kebab's slot as the wordless "something
+   is happening" signal — always visible, where a kebab reveals on hover. */
+#file-picker .recents-row-transcribing .recents-actions {
+  opacity: 1;
   align-items: center;
-  gap: 8px;
-  min-width: 0;
+  /* the kebab is a 2rem square button; give the spinner the same footprint
+     so the name column ends where every other row's does */
+  width: 2rem;
+  justify-content: center;
 }
-#file-picker .recents-transcribing-badge {
-  flex: 0 0 auto;
-  font-size: 0.75rem;
-  color: oklch(var(--p));
-  animation: ha-transcribing-pulse 1.6s ease-in-out infinite;
+#file-picker .recents-transcribing-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid oklch(var(--p) / 0.25);
+  border-top-color: oklch(var(--p));
+  border-radius: 50%;
+  animation: ha-transcribing-spin 0.8s linear infinite;
 }
-@keyframes ha-transcribing-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.35; }
+@keyframes ha-transcribing-spin {
+  to { transform: rotate(360deg); }
 }
 @media (prefers-reduced-motion: reduce) {
-  #file-picker .recents-transcribing-badge { animation: none; }
+  #file-picker .recents-transcribing-spinner { animation: none; }
 }
 
 /* One transcription at a time (#525): the engines share one transcript

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -1597,8 +1597,8 @@ label[data-a11y-wired]:focus-visible {
    transcript is busy (same :has pattern as the corner buttons); the modal's
    own submit labels need no gating because starting closes the modal and
    reopening goes through these. Batch transcription is its own feature. */
-html:has(#hypertranscript[aria-busy="true"]) #new-transcription-btn,
-html:has(#hypertranscript[aria-busy="true"]) #upload-transcribe-btn {
+html.ha-transcribing #new-transcription-btn,
+html.ha-transcribing #upload-transcribe-btn {
   pointer-events: none;
   opacity: 0.4;
 }

--- a/index.html
+++ b/index.html
@@ -569,7 +569,7 @@ If you are creating an open source application under a license compatible with t
           <label id="export-media-btn" for="export-modal" class="btn btn-square btn-primary tooltip" data-tip="Export media" style="margin-right:4px" aria-label="Export media">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-download"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
           </label>
-          <label for="transcribe-modal" class="btn btn-primary gap-2">
+          <label id="new-transcription-btn" for="transcribe-modal" class="btn btn-primary gap-2">
             <span id="transcribe-label">NEW</span>
             <span id="transcribe-label-mobile">NEW</span>
             <svg id="transcribe-logo" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sticker"><path d="M15.5 3H5a2 2 0 0 0-2 2v14c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2V8.5L15.5 3Z"></path><path d="M15 3v6h6"></path><path d="M10 16s.8 1 2 1c1.3 0 2-1 2-1"></path><path d="M8 13h0"></path><path d="M16 13h0"></path></svg>

--- a/index.html
+++ b/index.html
@@ -1049,7 +1049,7 @@ If you are creating an open source application under a license compatible with t
   <import-vtt></import-vtt>
   
 
-  <script src="js/editor-file-menu.js?v=1.0.0"></script>
+  <script src="js/editor-file-menu.js?v=1.2.5"></script>
 
   <script src="./js/hyperaudio-lite-editor-export.js?v=1.2.4" type="module"> </script>
   <!-- end of localstorage additions -->

--- a/index.html
+++ b/index.html
@@ -1051,7 +1051,7 @@ If you are creating an open source application under a license compatible with t
 
   <script src="js/editor-file-menu.js?v=1.2.5"></script>
 
-  <script src="./js/hyperaudio-lite-editor-export.js?v=1.2.4" type="module"> </script>
+  <script src="./js/hyperaudio-lite-editor-export.js?v=1.2.5" type="module"> </script>
   <!-- end of localstorage additions -->
 
   <!-- caption editor additions -->
@@ -1100,7 +1100,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.5.4"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.5.5"></script>
   <script src="js/hyperaudio-library.js?v=1.2.5.2"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -1100,7 +1100,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.5.5"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.5.6"></script>
   <script src="js/hyperaudio-library.js?v=1.2.5.3"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.2.4">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.2.5">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1101,7 +1101,7 @@ If you are creating an open source application under a license compatible with t
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
   <script src="js/hyperaudio-save.js?v=1.2.5"></script>
-  <script src="js/hyperaudio-library.js?v=1.2.4"></script>
+  <script src="js/hyperaudio-library.js?v=1.2.5"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>
 

--- a/index.html
+++ b/index.html
@@ -1100,7 +1100,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.5.2"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.5.3"></script>
   <script src="js/hyperaudio-library.js?v=1.2.5"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.2.4 (last changed in release 1.2.4) -->
+<!--  Hyperaudio Lite Editor - Version 1.2.5 (last changed in release 1.2.5) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.2.4">
+  <meta name="version" content="1.2.5">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -1041,7 +1041,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-serializer.js?v=1.1.8"></script>
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.2.0"></script>
-  <script src="js/editor-core.js?v=1.2.5"></script>
+  <script src="js/editor-core.js?v=1.2.5.1"></script>
 
 
   <import-deepgram-json></import-deepgram-json>

--- a/index.html
+++ b/index.html
@@ -1100,8 +1100,8 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.5.3"></script>
-  <script src="js/hyperaudio-library.js?v=1.2.5"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.5.4"></script>
+  <script src="js/hyperaudio-library.js?v=1.2.5.1"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>
 

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.2.5.1">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.2.5.2">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1101,7 +1101,7 @@ If you are creating an open source application under a license compatible with t
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
   <script src="js/hyperaudio-save.js?v=1.2.5.5"></script>
-  <script src="js/hyperaudio-library.js?v=1.2.5.2"></script>
+  <script src="js/hyperaudio-library.js?v=1.2.5.3"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>
 

--- a/index.html
+++ b/index.html
@@ -1041,7 +1041,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-serializer.js?v=1.1.8"></script>
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.2.0"></script>
-  <script src="js/editor-core.js?v=1.2.4"></script>
+  <script src="js/editor-core.js?v=1.2.5"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1100,7 +1100,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.4"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.5"></script>
   <script src="js/hyperaudio-library.js?v=1.2.4"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -1100,7 +1100,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.5.1"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.5.2"></script>
   <script src="js/hyperaudio-library.js?v=1.2.5"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.2.5">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.2.5.1">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1100,7 +1100,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.5"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.5.1"></script>
   <script src="js/hyperaudio-library.js?v=1.2.5"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -1078,7 +1078,7 @@ If you are creating an open source application under a license compatible with t
     }
 
   </style>
-  <script src="js/editor-main.js?v=1.2.4"></script>
+  <script src="js/editor-main.js?v=1.2.5"></script>
   <script src="js/find-replace.js?v=1.2.0"></script>
   <script src="js/transcript-history.js?v=1.2.4"></script>
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->

--- a/index.html
+++ b/index.html
@@ -1101,7 +1101,7 @@ If you are creating an open source application under a license compatible with t
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
   <script src="js/hyperaudio-save.js?v=1.2.5.4"></script>
-  <script src="js/hyperaudio-library.js?v=1.2.5.1"></script>
+  <script src="js/hyperaudio-library.js?v=1.2.5.2"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>
 

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -33,6 +33,17 @@
   // While a transcription is in flight the transcript container holds loader
   // markup, not a transcript – typing into it would be silently destroyed
   // when the result lands. Transcription modules call this around their work.
+  // Re-picking the SAME file fires no change event unless the input's value
+  // is cleared first — so retrying a transcription after an interruption (or
+  // transcribing the same file twice) was a silent no-op (#525). Clearing on
+  // click makes every pick fire. Wired centrally for the engines' file
+  // inputs; the same trick the project-open input has always used.
+  ['#file-input', '#parakeet-file-input', '#deepgram-file', '#assemblyai-file', '#parakeet-hf-file']
+    .forEach((selector) => {
+      const el = document.querySelector(selector);
+      if (el !== null) el.addEventListener('click', () => { el.value = ''; });
+    });
+
   function setTranscriptBusy(busy) {
     const transcript = document.getElementById("hypertranscript");
     if (transcript === null) {

--- a/js/editor-file-menu.js
+++ b/js/editor-file-menu.js
@@ -7,5 +7,11 @@
     .querySelector("#regenerate-captions")
     .addEventListener("click", function () {
       captionCache = null;
+      // Regenerating IS choosing transcript-derived captions: sync resumes
+      // until the next hand edit flips it off again. Before this, regenerated
+      // captions stayed marked "curated" and stopped following the transcript
+      // — a one-shot rebuild rather than the re-subscription the button's own
+      // confirm dialog implies.
+      updateCaptionsFromTranscript = true;
       hyperaudioGenerateCaptionsFromTranscript();
     });

--- a/js/editor-main.js
+++ b/js/editor-main.js
@@ -322,6 +322,11 @@
       video.addEventListener('play', reflectPlayState);
       video.addEventListener('pause', reflectPlayState);
       video.addEventListener('ended', reflectPlayState);
+      // Swapping src (every project switch) stops playback WITHOUT a pause
+      // event — the load algorithm fires 'emptied' instead. Without this, a
+      // switch away from a playing video left the pause button showing over
+      // a video that wasn't playing.
+      video.addEventListener('emptied', reflectPlayState);
 
       const reflectVolume = () => {
         const silent = video.muted || video.volume === 0;

--- a/js/hyperaudio-library.js
+++ b/js/hyperaudio-library.js
@@ -326,6 +326,23 @@
       pendingDeleted = null;
     }
 
+    // The in-progress transcription (#525): a virtual row at the top — it is
+    // the newest thing happening — with a live badge. Clicking it hands the
+    // screen back to the transcription; the engines' progress resumes there.
+    const pending = api.pendingTranscription ? api.pendingTranscription() : null;
+    if (pending !== null) {
+      const nameHtml = escapeMarkup(pending.name);
+      filePicker.insertAdjacentHTML('beforeend',
+        `<li class="recents-row recents-row-transcribing">` +
+        `<a class="file-item recents-transcribing-item">${nameHtml}` +
+        `<span class="recents-transcribing-badge">transcribing…</span></a></li>`);
+      filePicker.querySelector('.recents-transcribing-item')
+        .addEventListener('click', (event) => {
+          event.preventDefault();
+          api.openPendingTranscription();
+        });
+    }
+
     const entryById = {};
     const renderRow = (entry) => {
       if (entry.deletedPlaceholder === true) {

--- a/js/hyperaudio-library.js
+++ b/js/hyperaudio-library.js
@@ -330,11 +330,21 @@
     // the newest thing happening — with a live badge. Clicking it hands the
     // screen back to the transcription; the engines' progress resumes there.
     const pending = api.pendingTranscription ? api.pendingTranscription() : null;
+    // While the loader is what's on screen, the transcribing row is the
+    // selection — from the moment the engine starts until the user moves
+    // away, and again whenever they return. The project rows' own active
+    // marking stands down for exactly that window (the session may still
+    // point at the previous project before the birth, and its row showing
+    // active while the user watches the loader would be a lie).
+    const viewingPending = pending !== null && (() => {
+      const t = document.getElementById('hypertranscript');
+      return t !== null && t.getAttribute('aria-busy') === 'true';
+    })();
     if (pending !== null) {
       const nameHtml = escapeMarkup(pending.name);
       filePicker.insertAdjacentHTML('beforeend',
         `<li class="recents-row recents-row-transcribing">` +
-        `<a class="file-item recents-transcribing-item">${nameHtml}` +
+        `<a class="file-item recents-transcribing-item${viewingPending ? ' active' : ''}">${nameHtml}` +
         `<span class="recents-transcribing-badge">transcribing…</span></a></li>`);
       filePicker.querySelector('.recents-transcribing-item')
         .addEventListener('click', (event) => {
@@ -427,7 +437,7 @@
     }
 
     filePicker.querySelectorAll('.file-item[data-id]').forEach((el) => {
-      el.classList.toggle('active', el.getAttribute('data-id') === currentId);
+      el.classList.toggle('active', !viewingPending && el.getAttribute('data-id') === currentId);
       el.addEventListener('click', (event) => {
         // a rename input lives inside the row's <a>; its clicks are not loads
         if (event.target.classList && event.target.classList.contains('recents-rename-input')) return;

--- a/js/hyperaudio-library.js
+++ b/js/hyperaudio-library.js
@@ -426,7 +426,7 @@
       });
     }
 
-    filePicker.querySelectorAll('.file-item').forEach((el) => {
+    filePicker.querySelectorAll('.file-item[data-id]').forEach((el) => {
       el.classList.toggle('active', el.getAttribute('data-id') === currentId);
       el.addEventListener('click', (event) => {
         // a rename input lives inside the row's <a>; its clicks are not loads

--- a/js/hyperaudio-library.js
+++ b/js/hyperaudio-library.js
@@ -342,10 +342,15 @@
     })();
     if (pending !== null) {
       const nameHtml = escapeMarkup(pending.name);
+      // Same anatomy as a normal row — name column plus the actions slot —
+      // so the widths line up; a spinner sits where the kebab would, saying
+      // 'in progress' without words.
       filePicker.insertAdjacentHTML('beforeend',
         `<li class="recents-row recents-row-transcribing">` +
-        `<a class="file-item recents-transcribing-item${viewingPending ? ' active' : ''}">${nameHtml}` +
-        `<span class="recents-transcribing-badge">transcribing…</span></a></li>`);
+        `<a class="file-item recents-transcribing-item${viewingPending ? ' active' : ''}">${nameHtml}</a>` +
+        `<span class="recents-actions">` +
+        `<span class="recents-transcribing-spinner" role="img" aria-label="Transcribing"></span>` +
+        `</span></li>`);
       filePicker.querySelector('.recents-transcribing-item')
         .addEventListener('click', (event) => {
           event.preventDefault();

--- a/js/hyperaudio-lite-editor-export.js
+++ b/js/hyperaudio-lite-editor-export.js
@@ -47,6 +47,7 @@ class ImportJson extends HTMLElement {
         if (hypertranscript === null) {
           alert("Currently you can only import JSON from the Transcript View.");
         } else {
+          if (typeof window.clearPendingTranscription === 'function') window.clearPendingTranscription();
           hypertranscript.innerHTML = jsonToHtml(jsonData);
           const mediaUrl = jsonData.sections && jsonData.sections[0] && jsonData.sections[0].mediaUrl;
           if (mediaUrl) {
@@ -232,6 +233,8 @@ class ImportSrt extends HTMLElement {
       // leaves the previous document's cue pixels painted on the paused video.
       applyCaptionTrack(vttUrl, { mode: 'showing' });
 
+      // an errored transcription's surviving identity must not claim this import
+      if (typeof window.clearPendingTranscription === 'function') window.clearPendingTranscription();
       document.dispatchEvent(new CustomEvent('hyperaudioInit'));
 
       // Preserve original format — AFTER the init dispatch, which now
@@ -359,6 +362,8 @@ class ImportVtt extends HTMLElement {
       // Through the caption door (#356/#287) — see the SRT import above.
       applyCaptionTrack(vttUrl, { mode: 'showing' });
 
+      // an errored transcription's surviving identity must not claim this import
+      if (typeof window.clearPendingTranscription === 'function') window.clearPendingTranscription();
       document.dispatchEvent(new CustomEvent('hyperaudioInit'));
 
       // Preserve original format — AFTER the init dispatch, which now

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2203,6 +2203,97 @@
   // incoming one (draft first — its unsaved edits come back, still dirty),
   // move the per-project lock. Returns false (editor untouched) when the
   // target can't be read.
+  /* --------------------------------------------------------------------------
+   * Pending transcription as a first-class Recents citizen (#525). From the
+   * moment an engine starts, the transcription appears as an in-progress row
+   * (virtual — in memory only, so a reload, which kills the engine anyway,
+   * leaves no stuck entry). Clicking it switches back to the live loader:
+   * the local engines update progress via a null-guarded
+   * '#hypertranscript .transcribing-msg' lookup, so re-rendering the captured
+   * loader markup lets their message and elapsed time resume painting.
+   *
+   * Detection is the engines' own signal: they call setTranscriptBusy(true)
+   * right after writing their loader, and (false) on completion or error —
+   * wrapped here the same way setTranscriptionInfo is. Completion is the
+   * birth (hyperaudioInit); busy(false) with no timed spans in the transcript
+   * is a failure or cancellation, and the row leaves with the engine.
+   * ----------------------------------------------------------------------- */
+  let pendingTranscription = null; // { name, loaderHtml }
+
+  function pendingTranscriptionInfo() {
+    return pendingTranscription === null ? null : { name: pendingTranscription.name };
+  }
+
+  function mediaDisplayName() {
+    if (session.mediaFile !== null && session.mediaFile.name) return session.mediaFile.name;
+    const player = document.getElementById('hyperplayer');
+    const src = player !== null ? player.src : '';
+    if (/^https?:/i.test(src)) {
+      try {
+        const leaf = decodeURIComponent(new URL(src).pathname.split('/').pop() || '');
+        if (leaf !== '') return leaf;
+      } catch (e) { /* fall through */ }
+    }
+    return 'Transcription';
+  }
+
+  {
+    const originalSetBusy = window.setTranscriptBusy;
+    if (typeof originalSetBusy === 'function') {
+      window.setTranscriptBusy = function (busy) {
+        try {
+          const t = document.getElementById('hypertranscript');
+          if (busy === true && t !== null) {
+            pendingTranscription = { name: mediaDisplayName(), loaderHtml: t.innerHTML };
+            notifyLibraryChanged(false);
+          } else if (busy === false && pendingTranscription !== null) {
+            // success is announced by hyperaudioInit (the birth clears the row
+            // there); busy(false) with no timed spans means the engine ended
+            // without a transcript — an error, and the row goes with it
+            if (t === null || t.querySelector('span[data-m]') === null) {
+              pendingTranscription = null;
+              notifyLibraryChanged(false);
+            }
+          }
+        } catch (e) { /* observing only — never break the engine's call */ }
+        return originalSetBusy.apply(this, arguments);
+      };
+    }
+  }
+
+  document.addEventListener('hyperaudioInit', () => {
+    if (pendingTranscription !== null) {
+      pendingTranscription = null;
+      notifyLibraryChanged(false);
+    }
+  });
+
+  // Clicking the in-progress row: hand the screen back to the transcription.
+  // The current project's pending edits flush to its own draft first; the
+  // loader is re-rendered and the engines' progress painting resumes into it.
+  // No project owns the screen while watching (projectId null), exactly as
+  // during the original loader phase.
+  async function switchToPendingTranscription() {
+    if (pendingTranscription === null) return false;
+    const t = document.getElementById('hypertranscript');
+    if (t === null) return false;
+    if (t.getAttribute('aria-busy') === 'true') return true; // already watching
+    await flushPendingDraft();
+    releaseProjectLock();
+    session.projectId = null;
+    sessionEdited = false;
+    updateSaveIndicator();
+    suppressCapture = true;
+    try {
+      t.innerHTML = pendingTranscription.loaderHtml;
+      t.setAttribute('aria-busy', 'true');
+    } finally {
+      suppressCapture = false;
+    }
+    notifyLibraryChanged(false);
+    return true;
+  }
+
   // A transcription in flight owns the screen with loader markup and
   // aria-busy (#525). Navigating over it needs consent — and the truth: the
   // engine cannot be cancelled from here, so when it finishes it will land as
@@ -2216,7 +2307,15 @@
       'A transcription is still running. You can switch away — it will keep '
       + 'going and open as a new project when it finishes. Switch now?',
       'Switch', 'Stay');
-    if (proceed && typeof setTranscriptBusy === 'function') setTranscriptBusy(false);
+    if (proceed) {
+      // Clear the ATTRIBUTE directly, not via setTranscriptBusy: that call is
+      // the ENGINE's lifecycle signal, and the wrapper above reads
+      // busy(false)-without-spans as an engine failure — which would take the
+      // in-progress Recents row down with it. Here the engine is still very
+      // much running; only the styling must not follow us to the next view.
+      const t = document.getElementById('hypertranscript');
+      if (t !== null) t.removeAttribute('aria-busy');
+    }
     return proceed;
   }
 
@@ -2971,6 +3070,8 @@
       duplicate: duplicateProject,
       remove: deleteProject,
       restoreDeleted: restoreCurrentAsNewProject,
+      pendingTranscription: pendingTranscriptionInfo,
+      openPendingTranscription: switchToPendingTranscription,
     },
   };
 

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2345,6 +2345,13 @@
         t.innerHTML = pendingTranscription.loaderHtml;
       }
       t.setAttribute('aria-busy', 'true');
+      // The transcription's own media on the player too — without this, the
+      // pending view kept showing whatever project was on screen before.
+      const player = document.getElementById('hyperplayer');
+      if (player !== null && pendingIdentity !== null && pendingIdentity.playerSrc
+          && player.src !== pendingIdentity.playerSrc) {
+        player.src = pendingIdentity.playerSrc;
+      }
     } finally {
       suppressCapture = false;
     }

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.2.4 — last changed in release 1.2.4
+ * @version 1.2.5 — last changed in release 1.2.5
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind
@@ -1975,6 +1975,7 @@
   }
 
   async function openFromFileInner(file, token) {
+    if (!(await confirmOverTranscription())) return; // #525: same consent as switching
     // Parse and validate BEFORE the replace-confirmation: asking permission
     // to replace the current project and THEN refusing the file meant the
     // user consented to a replacement that never happened (prepare → confirm
@@ -2202,9 +2203,34 @@
   // incoming one (draft first — its unsaved edits come back, still dirty),
   // move the per-project lock. Returns false (editor untouched) when the
   // target can't be read.
+  // A transcription in flight owns the screen with loader markup and
+  // aria-busy (#525). Navigating over it needs consent — and the truth: the
+  // engine cannot be cancelled from here, so when it finishes it will land as
+  // its own new project. Clearing busy on the way through also stops the
+  // switched-to project rendering in the busy state (hidden corner buttons
+  // and timecodes) — the attribute survived the content swap.
+  async function confirmOverTranscription() {
+    const t = document.getElementById('hypertranscript');
+    if (t === null || t.getAttribute('aria-busy') !== 'true') return true;
+    const proceed = await projectConfirm(
+      'A transcription is still running. You can switch away — it will keep '
+      + 'going and open as a new project when it finishes. Switch now?',
+      'Switch', 'Stay');
+    if (proceed && typeof setTranscriptBusy === 'function') setTranscriptBusy(false);
+    return proceed;
+  }
+
   async function switchToProject(id) {
     if (!opfsAvailable) return false;
-    if (id === session.projectId) return true;
+    if (id === session.projectId) {
+      // Normally a no-op — but mid-transcription the SCREEN holds the loader
+      // while the session still points at this project (no birth has happened
+      // yet), and the no-op stranded the user staring at it with no way back
+      // (#525). When busy, fall through and re-apply the project from disk.
+      const t = document.getElementById('hypertranscript');
+      if (t === null || t.getAttribute('aria-busy') !== 'true') return true;
+    }
+    if (!(await confirmOverTranscription())) return false;
     const files = await readProjectFiles(id);
     if (files === null) return false;
     await flushPendingDraft();

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -1975,7 +1975,7 @@
   }
 
   async function openFromFileInner(file, token) {
-    if (!(await confirmOverTranscription())) return; // #525: same consent as switching
+    leaveTranscriptionView(); // #525: the busy styling must not follow us
     // Parse and validate BEFORE the replace-confirmation: asking permission
     // to replace the current project and THEN refusing the file meant the
     // user consented to a replacement that never happened (prepare → confirm
@@ -2294,29 +2294,17 @@
     return true;
   }
 
-  // A transcription in flight owns the screen with loader markup and
-  // aria-busy (#525). Navigating over it needs consent — and the truth: the
-  // engine cannot be cancelled from here, so when it finishes it will land as
-  // its own new project. Clearing busy on the way through also stops the
-  // switched-to project rendering in the busy state (hidden corner buttons
-  // and timecodes) — the attribute survived the content swap.
-  async function confirmOverTranscription() {
+  // Leaving a transcription in flight needs no consent any more (#525): the
+  // in-progress Recents row shows where it lives, nothing is lost, and the
+  // way back is one click. What remains of the old dialog is its cleanup —
+  // the busy ATTRIBUTE must not follow us to the next view, and it is
+  // cleared directly rather than via setTranscriptBusy, which is the
+  // ENGINE's lifecycle signal (the wrapper above reads busy(false) without
+  // spans as an engine failure and would drop the in-progress row).
+  function leaveTranscriptionView() {
     const t = document.getElementById('hypertranscript');
-    if (t === null || t.getAttribute('aria-busy') !== 'true') return true;
-    const proceed = await projectConfirm(
-      'A transcription is still running. You can switch away — it will keep '
-      + 'going and open as a new project when it finishes. Switch now?',
-      'Switch', 'Stay');
-    if (proceed) {
-      // Clear the ATTRIBUTE directly, not via setTranscriptBusy: that call is
-      // the ENGINE's lifecycle signal, and the wrapper above reads
-      // busy(false)-without-spans as an engine failure — which would take the
-      // in-progress Recents row down with it. Here the engine is still very
-      // much running; only the styling must not follow us to the next view.
-      const t = document.getElementById('hypertranscript');
-      if (t !== null) t.removeAttribute('aria-busy');
-    }
-    return proceed;
+    if (t !== null && t.getAttribute('aria-busy') === 'true') t.removeAttribute('aria-busy');
+    return true;
   }
 
   async function switchToProject(id) {
@@ -2329,7 +2317,7 @@
       const t = document.getElementById('hypertranscript');
       if (t === null || t.getAttribute('aria-busy') !== 'true') return true;
     }
-    if (!(await confirmOverTranscription())) return false;
+    leaveTranscriptionView();
     const files = await readProjectFiles(id);
     if (files === null) return false;
     await flushPendingDraft();

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2218,7 +2218,15 @@
    * birth (hyperaudioInit); busy(false) with no timed spans in the transcript
    * is a failure or cancellation, and the row leaves with the engine.
    * ----------------------------------------------------------------------- */
-  let pendingTranscription = null; // { name, loaderHtml }
+  let pendingTranscription = null; // { name, loaderHtml } — the row and the view
+  // The transcription's IDENTITY (file, URL marker, player src) lives longer
+  // than the row: Parakeet's worker can report a phantom error (#529) — which
+  // takes the row down, correctly, since the engine SAYS it died — and then
+  // recover and complete anyway. If the identity died with the row, that
+  // recovered birth stole the name, media and video of whatever project the
+  // user was viewing. The identity survives until a birth consumes it, a new
+  // transcription replaces it, or a user-initiated import clears it.
+  let pendingIdentity = null; // { file, fromUrl, playerSrc }
 
   function pendingTranscriptionInfo() {
     return pendingTranscription === null ? null : { name: pendingTranscription.name };
@@ -2251,9 +2259,8 @@
             // after the OTHER file and, worse, paired the transcript with the
             // other project's media. Captured here, restored at the birth.
             const player = document.getElementById('hyperplayer');
-            pendingTranscription = {
-              name: mediaDisplayName(),
-              loaderHtml: t.innerHTML,
+            pendingTranscription = { name: mediaDisplayName(), loaderHtml: t.innerHTML };
+            pendingIdentity = {
               file: session.mediaFile,
               fromUrl: session.mediaFileFromUrl,
               playerSrc: player !== null ? player.src : '',
@@ -2283,19 +2290,35 @@
   // Registered at module load, BEFORE wireCapture registers onNewTranscript —
   // so the pending identity is restored before the birth gathers it.
   document.addEventListener('hyperaudioInit', () => {
-    if (pendingTranscription !== null) {
-      session.mediaFile = pendingTranscription.file;
-      session.mediaFileFromUrl = pendingTranscription.fromUrl;
+    if (pendingIdentity !== null) {
+      session.mediaFile = pendingIdentity.file;
+      session.mediaFileFromUrl = pendingIdentity.fromUrl;
       const player = document.getElementById('hyperplayer');
-      if (player !== null && pendingTranscription.playerSrc
-          && player.src !== pendingTranscription.playerSrc) {
-        player.src = pendingTranscription.playerSrc; // the transcription's own media back on the player
+      if (player !== null && pendingIdentity.playerSrc
+          && player.src !== pendingIdentity.playerSrc) {
+        player.src = pendingIdentity.playerSrc; // the transcription's own media back on the player
       }
+      pendingIdentity = null;
+    }
+    if (pendingTranscription !== null) {
       pendingTranscription = null;
       document.documentElement.classList.remove('ha-transcribing');
       notifyLibraryChanged(false);
     }
   });
+
+  // User-initiated content imports (SRT/VTT/JSON) also dispatch
+  // hyperaudioInit; a surviving identity from an errored transcription must
+  // not hijack THEIR media. The import paths call this before dispatching.
+  function clearPendingTranscription() {
+    pendingIdentity = null;
+    if (pendingTranscription !== null) {
+      pendingTranscription = null;
+      document.documentElement.classList.remove('ha-transcribing');
+      notifyLibraryChanged(false);
+    }
+  }
+  window.clearPendingTranscription = clearPendingTranscription;
 
   // Clicking the in-progress row: hand the screen back to the transcription.
   // The current project's pending edits flush to its own draft first; the

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2245,6 +2245,11 @@
           const t = document.getElementById('hypertranscript');
           if (busy === true && t !== null) {
             pendingTranscription = { name: mediaDisplayName(), loaderHtml: t.innerHTML };
+            // ENGINE state, distinct from the transcript's aria-busy VIEW
+            // state (which switching away deliberately clears): the NEW /
+            // transcribe entry points grey on this class, so the gate holds
+            // while the engine runs in the background too.
+            document.documentElement.classList.add('ha-transcribing');
             notifyLibraryChanged(false);
           } else if (busy === false && pendingTranscription !== null) {
             // success is announced by hyperaudioInit (the birth clears the row
@@ -2252,6 +2257,7 @@
             // without a transcript — an error, and the row goes with it
             if (t === null || t.querySelector('span[data-m]') === null) {
               pendingTranscription = null;
+              document.documentElement.classList.remove('ha-transcribing');
               notifyLibraryChanged(false);
             }
           }
@@ -2264,6 +2270,7 @@
   document.addEventListener('hyperaudioInit', () => {
     if (pendingTranscription !== null) {
       pendingTranscription = null;
+      document.documentElement.classList.remove('ha-transcribing');
       notifyLibraryChanged(false);
     }
   });

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2310,7 +2310,18 @@
   // spans as an engine failure and would drop the in-progress row).
   function leaveTranscriptionView() {
     const t = document.getElementById('hypertranscript');
-    if (t !== null && t.getAttribute('aria-busy') === 'true') t.removeAttribute('aria-busy');
+    if (t !== null && t.getAttribute('aria-busy') === 'true') {
+      // Refresh the pending snapshot on the way out: it was captured at
+      // busy(true) — the 'Preparing model' stage — so switching back showed
+      // that stale first message for a beat until the engine's next interval
+      // tick repainted. Departure-time capture means the return shows the
+      // message (and elapsed time) as of when you left, corrected within a
+      // second by the engine's own clock.
+      if (pendingTranscription !== null && t.querySelector('.transcribing-msg') !== null) {
+        pendingTranscription.loaderHtml = t.innerHTML;
+      }
+      t.removeAttribute('aria-busy');
+    }
     return true;
   }
 

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2244,7 +2244,20 @@
         try {
           const t = document.getElementById('hypertranscript');
           if (busy === true && t !== null) {
-            pendingTranscription = { name: mediaDisplayName(), loaderHtml: t.innerHTML };
+            // Carry the transcription's own IDENTITY, not just its loader:
+            // switching away replaces session.mediaFile and the player src
+            // with the other project's, and the birth reads both — so a
+            // completion while viewing another project named the new project
+            // after the OTHER file and, worse, paired the transcript with the
+            // other project's media. Captured here, restored at the birth.
+            const player = document.getElementById('hyperplayer');
+            pendingTranscription = {
+              name: mediaDisplayName(),
+              loaderHtml: t.innerHTML,
+              file: session.mediaFile,
+              fromUrl: session.mediaFileFromUrl,
+              playerSrc: player !== null ? player.src : '',
+            };
             // ENGINE state, distinct from the transcript's aria-busy VIEW
             // state (which switching away deliberately clears): the NEW /
             // transcribe entry points grey on this class, so the gate holds
@@ -2267,8 +2280,17 @@
     }
   }
 
+  // Registered at module load, BEFORE wireCapture registers onNewTranscript —
+  // so the pending identity is restored before the birth gathers it.
   document.addEventListener('hyperaudioInit', () => {
     if (pendingTranscription !== null) {
+      session.mediaFile = pendingTranscription.file;
+      session.mediaFileFromUrl = pendingTranscription.fromUrl;
+      const player = document.getElementById('hyperplayer');
+      if (player !== null && pendingTranscription.playerSrc
+          && player.src !== pendingTranscription.playerSrc) {
+        player.src = pendingTranscription.playerSrc; // the transcription's own media back on the player
+      }
       pendingTranscription = null;
       document.documentElement.classList.remove('ha-transcribing');
       notifyLibraryChanged(false);

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2314,7 +2314,13 @@
     updateSaveIndicator();
     suppressCapture = true;
     try {
-      t.innerHTML = pendingTranscription.loaderHtml;
+      t.textContent = '';
+      if (pendingTranscription.fragment) {
+        t.appendChild(pendingTranscription.fragment); // the SAME nodes, state intact
+        pendingTranscription.fragment = null;
+      } else {
+        t.innerHTML = pendingTranscription.loaderHtml;
+      }
       t.setAttribute('aria-busy', 'true');
     } finally {
       suppressCapture = false;
@@ -2333,14 +2339,16 @@
   function leaveTranscriptionView() {
     const t = document.getElementById('hypertranscript');
     if (t !== null && t.getAttribute('aria-busy') === 'true') {
-      // Refresh the pending snapshot on the way out: it was captured at
-      // busy(true) — the 'Preparing model' stage — so switching back showed
-      // that stale first message for a beat until the engine's next interval
-      // tick repainted. Departure-time capture means the return shows the
-      // message (and elapsed time) as of when you left, corrected within a
-      // second by the engine's own clock.
+      // Move the loader's LIVE NODES aside rather than snapshotting HTML: a
+      // string copy goes stale the moment the engine repaints (the
+      // 'Preparing model' flash was exactly that), and element identity is
+      // what the engines' null-guarded '.transcribing-msg' lookups key on —
+      // the same nodes coming back means whatever state they carried comes
+      // back with them, with nothing to age.
       if (pendingTranscription !== null && t.querySelector('.transcribing-msg') !== null) {
-        pendingTranscription.loaderHtml = t.innerHTML;
+        const fragment = document.createDocumentFragment();
+        while (t.firstChild) fragment.appendChild(t.firstChild);
+        pendingTranscription.fragment = fragment;
       }
       t.removeAttribute('aria-busy');
     }


### PR DESCRIPTION
Fixes #525

The transcription lifecycle becomes visible, navigable and honest — an arc of nine live-found issues, each verified failing before its fix — plus caption-sync symmetry and a playbar truth fix.

## A running transcription is a first-class citizen (#525)

- **An in-progress row appears in Recents the moment an engine starts** — the media's filename, flush with the other rows, a spinner in the kebab's slot. It shows as selected while its loader owns the screen; selection returns to real projects when you navigate away. Virtual (in-memory): a reload kills the engine anyway, so nothing persists to get stuck.
- **Clicking the row hands the screen back to the live transcription** — the loader's actual DOM nodes move aside and return (element identity preserved, so the engines' progress painting resumes exactly where it was; the earlier HTML-snapshot design had an unfixable staleness class), and the player carries the transcription's own media.
- **Switching back to your own project mid-transcription works** (was a silent no-op — with one project you were stuck at the loader), switching away needs no dialog, and the busy styling no longer follows you.
- **A completed transcription keeps its own identity.** The birth reads session media and the player src, which navigating had replaced — a transcript of file X could be silently saved with file Y's name AND media. Identity (file, URL marker, player src) is captured at start and restored at the birth — and it survives Parakeet's phantom errors (#529): the error signal takes the row down, but the identity lives until a birth consumes it, a new transcription replaces it, or a user-initiated import explicitly clears it. Without that, the recovered completion stole the identity of whatever project was on screen.
- **One transcription at a time**: NEW and Upload & Transcribe grey out while an engine runs — keyed on engine state, not view state, so the gate holds from any project. Batch transcription is #528.
- **Retry works**: engine file inputs clear on click, so re-picking the same file after an interruption fires a change event again.

## Caption sync symmetry

Regenerate turns sync back on until the next caption edit — completing the rule: captions follow the transcript exactly while they are untouched. (The 1.2.4 half fixed inheritance at birth; this fixes the deliberate way back.)

## The play button tells the truth

Swapping the player's src — every project switch — stops playback without a `pause` event; the playbar synced only on play/pause/ended, so switching away from a playing video showed the pause button over a stopped video. One `emptied` listener covers every src-swap path.

## QA beyond the suite

- Full suite 178 green on Chromium; WebKit engine pass 76/78 with two honest capability skips (the bench's own-project tests need OPFS, which Playwright's WebKit lacks — #510's finding, now encoded as the probe-skip that discussion prescribed).
- The soak suite (parallel session's WIP) fails at ~196 leaked listeners per caption toggle — bisected to **pre-existing at v1.2.3, rate identical**, so it is that hunt's quarry, not this release's regression.
- One test de-raced (#504's in-flight open used an instantly-failing dummy as its "running" open).
