### PR TITLE
Version 1.3.0

### DIFF
--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1442,6 +1442,60 @@ test('a transcription appears in Recents while it runs, and resolves on completi
   expect(born.playerSrc).toBe(engineSrc);
 });
 
+test('a transcription in flight does not play the previous project\'s captions (#525)', async ({ page }, testInfo) => {
+  // The player gets the transcription's media at engine start, but the
+  // caption <track> kept the previous project's vtt — playing the
+  // transcribing video showed the old captions. Both doors into the pending
+  // view must clear the track; the birth's own caption pass restores it.
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs);
+  await awaitLibraryEntry(page);
+  const homeId = await page.evaluate(() => window.HyperaudioSave.library.currentId());
+  // WebKit's automatic track selection may flip a fresh subtitles track back
+  // to 'showing' from inside the browser (no JS setter involved), so mode is
+  // not assertable — what matters is that the track holds NO cue data.
+  const trackHasVtt = () => page.evaluate(() => {
+    const track = document.getElementById('hyperplayer-vtt');
+    return track !== null && track.src.startsWith('data:');
+  });
+  expect(await trackHasVtt()).toBe(true); // the fixture's captions are on
+
+  // engine start: its own media on the player, loader, busy(true)
+  const newWav = testInfo.outputPath('captionless-recording.wav');
+  (await import('node:fs')).writeFileSync(newWav, ladderWav(1));
+  await page.setInputFiles('#file-input', newWav);
+  await page.evaluate(() => {
+    const player = document.getElementById('hyperplayer');
+    player.src = URL.createObjectURL(new Blob([new Uint8Array(4)], { type: 'audio/wav' }));
+    document.querySelector('#hypertranscript').innerHTML =
+      '<div class="vertically-centre"><center><span class="transcribing-msg">Transcribing…</span></center></div>';
+    setTranscriptBusy(true);
+  });
+  expect(await trackHasVtt()).toBe(false); // door 1: engine start clears the track
+
+  // away to the project (its captions return), then back to the pending view
+  await page.evaluate((id) => window.HyperaudioSave.library.open(id), homeId);
+  await expect(page.locator('#hypertranscript')).toContainText('Benvenuti');
+  expect(await trackHasVtt()).toBe(true);
+  await page.locator('.recents-transcribing-item').click();
+  await expect(page.locator('#hypertranscript')).toContainText('Transcribing…');
+  expect(await trackHasVtt()).toBe(false); // door 2: the way back clears it too
+
+  // completion: the birth generates the NEW transcript's captions, exactly
+  // as the engines do (init, then the generate dispatch)
+  await page.evaluate(() => {
+    document.querySelector('#hypertranscript').innerHTML =
+      '<article><section><p><span data-m="0" data-d="500">DONE </span></p></section></article>';
+    setTranscriptBusy(false);
+    document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+    document.dispatchEvent(new CustomEvent('hyperaudioGenerateCaptionsFromTranscript'));
+  });
+  await pollPage(page, async () => {
+    const track = document.getElementById('hyperplayer-vtt');
+    return track !== null && track.src.startsWith('data:');
+  });
+});
+
 test('a phantom engine error does not let the birth steal another project\'s identity (#529 × #525)', async ({ page }, testInfo) => {
   // The measured Parakeet failure mode: handleError fires (error markup +
   // busy(false)) — then the worker recovers and completes anyway. The row

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -914,6 +914,46 @@ test('undo back to the save clears the dot even after deferred caption regen (#5
   await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/, { timeout: 6000 });
 });
 
+test('multi-step undo back to the save clears the dot promptly (sync-on)', async ({ page }, testInfo) => {
+  // Two typed runs, each folded by the local pass, then undo both. At the
+  // final undo the transcript matches the save but the caption track still
+  // holds the INTERMEDIATE vtt (undo #1's post-restore refresh built it;
+  // undo #2's regen is deferred). With sync on the vtt is a pure derivative
+  // of the transcript, so the signature must not compare it — otherwise the
+  // dot lingers ~3.4s until the recheck. Prompt means within 1s, well under
+  // that recheck window, so this test has teeth against the race.
+  const dialogs = [];
+  await openFixture(page, testInfo, dialogs, (project) => {
+    project.options.captions.updateFromTranscript = true;
+  });
+  await awaitLibraryEntry(page);
+
+  await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    t.focus();
+    const span = t.querySelector('span[data-m]:not(.speaker)');
+    const sel = window.getSelection();
+    const r = document.createRange();
+    r.setStart(span.firstChild, 2);
+    r.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(r);
+  });
+  await page.keyboard.press('Control+s');
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+
+  await page.keyboard.type('XX yy');
+  await page.waitForTimeout(1700); // run 1 folds into its history entry
+  await page.keyboard.type('zz ww');
+  await page.waitForTimeout(1700); // run 2 folds
+
+  await page.keyboard.press('Meta+z');
+  await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/); // one run still applied
+  await page.waitForTimeout(500);
+  await page.keyboard.press('Meta+z');
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/, { timeout: 1000 });
+});
+
 test('undo does not clear the dot while a non-transcript edit is pending', async ({ page }, testInfo) => {
   const dialogs = [];
   await openFixture(page, testInfo, dialogs);

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -875,6 +875,45 @@ test('undo back to the last save clears the dirty dot and retires the draft', as
   await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
 });
 
+test('undo back to the save clears the dot even after deferred caption regen (#517 perf)', async ({ page }, testInfo) => {
+  // The perf rework defers caption regeneration to a ~3s idle queue. Type,
+  // pause past that window (captions now reflect the edit), then undo: the
+  // transcript matches the save but the TRACK catches up only in the forced
+  // post-restore refresh — which runs after the restored signal. The
+  // signature comparison must happen after that refresh, or the dot stays.
+  const dialogs = [];
+  // caption sync ON — the fixture default is curated captions, whose track
+  // never changes and cannot exhibit the drift under test
+  await openFixture(page, testInfo, dialogs, (project) => {
+    project.options.captions.updateFromTranscript = true;
+  });
+  await awaitLibraryEntry(page);
+
+  await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    t.focus();
+    const span = t.querySelector('span[data-m]:not(.speaker)');
+    const sel = window.getSelection();
+    const r = document.createRange();
+    r.setStart(span.firstChild, 2);
+    r.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(r);
+  });
+  // A sync-on save stores MACHINE-generated captions (the fixture's stored
+  // vtt is hand-written and regeneration can never reproduce it) — save
+  // first, as the scenario implies, so the signature baseline is honest.
+  await page.keyboard.press('Control+s');
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/);
+
+  await page.keyboard.type('ZZ');
+  await expect(page.locator('#project-save-btn')).toHaveClass(/dirty/);
+  await page.waitForTimeout(3800); // past the idle reconciliation window
+
+  await page.keyboard.press('Meta+z');
+  await expect(page.locator('#project-save-btn')).not.toHaveClass(/dirty/, { timeout: 6000 });
+});
+
 test('undo does not clear the dot while a non-transcript edit is pending', async ({ page }, testInfo) => {
   const dialogs = [];
   await openFixture(page, testInfo, dialogs);

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1319,6 +1319,9 @@ test('switching back to your project mid-transcription rescues it from the loade
   await expect(page.locator('#hypertranscript')).toContainText('Benvenuti'); // the project is back
   expect(await page.evaluate(() =>
     document.querySelector('#hypertranscript').getAttribute('aria-busy'))).toBeNull(); // busy cleared
+  // ...and EDITABLE: busy(true) turned contenteditable off, and until that
+  // was undone here every transcript opened mid-transcription had no caret
+  await expect(page.locator('#hypertranscript')).toHaveAttribute('contenteditable', 'true');
 });
 
 
@@ -1397,6 +1400,9 @@ test('a transcription appears in Recents while it runs, and resolves on completi
   await row.locator('.recents-transcribing-item').click();
   await expect(page.locator('#hypertranscript')).toContainText('Transcribing… (0m 42s)');
   await expect(row.locator('.recents-transcribing-item')).toHaveClass(/active/); // selected again on return
+  // the loader view is not for typing in — the leave path restored
+  // contenteditable for the project, the way back must take it away again
+  await expect(page.locator('#hypertranscript')).toHaveAttribute('contenteditable', 'false');
   // and the player carries the TRANSCRIPTION's media, not the previous project's
   expect(await page.evaluate(() => document.getElementById('hyperplayer').src)).toBe(engineSrc);
   expect(await page.evaluate(() =>

--- a/__TEST__/e2e/real-project-performance.spec.mjs
+++ b/__TEST__/e2e/real-project-performance.spec.mjs
@@ -1,0 +1,157 @@
+// Optional performance/regression probe driven by a real .hyperaudio project.
+// Usage:
+//   HLE_REAL_PROJECT='/path/to/project.hyperaudio' \
+//     npx playwright test __TEST__/e2e/real-project-performance.spec.mjs
+//
+// By default the test rebuilds a transcript-only container from the real
+// project, avoiding a large media copy while preserving every real word,
+// paragraph, timing, style and option. Set HLE_REAL_PROJECT_FULL=1 to make the
+// browser open the original archive including its media.
+import { test, expect } from '@playwright/test';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+
+const require = createRequire(import.meta.url);
+const JSZip = require('jszip');
+const save = require('../../js/hyperaudio-save.js');
+const projectPath = process.env.HLE_REAL_PROJECT || '';
+
+async function browserFixture(testInfo) {
+  if (process.env.HLE_REAL_PROJECT_FULL === '1') return projectPath;
+  const source = await JSZip.loadAsync(fs.readFileSync(projectPath));
+  const project = JSON.parse(await source.file('hyperaudio.json').async('string'));
+  project.media = {
+    kind: 'none', path: null, url: null, filename: '', mimeType: '',
+    durationSeconds: 0, sizeBytes: 0,
+  };
+  const fixture = await save.zipProject({
+    json: save.serializeProjectJson(project),
+    html: await source.file('transcript.html').async('string'),
+    originalJson: source.file('transcript.original.json')
+      ? await source.file('transcript.original.json').async('string') : null,
+    captionsVtt: source.file('captions.vtt')
+      ? await source.file('captions.vtt').async('string') : '',
+  }, JSZip, 'nodebuffer');
+  const fixturePath = testInfo.outputPath('real-transcript.hyperaudio');
+  fs.writeFileSync(fixturePath, fixture);
+  return fixturePath;
+}
+
+test('real project preserves editing, local maintenance, undo and redo', async ({ page }, testInfo) => {
+  test.skip(!projectPath || !fs.existsSync(projectPath),
+    'Set HLE_REAL_PROJECT to a readable .hyperaudio file');
+  test.setTimeout(240000);
+
+  const source = await JSZip.loadAsync(fs.readFileSync(projectPath));
+  const project = JSON.parse(await source.file('hyperaudio.json').async('string'));
+  const expectedWords = project.transcript.words.length;
+  const expectedParagraphs = project.transcript.paragraphs.length;
+
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript span[data-m]');
+  await page.setInputFiles('#project-open-input', await browserFixture(testInfo));
+  await expect.poll(() => page.locator('#hypertranscript span[data-m]:not(.speaker)').count(), {
+    timeout: 60000,
+  }).toBe(expectedWords);
+
+  await page.evaluate(({ expectedWords, expectedParagraphs }) => {
+    window.hyperaudioFlushTranscriptMaintenance('real-project-ready', {
+      force: true,
+      global: true,
+    });
+    const transcript = document.getElementById('hypertranscript');
+    const paragraphs = transcript.querySelectorAll('p');
+    const paragraph = paragraphs[Math.floor(paragraphs.length / 2)];
+    const word = paragraph.querySelector('span[data-m]:not(.speaker)');
+    const wordStart = word.getAttribute('data-m');
+    const original = word.textContent;
+    transcript.focus();
+    const range = document.createRange();
+    range.setStart(word.firstChild, Math.min(1, word.firstChild.length));
+    range.collapse(true);
+    const selection = getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    const historyBefore = window.transcriptHistory.inspect();
+    let resolveInput;
+    const inputDone = new Promise((resolve) => { resolveInput = resolve; });
+    // Register after the application listeners and on their same bubbling
+    // target, so the timestamp includes history's post-edit snapshot.
+    document.addEventListener('input', () => resolveInput(performance.now()), { once: true });
+    window.__realProjectProbe = {
+      expectedWords,
+      expectedParagraphs,
+      wordStart,
+      original,
+      historyBefore,
+      maintenanceBefore: window.hyperaudioInspectTranscriptMaintenance(),
+      inputDone,
+      keyStarted: performance.now(),
+    };
+  }, { expectedWords, expectedParagraphs });
+
+  // Use the browser input pipeline, not execCommand: the optimization under
+  // test starts at beforeinput, exactly as it does for a real user key.
+  await page.keyboard.insertText('x');
+
+  const report = await page.evaluate(async () => {
+    const probe = window.__realProjectProbe;
+    const inputAt = await probe.inputDone;
+    const transcript = document.getElementById('hypertranscript');
+    const keyMs = inputAt - probe.keyStarted;
+    const maintenanceAfterKey = window.hyperaudioInspectTranscriptMaintenance();
+
+    const maintenanceStarted = performance.now();
+    window.hyperaudioFlushTranscriptMaintenance('real-project-maintenance');
+    const maintenanceMs = performance.now() - maintenanceStarted;
+    const maintenance = window.hyperaudioInspectTranscriptMaintenance();
+
+    const undoStarted = performance.now();
+    const undone = window.transcriptHistory.undo();
+    const undoMs = performance.now() - undoStarted;
+    const liveWord = () => transcript.querySelector(
+      `span[data-m="${CSS.escape(probe.wordStart)}"]:not(.speaker)`);
+    const afterUndo = liveWord().textContent;
+    const redone = window.transcriptHistory.redo();
+    const afterRedo = liveWord().textContent;
+    const history = window.transcriptHistory.inspect();
+
+    return {
+      expectedWords: probe.expectedWords,
+      actualWords: transcript.querySelectorAll('span[data-m]:not(.speaker)').length,
+      expectedParagraphs: probe.expectedParagraphs,
+      actualParagraphs: transcript.querySelectorAll('p').length,
+      original: probe.original,
+      afterUndo,
+      afterRedo,
+      keyMs: +keyMs.toFixed(1),
+      maintenanceMs: +maintenanceMs.toFixed(1),
+      undoMs: +undoMs.toFixed(1),
+      maintenanceMode: maintenance.lastMode,
+      maintenanceScopes: maintenance.lastScopeCount,
+      maintenanceBefore: probe.maintenanceBefore,
+      maintenanceAfterKey,
+      history,
+      fullSnapshots: history.fullSnapshotCount - probe.historyBefore.fullSnapshotCount,
+      reusedSnapshots: history.reusedSnapshotCount - probe.historyBefore.reusedSnapshotCount,
+      undone,
+      redone,
+    };
+  });
+
+  console.log('REAL_PROJECT_PERFORMANCE ' + JSON.stringify(report));
+  await testInfo.attach('real-project-performance.json', {
+    body: Buffer.from(JSON.stringify(report, null, 2)),
+    contentType: 'application/json',
+  });
+
+  expect(report.actualWords).toBe(report.expectedWords);
+  expect(report.actualParagraphs).toBe(report.expectedParagraphs);
+  expect(report.maintenanceMode).toBe('local');
+  expect(report.maintenanceScopes).toBe(1);
+  expect(report.undone).toBe(true);
+  expect(report.redone).toBe(true);
+  expect(report.afterUndo).toBe(report.original);
+  expect(report.afterRedo).not.toBe(report.original);
+  if ('reusedSnapshotCount' in report.history) expect(report.reusedSnapshots).toBeGreaterThan(0);
+});

--- a/__TEST__/e2e/real-project-performance.spec.mjs
+++ b/__TEST__/e2e/real-project-performance.spec.mjs
@@ -133,7 +133,8 @@ test('real project preserves editing, local maintenance, undo and redo', async (
       maintenanceAfterKey,
       history,
       fullSnapshots: history.fullSnapshotCount - probe.historyBefore.fullSnapshotCount,
-      reusedSnapshots: history.reusedSnapshotCount - probe.historyBefore.reusedSnapshotCount,
+      paragraphSnapshots: (history.paragraphSnapshotCount ?? history.reusedSnapshotCount)
+        - (probe.historyBefore.paragraphSnapshotCount ?? probe.historyBefore.reusedSnapshotCount),
       undone,
       redone,
     };
@@ -153,5 +154,11 @@ test('real project preserves editing, local maintenance, undo and redo', async (
   expect(report.redone).toBe(true);
   expect(report.afterUndo).toBe(report.original);
   expect(report.afterRedo).not.toBe(report.original);
-  if ('reusedSnapshotCount' in report.history) expect(report.reusedSnapshots).toBeGreaterThan(0);
+  if ('paragraphSnapshotCount' in report.history || 'reusedSnapshotCount' in report.history) {
+    expect(report.paragraphSnapshots).toBeGreaterThan(0);
+  }
+  if ('localEntries' in report.history) {
+    expect(report.fullSnapshots).toBe(0);
+    expect(report.history.localEntries).toBeGreaterThan(0);
+  }
 });

--- a/__TEST__/e2e/span-merge.spec.mjs
+++ b/__TEST__/e2e/span-merge.spec.mjs
@@ -541,3 +541,55 @@ test('a caret legitimately at a paragraph END is not pushed into the next (#530 
   });
   expect(after.paraIndex).toBe(after.splitAt - 1); // stays at the END of the paragraph above
 });
+
+// #511 on the PARAGRAPH-LOCAL pass (#517 perf): the scoped pass hands a <p>
+// to normalizeTranscriptSpans, whose focus check compared against that root —
+// focus sits on the contenteditable host, so the caret guard silently never
+// ran on local passes. A fresh page's FIRST pass is always global (pendingGlobal
+// starts true), which is why every earlier test missed it: the pass must be
+// primed once so the next one is local.
+test('the caret survives the PRIMED paragraph-local pass (#511 × #517)', async ({ page }) => {
+  // prime: one edit + pass, so the next pass takes the local path
+  await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    t.focus();
+    const span = [...t.querySelectorAll('span[data-m]')].find((s) => s.textContent.trim() === 'audio');
+    const sel = window.getSelection();
+    const r = document.createRange();
+    r.setStart(span.firstChild, 1);
+    r.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(r);
+  });
+  await page.keyboard.type('P');
+  await page.keyboard.press('Shift');
+  await page.waitForTimeout(1600); // first pass: global, primes pendingGlobal=false
+
+  // now the #511 scenario again — this pass is paragraph-local
+  await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    const span = [...t.querySelectorAll('span[data-m]')].find((s) => s.textContent.trim() === 'makes');
+    const sel = window.getSelection();
+    const r = document.createRange();
+    r.setStart(span.firstChild, span.firstChild.nodeValue.length);
+    r.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(r);
+  });
+  await page.keyboard.type('scooby dooby doo ');
+  await page.keyboard.press('Shift');
+  await page.waitForTimeout(1600);
+
+  const r = await page.evaluate(() => {
+    const sel = window.getSelection();
+    return {
+      anchorText: sel.anchorNode && sel.anchorNode.nodeValue,
+      atEnd: sel.anchorNode && sel.anchorOffset === sel.anchorNode.nodeValue.length,
+      spans: [...document.querySelectorAll('#hypertranscript span[data-m]')]
+        .map((s) => s.textContent.trim()).filter((t) => /^(scooby|dooby|doo)$/.test(t)),
+    };
+  });
+  expect(r.spans).toEqual(['scooby', 'dooby', 'doo']); // the local split still works
+  expect(r.anchorText).toBe('doo ');
+  expect(r.atEnd).toBe(true);
+});

--- a/__TEST__/e2e/span-merge.spec.mjs
+++ b/__TEST__/e2e/span-merge.spec.mjs
@@ -444,3 +444,100 @@ test('the caret survives a pass where only the nbsp rewrite fires (#511)', async
   expect(r.anchorText).toContain('maX'); // still in the edited word's node
   expect(r.offset).toBe(3); // right after the typed X
 });
+
+// #530 — after Enter mid-paragraph, the debounced sanitise pass sometimes
+// yanked the caret from the start of the new paragraph back to the end of the
+// previous one: both positions have the SAME absolute character offset (the
+// split leaves the blocks adjacent, so Range.toString() emits nothing between
+// them), and resolveCharOffset greedily took the earlier side. The save now
+// records the caret's containing block and restore honours it — in both
+// directions.
+test('the caret stays at the start of the new paragraph after Enter + pause (#530)', async ({ page }) => {
+  await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    t.focus();
+    const span = [...t.querySelectorAll('span[data-m]')].find((s) => s.textContent.trim() === 'makes');
+    const sel = window.getSelection();
+    const r = document.createRange();
+    r.setStart(span.firstChild, 2); // MID-TEXT: the split leaves 'ma' | 'kes'
+    r.collapse(true);               // hard-adjacent across the block boundary
+    sel.removeAllRanges();
+    sel.addRange(r);
+  });
+  const parasBefore = await page.locator('#hypertranscript p').count();
+  await page.keyboard.press('Enter');
+  await page.waitForFunction((n) =>
+    document.querySelectorAll('#hypertranscript p').length === n + 1, parasBefore);
+
+  // give the debounced pass something to normalise WITHOUT touching the caret
+  // (typing would move it off the boundary — the repro requires Enter, pause)
+  await page.evaluate(() => {
+    const spans = document.querySelectorAll('#hypertranscript span[data-m]');
+    spans[0].textContent = spans[0].textContent.replace(' ', ' ');
+  });
+  await page.keyboard.press('Shift'); // a keyup, to arm the sanitise timer
+  await page.waitForTimeout(1600);
+
+  const after = await page.evaluate(() => {
+    const sel = window.getSelection();
+    const paras = [...document.querySelectorAll('#hypertranscript p')];
+    const el = sel.anchorNode.nodeType === Node.ELEMENT_NODE
+      ? sel.anchorNode : sel.anchorNode.parentElement;
+    return {
+      paraIndex: paras.indexOf(el.closest('p')),
+      splitAt: paras.findIndex((p) => p.textContent.trim().startsWith('kes')),
+    };
+  });
+  expect(after.paraIndex).toBe(after.splitAt); // the NEW paragraph, not the one above
+});
+
+test('a caret legitimately at a paragraph END is not pushed into the next (#530 guard)', async ({ page }) => {
+  await page.evaluate(() => {
+    const t = document.querySelector('#hypertranscript');
+    t.focus();
+    const span = [...t.querySelectorAll('span[data-m]')].find((s) => s.textContent.trim() === 'makes');
+    const sel = window.getSelection();
+    const r = document.createRange();
+    r.setStart(span.firstChild, 2); // MID-TEXT: the split leaves 'ma' | 'kes'
+    r.collapse(true);               // hard-adjacent across the block boundary
+    sel.removeAllRanges();
+    sel.addRange(r);
+  });
+  const parasBefore = await page.locator('#hypertranscript p').count();
+  await page.keyboard.press('Enter'); // adjacent blocks: the ambiguous DOM shape
+  await page.waitForFunction((n) =>
+    document.querySelectorAll('#hypertranscript p').length === n + 1, parasBefore);
+
+  // NOW place the caret at the END of the first paragraph — the same absolute
+  // offset as the new paragraph's start; the block record must keep it there
+  await page.evaluate(() => {
+    const paras = [...document.querySelectorAll('#hypertranscript p')];
+    const idx = paras.findIndex((p) => p.textContent.trim().startsWith('kes'));
+    const prev = paras[idx - 1];
+    const walker = document.createTreeWalker(prev, NodeFilter.SHOW_TEXT);
+    let lastText = null; let n;
+    while ((n = walker.nextNode())) lastText = n;
+    const sel = window.getSelection();
+    const r = document.createRange();
+    r.setStart(lastText, lastText.nodeValue.length);
+    r.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(r);
+    const spans = document.querySelectorAll('#hypertranscript span[data-m]');
+    spans[1].textContent = spans[1].textContent.replace(' ', ' ');
+  });
+  await page.keyboard.press('Shift');
+  await page.waitForTimeout(1600);
+
+  const after = await page.evaluate(() => {
+    const sel = window.getSelection();
+    const paras = [...document.querySelectorAll('#hypertranscript p')];
+    const el = sel.anchorNode.nodeType === Node.ELEMENT_NODE
+      ? sel.anchorNode : sel.anchorNode.parentElement;
+    return {
+      paraIndex: paras.indexOf(el.closest('p')),
+      splitAt: paras.findIndex((p) => p.textContent.trim().startsWith('kes')),
+    };
+  });
+  expect(after.paraIndex).toBe(after.splitAt - 1); // stays at the END of the paragraph above
+});

--- a/__TEST__/e2e/transcript-gateway.spec.mjs
+++ b/__TEST__/e2e/transcript-gateway.spec.mjs
@@ -50,7 +50,7 @@ test('outer transaction owns nesting, returns values, and clears state after err
   });
 });
 
-test('blur normalization and debounced sanitise cross the gateway', async ({ page }) => {
+test('blur flushes queued sanitise through the gateway without a delayed duplicate', async ({ page }) => {
   const origins = await page.evaluate(async () => {
     const seen = [];
     const off = transcriptGateway.onBeforeMutate((tx) => seen.push(tx.origin));
@@ -65,8 +65,7 @@ test('blur normalization and debounced sanitise cross the gateway', async ({ pag
     return seen;
   });
 
-  expect(origins).toContain('normalize-blur');
-  expect(origins).toContain('sanitise');
+  expect(origins.filter((origin) => /sanitise/.test(origin))).toEqual(['sanitise-blur']);
 });
 
 test('Replace One, Replace All, and strike have explicit transaction origins', async ({ page }) => {

--- a/__TEST__/e2e/transcript-history.spec.mjs
+++ b/__TEST__/e2e/transcript-history.spec.mjs
@@ -23,6 +23,28 @@ test('native typing coalesces and structural input forces a boundary', async ({ 
   expect(await page.evaluate(() => transcriptHistory.inspect())).toMatchObject({ length: 3, position: 2 });
 });
 
+test('real keyboard input reuses the current before snapshot and remains undoable', async ({ page }) => {
+  const before = await page.evaluate(() => {
+    const root = document.getElementById('hypertranscript');
+    const text = root.querySelector('span[data-m]:not(.speaker)').firstChild;
+    root.focus();
+    getSelection().setBaseAndExtent(text, 1, text, 1);
+    return {
+      text: text.nodeValue,
+      history: transcriptHistory.inspect(),
+    };
+  });
+
+  await page.keyboard.insertText('x');
+  const after = await page.evaluate(() => transcriptHistory.inspect());
+  expect(after.reusedSnapshotCount).toBe(before.history.reusedSnapshotCount + 1);
+  expect(after.fullSnapshotCount).toBe(before.history.fullSnapshotCount + 1);
+  expect(await page.evaluate(() => transcriptHistory.undo())).toBe(true);
+  expect(await page.locator('#hypertranscript span[data-m]:not(.speaker)').first().textContent())
+    .toBe(before.text);
+  expect(await page.evaluate(() => transcriptHistory.redo())).toBe(true);
+});
+
 test('semantic normalization folds into current without clearing redo', async ({ page }) => {
   const result = await page.evaluate(() => {
     let word = document.querySelector('#hypertranscript span[data-m]:not(.speaker)');

--- a/__TEST__/e2e/transcript-history.spec.mjs
+++ b/__TEST__/e2e/transcript-history.spec.mjs
@@ -37,12 +37,84 @@ test('real keyboard input reuses the current before snapshot and remains undoabl
 
   await page.keyboard.insertText('x');
   const after = await page.evaluate(() => transcriptHistory.inspect());
-  expect(after.reusedSnapshotCount).toBe(before.history.reusedSnapshotCount + 1);
-  expect(after.fullSnapshotCount).toBe(before.history.fullSnapshotCount + 1);
+  expect(after.paragraphSnapshotCount).toBe(before.history.paragraphSnapshotCount + 1);
+  expect(after.fullSnapshotCount).toBe(before.history.fullSnapshotCount);
+  expect(after).toMatchObject({ localEntries: 1, fullEntries: 1 });
   expect(await page.evaluate(() => transcriptHistory.undo())).toBe(true);
   expect(await page.locator('#hypertranscript span[data-m]:not(.speaker)').first().textContent())
     .toBe(before.text);
   expect(await page.evaluate(() => transcriptHistory.redo())).toBe(true);
+});
+
+test('local and full entries undo in order without losing either state', async ({ page }) => {
+  const original = await page.evaluate(() => {
+    const root = document.getElementById('hypertranscript');
+    const words = root.querySelectorAll('span[data-m]:not(.speaker)');
+    root.focus();
+    getSelection().setBaseAndExtent(words[0].firstChild, 1, words[0].firstChild, 1);
+    return {
+      text: words[0].textContent,
+      duration: words[1].getAttribute('data-d'),
+    };
+  });
+  await page.keyboard.insertText('A');
+  await page.evaluate(() => {
+    const word = document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)')[1];
+    transcriptGateway.mutate(() => word.setAttribute('data-d', '9876'), { origin: 'mixed-full' });
+    const first = document.querySelector('#hypertranscript span[data-m]:not(.speaker)').firstChild;
+    getSelection().setBaseAndExtent(first, 2, first, 2);
+  });
+  await page.keyboard.insertText('B');
+
+  expect(await page.evaluate(() => transcriptHistory.inspect())).toMatchObject({
+    length: 4, localEntries: 2, fullEntries: 2,
+  });
+  await page.evaluate(() => transcriptHistory.undo());
+  expect(await page.evaluate(() => ({
+    text: document.querySelector('#hypertranscript span[data-m]:not(.speaker)').textContent,
+    duration: document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)')[1]
+      .getAttribute('data-d'),
+  }))).toEqual({
+    text: original.text.slice(0, 1) + 'A' + original.text.slice(1),
+    duration: '9876',
+  });
+  await page.evaluate(() => transcriptHistory.undo());
+  expect(await page.evaluate(() => ({
+    text: document.querySelector('#hypertranscript span[data-m]:not(.speaker)').textContent,
+    duration: document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)')[1]
+      .getAttribute('data-d'),
+  }))).toEqual({
+    text: original.text.slice(0, 1) + 'A' + original.text.slice(1),
+    duration: original.duration,
+  });
+  await page.evaluate(() => transcriptHistory.undo());
+  expect(await page.locator('#hypertranscript span[data-m]:not(.speaker)').first().textContent())
+    .toBe(original.text);
+});
+
+test('local history pruning leaves a full undoable checkpoint', async ({ page }) => {
+  const state = await page.evaluate(() => {
+    const root = document.getElementById('hypertranscript');
+    for (let index = 0; index < 120; index += 1) {
+      const word = root.querySelector('span[data-m]:not(.speaker)');
+      const text = word.firstChild;
+      root.focus();
+      getSelection().setBaseAndExtent(text, text.length, text, text.length);
+      word.dispatchEvent(new InputEvent('beforeinput', {
+        bubbles: true, inputType: 'insertText', data: 'x',
+      }));
+      text.nodeValue += 'x';
+      word.dispatchEvent(new InputEvent('input', {
+        bubbles: true, inputType: 'insertText', data: 'x',
+      }));
+      word.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+    }
+    return transcriptHistory.inspect();
+  });
+
+  expect(state).toMatchObject({ length: 100, position: 99, fullEntries: 1, localEntries: 99 });
+  expect(await page.evaluate(() => transcriptHistory.undo())).toBe(true);
+  expect(await page.evaluate(() => transcriptHistory.inspect().position)).toBe(98);
 });
 
 test('semantic normalization folds into current without clearing redo', async ({ page }) => {

--- a/__TEST__/e2e/transcript-history.spec.mjs
+++ b/__TEST__/e2e/transcript-history.spec.mjs
@@ -96,7 +96,8 @@ test('local history pruning leaves a full undoable checkpoint', async ({ page })
   const state = await page.evaluate(() => {
     const root = document.getElementById('hypertranscript');
     for (let index = 0; index < 120; index += 1) {
-      const word = root.querySelector('span[data-m]:not(.speaker)');
+      const word = root.querySelectorAll('p')[1]
+        .querySelector('span[data-m]:not(.speaker)');
       const text = word.firstChild;
       root.focus();
       getSelection().setBaseAndExtent(text, text.length, text, text.length);
@@ -112,9 +113,33 @@ test('local history pruning leaves a full undoable checkpoint', async ({ page })
     return transcriptHistory.inspect();
   });
 
-  expect(state).toMatchObject({ length: 100, position: 99, fullEntries: 1, localEntries: 99 });
-  expect(await page.evaluate(() => transcriptHistory.undo())).toBe(true);
-  expect(await page.evaluate(() => transcriptHistory.inspect().position)).toBe(98);
+  expect(state).toMatchObject({
+    length: 100, position: 99, fullEntries: 1, localEntries: 99,
+  });
+  const checkpointCaret = await page.evaluate(() => {
+    const selectionOffset = () => {
+      const root = document.getElementById('hypertranscript');
+      const selection = getSelection();
+      const range = document.createRange();
+      range.selectNodeContents(root);
+      range.setEnd(selection.anchorNode, selection.anchorOffset);
+      return range.toString().length;
+    };
+    while (transcriptHistory.inspect().position > 0) transcriptHistory.undo();
+    let word = document.querySelectorAll('#hypertranscript p')[1]
+      .querySelector('span[data-m]:not(.speaker)');
+    const beforeFallback = selectionOffset();
+    word.setAttribute('data-d', '779');
+    word.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'formatBold' }));
+    transcriptHistory.undo();
+    return {
+      position: transcriptHistory.inspect().position,
+      beforeFallback,
+      afterFallback: selectionOffset(),
+    };
+  });
+  expect(checkpointCaret.position).toBe(0);
+  expect(checkpointCaret.afterFallback).toBe(checkpointCaret.beforeFallback);
 });
 
 test('semantic normalization folds into current without clearing redo', async ({ page }) => {
@@ -135,6 +160,68 @@ test('semantic normalization folds into current without clearing redo', async ({
   expect(result.beforeFold).toMatchObject({ length: 3, position: 1 });
   expect(result.afterFold).toMatchObject({ length: 3, position: 1 });
   expect(result.redo).toBe(true);
+});
+
+test('normalization fold promotes a local caret to transcript coordinates', async ({ page }) => {
+  const target = await page.evaluate(() => {
+    const root = document.getElementById('hypertranscript');
+    const paragraph = root.querySelectorAll('p')[1];
+    const word = paragraph.querySelector('span[data-m]:not(.speaker)');
+    root.focus();
+    getSelection().setBaseAndExtent(word.firstChild, 1, word.firstChild, 1);
+    return word.textContent;
+  });
+
+  await page.keyboard.insertText('X');
+  await page.evaluate(() => {
+    const word = document.querySelectorAll('#hypertranscript p')[1]
+      .querySelector('span[data-m]:not(.speaker)');
+    transcriptGateway.mutate(() => word.setAttribute('data-d', '777'), {
+      origin: 'test-local-normalize', foldPolicy: 'normalization',
+    });
+    transcriptHistory.undo();
+  });
+
+  const restored = await page.evaluate(() => {
+    const paragraph = document.querySelectorAll('#hypertranscript p')[1];
+    const word = paragraph.querySelector('span[data-m]:not(.speaker)');
+    const selection = getSelection();
+    return {
+      text: word.textContent,
+      inTargetWord: selection.anchorNode === word.firstChild,
+      offset: selection.anchorOffset,
+    };
+  });
+  expect(restored).toEqual({ text: target, inTargetWord: true, offset: 1 });
+});
+
+test('full fallback promotes the current local caret to transcript coordinates', async ({ page }) => {
+  await page.evaluate(() => {
+    const root = document.getElementById('hypertranscript');
+    const paragraph = root.querySelectorAll('p')[1];
+    const word = paragraph.querySelector('span[data-m]:not(.speaker)');
+    root.focus();
+    getSelection().setBaseAndExtent(word.firstChild, 1, word.firstChild, 1);
+  });
+  await page.keyboard.insertText('X');
+  await page.evaluate(() => {
+    const word = document.querySelectorAll('#hypertranscript p')[1]
+      .querySelector('span[data-m]:not(.speaker)');
+    word.setAttribute('data-d', '778');
+    word.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'formatBold' }));
+    transcriptHistory.undo();
+  });
+
+  const restored = await page.evaluate(() => {
+    const word = document.querySelectorAll('#hypertranscript p')[1]
+      .querySelector('span[data-m]:not(.speaker)');
+    const selection = getSelection();
+    return {
+      inTargetWord: selection.anchorNode === word.firstChild,
+      offset: selection.anchorOffset,
+    };
+  });
+  expect(restored).toEqual({ inTargetWord: true, offset: 2 });
 });
 
 test('keydown fallback and keydown-beforeinput execute exactly once', async ({ page, browserName }) => {

--- a/__TEST__/e2e/transcript-maintenance.spec.mjs
+++ b/__TEST__/e2e/transcript-maintenance.spec.mjs
@@ -111,6 +111,27 @@ test('a real content edit sanitises only its paragraph, then settles globally', 
   expect(result.afterGlobal.reconciliation.dirty).toBe(false);
 });
 
+test('real keyboard input retains its paragraph scope across observer delivery', async ({ page }) => {
+  await page.evaluate(() => {
+    const root = document.getElementById('hypertranscript');
+    const text = root.querySelector('span[data-m]:not(.speaker)').firstChild;
+    root.focus();
+    getSelection().setBaseAndExtent(text, 1, text, 1);
+  });
+  await page.keyboard.insertText('x');
+
+  const result = await page.evaluate(() => {
+    const queued = window.hyperaudioInspectTranscriptMaintenance();
+    window.hyperaudioFlushTranscriptMaintenance('test-native-local');
+    return { queued, flushed: window.hyperaudioInspectTranscriptMaintenance() };
+  });
+
+  expect(result.queued.pendingGlobal).toBe(false);
+  expect(result.queued.dirtyScopes).toBe(1);
+  expect(result.flushed.lastMode).toBe('local');
+  expect(result.flushed.lastScopeCount).toBe(1);
+});
+
 test('a structural edit falls back to global maintenance', async ({ page }) => {
   const state = await page.evaluate(() => {
     const transcript = document.getElementById('hypertranscript');

--- a/__TEST__/e2e/transcript-maintenance.spec.mjs
+++ b/__TEST__/e2e/transcript-maintenance.spec.mjs
@@ -1,0 +1,155 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript span[data-m]');
+  await page.evaluate(() => {
+    // Consume the initial canonicalisation so every assertion starts with a
+    // clean queue and can count only the work triggered by the test.
+    window.transcriptMaintenance.flush('test-ready', { force: true });
+  });
+});
+
+test('transcript inputs collapse into one delayed sanitise pass', async ({ page }) => {
+  const before = await page.evaluate(() => {
+    const transcript = document.getElementById('hypertranscript');
+    for (let i = 0; i < 3; i += 1) {
+      transcript.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        inputType: 'insertText',
+        data: 'x',
+      }));
+      document.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, key: 'x' }));
+    }
+    return window.transcriptMaintenance.inspect();
+  });
+
+  expect(before.dirty).toBe(true);
+  expect(before.pending).toBe(true);
+  await page.waitForTimeout(1150);
+  const after = await page.evaluate(() => window.transcriptMaintenance.inspect());
+  expect(after.runCount).toBe(before.runCount + 1);
+  expect(after.dirty).toBe(false);
+  expect(after.pending).toBe(false);
+});
+
+test('unrelated key activity cannot create transcript maintenance work', async ({ page }) => {
+  const before = await page.evaluate(() => window.transcriptMaintenance.inspect().runCount);
+  await page.locator('#search-box').focus();
+  await page.keyboard.press('Shift');
+  await page.waitForTimeout(1150);
+  const after = await page.evaluate(() => window.transcriptMaintenance.inspect());
+
+  expect(after.runCount).toBe(before);
+  expect(after.dirty).toBe(false);
+  expect(after.pending).toBe(false);
+});
+
+test('blur is a barrier and cancels the delayed duplicate', async ({ page }) => {
+  const state = await page.evaluate(() => {
+    const transcript = document.getElementById('hypertranscript');
+    transcript.focus();
+    transcript.dispatchEvent(new InputEvent('input', {
+      bubbles: true,
+      inputType: 'insertText',
+      data: 'x',
+    }));
+    const queued = window.transcriptMaintenance.inspect();
+    transcript.dispatchEvent(new FocusEvent('blur'));
+    return { queued, flushed: window.transcriptMaintenance.inspect() };
+  });
+
+  expect(state.queued.pending).toBe(true);
+  expect(state.flushed.runCount).toBe(state.queued.runCount + 1);
+  expect(state.flushed.lastReason).toBe('sanitise-blur');
+  expect(state.flushed.pending).toBe(false);
+  await page.waitForTimeout(1150);
+  expect(await page.evaluate(() => window.transcriptMaintenance.inspect().runCount))
+    .toBe(state.flushed.runCount);
+});
+
+test('a real content edit sanitises only its paragraph, then settles globally', async ({ page }) => {
+  const result = await page.evaluate(() => {
+    const transcript = document.getElementById('hypertranscript');
+    const paragraphs = transcript.querySelectorAll('p');
+    const localWord = paragraphs[0].querySelector('span[data-m]:not(.speaker)');
+    const distantWord = paragraphs[1].querySelector('span[data-m]:not(.speaker)');
+    const hrefBefore = document.getElementById('download-html').getAttribute('href');
+
+    transcript.focus();
+    localWord.firstChild.nodeValue = 'two words ';
+    transcript.dispatchEvent(new InputEvent('input', {
+      bubbles: true,
+      inputType: 'insertText',
+      data: 'x',
+    }));
+    // This second mutation is intentionally not announced by an input event:
+    // it proves that the already-captured local scope cannot sweep a distant p.
+    distantWord.style.fontSize = '19px';
+    window.hyperaudioFlushTranscriptMaintenance('test-local');
+    const afterLocal = window.hyperaudioInspectTranscriptMaintenance();
+    const hrefAfterLocal = document.getElementById('download-html').getAttribute('href');
+
+    window.transcriptReconciliation.flush('sanitise-settle');
+    const afterGlobal = window.hyperaudioInspectTranscriptMaintenance();
+    return {
+      distantStyleAfterGlobal: distantWord.style.fontSize,
+      hrefStayedDeferred: hrefAfterLocal === hrefBefore,
+      hrefRefreshed: document.getElementById('download-html').getAttribute('href') !== hrefBefore,
+      afterLocal,
+      afterGlobal,
+    };
+  });
+
+  expect(result.afterLocal.lastMode).toBe('local');
+  expect(result.afterLocal.lastScopeCount).toBe(1);
+  expect(result.afterLocal.reconciliation.dirty).toBe(true);
+  expect(result.hrefStayedDeferred).toBe(true);
+  expect(result.hrefRefreshed).toBe(true);
+  expect(result.distantStyleAfterGlobal).toBe('');
+  expect(result.afterGlobal.lastMode).toBe('global');
+  expect(result.afterGlobal.reconciliation.dirty).toBe(false);
+});
+
+test('a structural edit falls back to global maintenance', async ({ page }) => {
+  const state = await page.evaluate(() => {
+    const transcript = document.getElementById('hypertranscript');
+    const section = transcript.querySelector('section');
+    const paragraph = document.createElement('p');
+    paragraph.innerHTML = '<span data-m="999999" data-d="100">added </span>';
+    section.appendChild(paragraph);
+    transcript.dispatchEvent(new InputEvent('input', {
+      bubbles: true,
+      inputType: 'insertParagraph',
+    }));
+    window.hyperaudioFlushTranscriptMaintenance('test-structural');
+    return window.hyperaudioInspectTranscriptMaintenance();
+  });
+
+  expect(state.lastMode).toBe('global');
+  expect(state.lastScopeCount).toBe(0);
+  expect(state.reconciliation.dirty).toBe(false);
+});
+
+test('a clean local pass skips whole-document history capture', async ({ page }) => {
+  const transaction = await page.evaluate(() => {
+    let seen = null;
+    const off = transcriptGateway.onBeforeMutate((tx) => {
+      if (tx.origin === 'sanitise-local') {
+        seen = { origin: tx.origin, captureHistory: tx.captureHistory };
+      }
+    });
+    const paragraph = document.querySelector('#hypertranscript p');
+    window.hyperaudioRequestTranscriptMaintenance(paragraph, 'test-clean', {
+      reconcile: false,
+    });
+    window.hyperaudioFlushTranscriptMaintenance('test-clean');
+    off();
+    return seen;
+  });
+
+  expect(transaction).toEqual({
+    origin: 'sanitise-local',
+    captureHistory: false,
+  });
+});

--- a/__TEST__/unit/transcript-maintenance.test.mjs
+++ b/__TEST__/unit/transcript-maintenance.test.mjs
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import maintenance from '../../js/transcript-maintenance.js';
+
+const { createTranscriptMaintenanceQueue } = maintenance;
+
+function fakeClock() {
+  let serial = 0;
+  const tasks = new Map();
+  return {
+    setTimer(fn) {
+      const id = ++serial;
+      tasks.set(id, fn);
+      return id;
+    },
+    clearTimer(id) { tasks.delete(id); },
+    fire() {
+      const pending = [...tasks.values()];
+      tasks.clear();
+      pending.forEach((fn) => fn());
+    },
+    size: () => tasks.size,
+  };
+}
+
+test('many dirty signals collapse into one pending run', () => {
+  const clock = fakeClock();
+  const reasons = [];
+  const queue = createTranscriptMaintenanceQueue({
+    run: (reason) => reasons.push(reason),
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+  });
+
+  queue.markDirty('input-1');
+  queue.markDirty('input-2');
+  queue.schedule('keyup');
+  assert.equal(clock.size(), 1);
+
+  clock.fire();
+  assert.deepEqual(reasons, ['keyup']);
+  assert.equal(queue.inspect().dirty, false);
+  assert.equal(queue.inspect().runCount, 1);
+});
+
+test('a barrier flushes immediately and cancels the delayed duplicate', () => {
+  const clock = fakeClock();
+  const reasons = [];
+  const queue = createTranscriptMaintenanceQueue({
+    run: (reason) => reasons.push(reason),
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+  });
+
+  queue.markDirty('input');
+  assert.equal(queue.flush('blur'), true);
+  assert.equal(clock.size(), 0);
+  clock.fire();
+  assert.deepEqual(reasons, ['blur']);
+});
+
+test('a closed gate retains dirty work until it can run', () => {
+  const clock = fakeClock();
+  let allowed = false;
+  let runs = 0;
+  const queue = createTranscriptMaintenanceQueue({
+    run: () => { runs += 1; },
+    canRun: () => allowed,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+  });
+
+  assert.equal(queue.markDirty('caption-mode'), false);
+  assert.equal(queue.inspect().dirty, true);
+  allowed = true;
+  assert.equal(queue.schedule('transcript-mode'), true);
+  clock.fire();
+  assert.equal(runs, 1);
+  assert.equal(queue.inspect().dirty, false);
+});
+
+test('destroy makes a superseded queue inert', () => {
+  const clock = fakeClock();
+  let runs = 0;
+  const queue = createTranscriptMaintenanceQueue({
+    run: () => { runs += 1; },
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+  });
+
+  queue.markDirty('old-document');
+  queue.destroy();
+  clock.fire();
+  assert.equal(runs, 0);
+  assert.equal(queue.inspect().destroyed, true);
+  assert.equal(queue.markDirty('late'), false);
+});
+
+test('cancel drops pending work but leaves the queue reusable', () => {
+  const clock = fakeClock();
+  let runs = 0;
+  const queue = createTranscriptMaintenanceQueue({
+    run: () => { runs += 1; },
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+  });
+
+  queue.markDirty('superseded');
+  assert.equal(queue.cancel(), true);
+  clock.fire();
+  assert.equal(runs, 0);
+  assert.equal(queue.inspect().dirty, false);
+
+  queue.markDirty('new-work');
+  clock.fire();
+  assert.equal(runs, 1);
+});

--- a/index.html
+++ b/index.html
@@ -1101,7 +1101,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.6.1"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.6.2"></script>
   <script src="js/hyperaudio-library.js?v=1.2.5.3"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -1041,7 +1041,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-serializer.js?v=1.1.8"></script>
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.2.0"></script>
-  <script src="js/editor-core.js?v=1.2.5.1"></script>
+  <script src="js/editor-core.js?v=1.2.6"></script>
 
 
   <import-deepgram-json></import-deepgram-json>

--- a/index.html
+++ b/index.html
@@ -1042,7 +1042,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.2.0"></script>
   <script src="js/transcript-maintenance.js?v=1.2.6"></script>
-  <script src="js/editor-core.js?v=1.2.6"></script>
+  <script src="js/editor-core.js?v=1.2.6.1"></script>
 
 
   <import-deepgram-json></import-deepgram-json>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.2.5 (last changed in release 1.2.5) -->
+<!--  Hyperaudio Lite Editor - Version 1.3.0 (last changed in release 1.3.0) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.2.5">
+  <meta name="version" content="1.3.0">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -1040,9 +1040,9 @@ If you are creating an open source application under a license compatible with t
   <script src="js/caption.js?v=0.8.6"></script>
   <script src="js/transcript-serializer.js?v=1.1.8"></script>
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
-  <script src="js/transcript-gateway.js?v=1.2.0"></script>
-  <script src="js/transcript-maintenance.js?v=1.2.6"></script>
-  <script src="js/editor-core.js?v=1.2.6.1"></script>
+  <script src="js/transcript-gateway.js?v=1.3.0"></script>
+  <script src="js/transcript-maintenance.js?v=1.3.0"></script>
+  <script src="js/editor-core.js?v=1.3.0"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1081,9 +1081,9 @@ If you are creating an open source application under a license compatible with t
   </style>
   <script src="js/editor-main.js?v=1.2.5"></script>
   <script src="js/find-replace.js?v=1.2.0"></script>
-  <script src="js/transcript-history.js?v=1.2.4"></script>
+  <script src="js/transcript-history.js?v=1.3.0"></script>
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
-  <script src="js/transcript-bench.js?v=1.2.3"></script>
+  <script src="js/transcript-bench.js?v=1.3.0"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
   <script src="js/media-export.js?v=1.1.8"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
@@ -1101,7 +1101,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.6.3"></script>
+  <script src="js/hyperaudio-save.js?v=1.3.0"></script>
   <script src="js/hyperaudio-library.js?v=1.2.5.3"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -1101,7 +1101,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.6"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.6.1"></script>
   <script src="js/hyperaudio-library.js?v=1.2.5.3"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -1101,7 +1101,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.5.6"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.6"></script>
   <script src="js/hyperaudio-library.js?v=1.2.5.3"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -1101,7 +1101,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.2.6.2"></script>
+  <script src="js/hyperaudio-save.js?v=1.2.6.3"></script>
   <script src="js/hyperaudio-library.js?v=1.2.5.3"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -1041,6 +1041,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-serializer.js?v=1.1.8"></script>
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.2.0"></script>
+  <script src="js/transcript-maintenance.js?v=1.2.3"></script>
   <script src="js/editor-core.js?v=1.2.0"></script>
 
 

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -932,14 +932,6 @@
       let pendingGlobal = true;
       let lastMode = 'none';
       let lastScopeCount = 0;
-      const observer = new MutationObserver(() => {});
-      observer.observe(rootnode, {
-        subtree: true,
-        childList: true,
-        characterData: true,
-        attributes: true,
-      });
-      window.transcriptMaintenanceObserver = observer;
 
       const paragraphOf = (node) => {
         const element = node && node.nodeType === Node.ELEMENT_NODE
@@ -948,8 +940,24 @@
         return paragraph && rootnode.contains(paragraph) ? paragraph : null;
       };
 
+      // Native editing may deliver MutationObserver callbacks before its
+      // subsequent input event. Keep those records instead of letting an empty
+      // callback discard them; input remains the signal that queues work.
+      let deliveredRecords = [];
+      const observer = new MutationObserver((records) => {
+        deliveredRecords.push(...records);
+      });
+      observer.observe(rootnode, {
+        subtree: true,
+        childList: true,
+        characterData: true,
+        attributes: true,
+      });
+      window.transcriptMaintenanceObserver = observer;
+
       const captureDirtyScopes = (hint) => {
-        const records = observer.takeRecords();
+        const records = deliveredRecords.concat(observer.takeRecords());
+        deliveredRecords = [];
         if (records.length > 0) {
           records.forEach((record) => {
             const paragraph = paragraphOf(record.target);
@@ -978,6 +986,7 @@
             global ? (origin || 'sanitise') : 'sanitise-local',
           );
           observer.takeRecords(); // mutations made by maintenance are not user edits
+          deliveredRecords = [];
           pendingGlobal = false;
           dirtyScopes.clear();
           lastMode = global ? 'global' : 'local';
@@ -992,6 +1001,7 @@
           maintenance.cancel();
           runSanitise({ refreshDerived: true }, origin || 'sanitise-settle');
           observer.takeRecords();
+          deliveredRecords = [];
           pendingGlobal = false;
           dirtyScopes.clear();
           lastMode = 'global';

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -51,9 +51,13 @@
   let captionMode = false; // used to detect whether we need to sanitise amongst other things
   let transcriptRequiresInit = false; // to know whether a transcript has been loaded while in captionMode and so not initialised
 
-  function mutateTranscript(fn, origin, foldPolicy) {
+  function mutateTranscript(fn, origin, foldPolicy, captureHistory) {
     if (window.transcriptGateway && typeof window.transcriptGateway.mutate === 'function') {
-      return window.transcriptGateway.mutate(fn, { origin, foldPolicy });
+      return window.transcriptGateway.mutate(fn, {
+        origin,
+        foldPolicy,
+        captureHistory: captureHistory !== false,
+      });
     }
     return fn();
   }
@@ -265,6 +269,12 @@
       hyperaudio();
       transcriptRequiresInit = false;
     }
+    if (window.transcriptMaintenance) {
+      window.transcriptMaintenance.schedule('sanitise');
+    }
+    if (window.transcriptReconciliation) {
+      window.transcriptReconciliation.schedule('sanitise-settle');
+    }
     reflectViewSwitch();
   });
 
@@ -284,7 +294,15 @@
   // pass simply happens on the next keyup/blur.
   let imeComposing = false;
   document.addEventListener('compositionstart', () => { imeComposing = true; });
-  document.addEventListener('compositionend', () => { imeComposing = false; });
+  document.addEventListener('compositionend', () => {
+    imeComposing = false;
+    if (window.transcriptMaintenance) {
+      window.transcriptMaintenance.schedule('sanitise');
+    }
+    if (window.transcriptReconciliation) {
+      window.transcriptReconciliation.schedule('sanitise-settle');
+    }
+  });
 
   // Estimate syllables from contiguous vowel groups (Latin-script heuristic);
   // floored at 1 so every part carries weight.
@@ -388,8 +406,18 @@
   // Returns whether any span was UNWRAPPED — the one scrub action that moves
   // the caret's text node, so callers know the selection may need restoring
   // (#511). The style strip touches attributes only and cannot move a caret.
+  function hasUnsupportedTranscriptStyle(span) {
+    return Array.from(span.style).some((property) => {
+      if (property === 'display' && span.classList.contains('speaker')) return false;
+      if (property === 'text-decoration'
+          && span.style.textDecoration.includes('line-through')) return false;
+      return true;
+    });
+  }
+
   function scrubEditingArtifacts(root) {
     root.querySelectorAll('span[style]').forEach((span) => {
+      if (!hasUnsupportedTranscriptStyle(span)) return;
       const display = span.classList.contains('speaker') ? span.style.display : '';
       const struck = (span.style.textDecoration || '').includes('line-through');
       span.removeAttribute('style');
@@ -611,10 +639,15 @@
     if (transcriptEl !== null && transcriptEl.dataset.autoscrollPause !== '1') {
       transcriptEl.dataset.autoscrollPause = '1';
       let typingResume = null;
-      transcriptEl.addEventListener('input', () => {
+      transcriptEl.addEventListener('input', (event) => {
         const hla = window.hyperaudioInstance;
         if (hla && typeof hla.pauseAutoscroll === 'function') {
           hla.pauseAutoscroll();
+        }
+        if (typeof window.hyperaudioRequestTranscriptMaintenance === 'function') {
+          window.hyperaudioRequestTranscriptMaintenance(event, 'sanitise');
+        } else if (window.transcriptMaintenance) {
+          window.transcriptMaintenance.markDirty('sanitise');
         }
         clearTimeout(typingResume);
         typingResume = setTimeout(() => {
@@ -629,26 +662,66 @@
       // and the debounced sanitise pass runs it too so it also fires while
       // editing without a blur (e.g. clicking words to seek). See normalize-
       // TranscriptSpans above and the sanitise() call below.
-      transcriptEl.addEventListener('blur', () => mutateTranscript(
-        () => normalizeTranscriptSpans(transcriptEl),
-        'normalize-blur',
-        'normalization',
-      ));
+      transcriptEl.addEventListener('blur', () => {
+        if (typeof window.hyperaudioFlushTranscriptMaintenance === 'function'
+            && window.hyperaudioFlushTranscriptMaintenance('sanitise-blur', {
+              force: true,
+              global: true,
+            })) return;
+        mutateTranscript(
+          () => normalizeTranscriptSpans(transcriptEl),
+          'normalize-blur',
+          'normalization',
+        );
+      });
     }
 
     const sanitisationCheck = function () {
-
-      let time = 0;
-      resetTimer();
-      window.onload = resetTimer;
-      document.onkeyup = resetTimer;
-      document.ontouchend = resetTimer;
-
       let rootnode = document.querySelector("#hypertranscript");
       let sourceMedia = document.querySelector("#hyperplayer").src;
       let track = document.querySelector('#hyperplayer-vtt');
 
-      function sanitise() {
+      // Conservative preflight for the exact transcript mutations performed
+      // below. A clean paragraph still crosses the gateway (for audit/view
+      // classification), but can explicitly skip history's two whole-document
+      // snapshots. Any uncertain or repairable shape keeps normal history.
+      function scopeNeedsSanitise(scope) {
+        if (!scope || scope.textContent.indexOf(' ') !== -1) return true;
+        if (scope.querySelector('span:not([data-m]):not(.speaker)')) return true;
+        if (Array.from(scope.querySelectorAll('span[style]'))
+          .some((span) => hasUnsupportedTranscriptStyle(span))) return true;
+
+        const spans = scope.querySelectorAll('span[data-m]');
+        for (let i = 0; i < spans.length; i += 1) {
+          const span = spans[i];
+          const text = span.textContent;
+          if (!span.classList.contains('speaker') && !isSpeakerText(span)) {
+            if (/\S\s+\S/.test(text)) return true;
+            if (text.length > 0 && !/\s$/.test(text)) {
+              const next = span.nextElementSibling;
+              if (next && next.hasAttribute('data-m')
+                  && !next.classList.contains('speaker') && !isSpeakerText(next)
+                  && onlyWhitespaceBetween(span, next)) return true;
+            }
+          }
+          if (text.includes('[') && text.includes(']')
+              && (!text.trim().startsWith('[') || !text.trim().endsWith(']'))
+              && / *\[[^\]]*]/.test(text)) return true;
+        }
+
+        const walker = document.createTreeWalker(scope, NodeFilter.SHOW_TEXT);
+        while (walker.nextNode()) {
+          const node = walker.currentNode;
+          if (node.parentElement.tagName === 'SPAN'
+              || node.textContent.replaceAll('\n', '').trim().length === 0) continue;
+          if ((node.previousSibling && node.previousSibling.tagName === 'SPAN')
+              || node.nextSibling !== null) return true;
+        }
+        return false;
+      }
+
+      function sanitise(options) {
+        const opts = options || {};
         let d = new Date();
         let starttime = d.getTime();
 
@@ -659,11 +732,18 @@
           return;
         }
 
+        const requestedScopes = Array.isArray(opts.scopes) ? opts.scopes : [];
+        const localScopes = requestedScopes.filter((scope) => scope && scope.isConnected
+          && rootnode.contains(scope) && scope.matches('p'));
+        const roots = localScopes.length === requestedScopes.length && localScopes.length > 0
+          ? localScopes : [rootnode];
+        const refreshDerived = opts.refreshDerived !== false || roots[0] === rootnode;
+
         // Repair split/merged/reflowed word spans on the debounced pass too, not
         // just on blur — editing while clicking words to seek never fires a blur,
         // so this keeps the spans and the player's word index correct mid-edit
         // (#394). Self-contained: it re-indexes when the span set changes.
-        normalizeTranscriptSpans(rootnode);
+        roots.forEach((scope) => normalizeTranscriptSpans(scope));
 
         // check that transcript has the focus
 
@@ -677,9 +757,10 @@
         }
 
 
-        let walker = document.createTreeWalker(rootnode, NodeFilter.SHOW_TEXT, null, false);
+        roots.forEach((scope) => {
+          let walker = document.createTreeWalker(scope, NodeFilter.SHOW_TEXT, null, false);
 
-        while (walker.nextNode()) {
+          while (walker.nextNode()) {
 
           if (walker.currentNode.textContent.replaceAll('\n', '').trim().length > 0
               && walker.currentNode.parentElement.tagName !== "SPAN") {
@@ -699,13 +780,16 @@
             //walker.currentNode.parentNode.removeChild(walker.currentNode);
             walker.currentNode.textContent = "";
           }
-        }
+          }
+        });
 
         // look for speakers and break them out into their own spans
 
-        walker = document.createTreeWalker(rootnode, NodeFilter.SHOW_TEXT, null, false);
+        let speakerChanged = false;
+        roots.forEach((scope) => {
+          const walker = document.createTreeWalker(scope, NodeFilter.SHOW_TEXT, null, false);
 
-        while (walker.nextNode()) {
+          while (walker.nextNode()) {
           if (walker.currentNode.textContent.replaceAll('\n', '').replaceAll('  ', ' ').trim().length > 0
               && walker.currentNode.parentElement.tagName === "SPAN" && walker.currentNode.textContent.includes('[') && walker.currentNode.textContent.includes(']')) {
 
@@ -737,6 +821,7 @@
               if (span.textContent.includes('[') && span.textContent.includes(']')) {
                 span.classList.add("speaker");
                 closedSpeaker = false;
+                speakerChanged = true;
               }
 
               // add the classes of the current node
@@ -768,6 +853,20 @@
               }
             }
           }
+          }
+        });
+
+        // The fast pass deliberately stops before transcript-wide derived
+        // products. They are refreshed by the settle queue or synchronously at
+        // an observation barrier (blur/history/export). Speaker extraction is
+        // the rare local operation that changes the word-node set, so keep the
+        // player index live even before reconciliation.
+        if (!refreshDerived) {
+          if (speakerChanged && hyperaudioInstance
+              && typeof hyperaudioInstance.setupTranscriptWords === 'function') {
+            hyperaudioInstance.setupTranscriptWords();
+          }
+          return;
         }
 
         // Canonical serialization (transcript-serializer.js): one span per
@@ -805,26 +904,170 @@
         //console.log("sanitising took "+(d.getTime() - starttime)+"ms");
       }
 
-      function resetTimer() {
-        clearTimeout(time);
-        if (captionMode !== true) {
-          time = setTimeout(() => mutateTranscript(
-            sanitise,
-            'sanitise',
-            'normalization',
-          ), 1000);
-        }
+      function runSanitise(options, origin) {
+        const opts = options || {};
+        const requested = Array.isArray(opts.scopes) ? opts.scopes : [];
+        const validLocal = requested.filter((scope) => scope && scope.isConnected
+          && rootnode.contains(scope) && scope.matches('p'));
+        const scopes = validLocal.length === requested.length && validLocal.length > 0
+          ? validLocal : [rootnode];
+        const captureHistory = scopes.some((scope) => scopeNeedsSanitise(scope));
+        return mutateTranscript(
+          () => sanitise(opts),
+          origin || 'sanitise',
+          'normalization',
+          captureHistory,
+        );
       }
+
+      // Fast maintenance is paragraph-local; a second, longer idle window owns
+      // the global derived work (canonical download + captions). Mutation
+      // records identify the paragraph touched by contenteditable without
+      // trusting InputEvent.target, which is normally the transcript host.
+      if (window.transcriptMaintenance) window.transcriptMaintenance.destroy();
+      if (window.transcriptReconciliation) window.transcriptReconciliation.destroy();
+      if (window.transcriptMaintenanceObserver) window.transcriptMaintenanceObserver.disconnect();
+
+      const dirtyScopes = new Set();
+      let pendingGlobal = true;
+      let lastMode = 'none';
+      let lastScopeCount = 0;
+      const observer = new MutationObserver(() => {});
+      observer.observe(rootnode, {
+        subtree: true,
+        childList: true,
+        characterData: true,
+        attributes: true,
+      });
+      window.transcriptMaintenanceObserver = observer;
+
+      const paragraphOf = (node) => {
+        const element = node && node.nodeType === Node.ELEMENT_NODE
+          ? node : node && node.parentElement;
+        const paragraph = element && element.closest ? element.closest('p') : null;
+        return paragraph && rootnode.contains(paragraph) ? paragraph : null;
+      };
+
+      const captureDirtyScopes = (hint) => {
+        const records = observer.takeRecords();
+        if (records.length > 0) {
+          records.forEach((record) => {
+            const paragraph = paragraphOf(record.target);
+            if (paragraph) dirtyScopes.add(paragraph);
+            else pendingGlobal = true;
+          });
+          return;
+        }
+        const direct = hint && hint.target ? null : paragraphOf(hint);
+        if (direct) dirtyScopes.add(direct);
+        else pendingGlobal = true;
+      };
+
+      let reconciliation;
+      const maintenance = window.createTranscriptMaintenanceQueue({
+        delay: 1000,
+        canRun: () => captionMode !== true && imeComposing !== true,
+        run: (origin) => {
+          const scopes = Array.from(dirtyScopes);
+          const scopesAreLocal = scopes.length > 0 && scopes.every((scope) => scope
+            && scope.isConnected && rootnode.contains(scope) && scope.matches('p'));
+          const global = pendingGlobal || !scopesAreLocal
+            || /(?:blur|history|global|initial)/.test(origin || '');
+          runSanitise(
+            { scopes: global ? null : scopes, refreshDerived: global },
+            global ? (origin || 'sanitise') : 'sanitise-local',
+          );
+          observer.takeRecords(); // mutations made by maintenance are not user edits
+          pendingGlobal = false;
+          dirtyScopes.clear();
+          lastMode = global ? 'global' : 'local';
+          lastScopeCount = global ? 0 : scopes.length;
+          if (global && reconciliation) reconciliation.cancel();
+        },
+      });
+      reconciliation = window.createTranscriptMaintenanceQueue({
+        delay: 3000,
+        canRun: () => captionMode !== true && imeComposing !== true,
+        run: (origin) => {
+          maintenance.cancel();
+          runSanitise({ refreshDerived: true }, origin || 'sanitise-settle');
+          observer.takeRecords();
+          pendingGlobal = false;
+          dirtyScopes.clear();
+          lastMode = 'global';
+          lastScopeCount = 0;
+        },
+      });
+      window.transcriptMaintenance = maintenance;
+      window.transcriptReconciliation = reconciliation;
+
+      window.hyperaudioRequestTranscriptMaintenance = function (hint, reason, options) {
+        captureDirtyScopes(hint);
+        const queued = maintenance.markDirty(reason || 'sanitise');
+        if (!(options && options.reconcile === false)) {
+          reconciliation.markDirty('sanitise-settle');
+        }
+        return queued;
+      };
+
+      window.hyperaudioFlushTranscriptMaintenance = function (origin, options) {
+        if (options && options.global) pendingGlobal = true;
+        return maintenance.flush(origin || 'sanitise', {
+          force: !!(options && options.force),
+        });
+      };
+
+      window.hyperaudioInspectTranscriptMaintenance = function () {
+        return {
+          local: maintenance.inspect(),
+          reconciliation: reconciliation.inspect(),
+          pendingGlobal,
+          dirtyScopes: dirtyScopes.size,
+          lastMode,
+          lastScopeCount,
+        };
+      };
+
+      ['download-html', 'download-vtt', 'download-srt', 'download-vtt-words',
+        'download-hypertranscript'].forEach((id) => {
+        const link = document.getElementById(id);
+        if (!link || link.dataset.maintenanceBarrier === '1') return;
+        link.dataset.maintenanceBarrier = '1';
+        link.addEventListener('click', () => {
+          const state = window.hyperaudioInspectTranscriptMaintenance();
+          if (!state.pendingGlobal && !state.local.dirty
+              && !state.reconciliation.dirty) return;
+          window.hyperaudioFlushTranscriptMaintenance('sanitise-export', {
+            force: true,
+            global: true,
+          });
+        }, true);
+      });
+
+      // Preserve the original first canonicalisation. Afterwards, unrelated
+      // key/touch activity cannot create work: it can only postpone work that
+      // a transcript input (or an explicit producer) already marked dirty.
+      maintenance.markDirty('sanitise-initial');
+      window.onload = () => {
+        pendingGlobal = true;
+        maintenance.markDirty('sanitise-initial');
+      };
+      document.onkeyup = () => {
+        maintenance.schedule('sanitise');
+        reconciliation.schedule('sanitise-settle');
+      };
+      document.ontouchend = () => {
+        maintenance.schedule('sanitise');
+        reconciliation.schedule('sanitise-settle');
+      };
 
       // History restore replaces the transcript DOM synchronously. Cancel any
       // timer belonging to the pre-restore DOM and run exactly one fresh pass;
       // its explicit fold policy lets history amend the restored entry without
       // consuming redo or creating a visible step.
       window.hyperaudioNormalizeAfterHistoryRestore = function () {
-        clearTimeout(time);
-        if (captionMode === true || imeComposing === true) return false;
-        mutateTranscript(sanitise, 'history-restore-normalize', 'normalization');
-        return true;
+        pendingGlobal = true;
+        return maintenance.flush('history-restore-normalize', { force: true });
       };
 
       //longpress to set playhead on mobile

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -361,21 +361,53 @@
       pre.setEnd(container, offset);
       return pre.toString().length;
     };
+    // The caret's containing block, because an absolute offset is AMBIGUOUS
+    // exactly at a paragraph boundary (#530): right after Enter, 'start of
+    // the new <p>' and 'end of the previous <p>' are the same character
+    // count — Range.toString() emits nothing between blocks the split left
+    // adjacent. Recording which <p> held the caret lets restore pick the
+    // right side; without it the debounced pass yanked a freshly-placed
+    // caret back to the end of the paragraph above.
+    const blockOf = (container) => {
+      const el = container.nodeType === Node.ELEMENT_NODE ? container : container.parentElement;
+      const block = el !== null ? el.closest('p') : null;
+      return block !== null ? Array.prototype.indexOf.call(root.querySelectorAll('p'), block) : -1;
+    };
     return {
       start: measure(range.startContainer, range.startOffset),
+      startBlock: blockOf(range.startContainer),
       end: range.collapsed ? null : measure(range.endContainer, range.endOffset),
+      endBlock: range.collapsed ? null : blockOf(range.endContainer),
     };
   }
 
   // Resolve an absolute character offset back to a (text node, offset) pair;
   // clamps past-the-end to the final position.
-  function resolveCharOffset(root, chars) {
+  function resolveCharOffset(root, chars, preferredBlock) {
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const paragraphs = root.querySelectorAll('p');
+    const blockOf = (n) => {
+      const block = n.parentElement !== null ? n.parentElement.closest('p') : null;
+      return block !== null ? Array.prototype.indexOf.call(paragraphs, block) : -1;
+    };
     let node;
     let last = null;
     let remaining = chars;
     while ((node = walker.nextNode())) {
       if (remaining <= node.nodeValue.length) {
+        // Exactly at this node's end, the same offset also describes the
+        // start of the NEXT text node — a different position when a block
+        // boundary sits between them (#530). The saved block says which side
+        // the caret was really on; only cross the boundary when it says so.
+        if (remaining === node.nodeValue.length
+            && preferredBlock !== undefined && preferredBlock !== -1
+            && blockOf(node) !== preferredBlock) {
+          let ahead = walker.nextNode();
+          while (ahead !== null && ahead.nodeValue.length === 0) ahead = walker.nextNode();
+          if (ahead !== null && blockOf(ahead) === preferredBlock) {
+            return { node: ahead, offset: 0 };
+          }
+        }
         return { node, offset: remaining };
       }
       remaining -= node.nodeValue.length;
@@ -385,13 +417,13 @@
   }
 
   function restoreCaretOffset(root, saved) {
-    const start = resolveCharOffset(root, saved.start);
+    const start = resolveCharOffset(root, saved.start, saved.startBlock);
     if (start === null) return;
     const sel = window.getSelection();
     const range = document.createRange();
     range.setStart(start.node, start.offset);
     if (saved.end !== null) {
-      const end = resolveCharOffset(root, saved.end);
+      const end = resolveCharOffset(root, saved.end, saved.endBlock);
       if (end !== null) range.setEnd(end.node, end.offset);
     } else {
       range.collapse(true);

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -578,7 +578,16 @@
     // text nodes rather than rewriting them), so offsets measured here stay
     // valid for the restore. Only when the transcript has focus — on blur
     // there is nothing to preserve.
-    const hasFocus = document.activeElement === root;
+    // root may be a single <p> on the paragraph-local pass (#517 perf), but
+    // focus always sits on the contenteditable HOST — comparing against root
+    // made hasFocus permanently false on the scoped path, which silently
+    // disabled this whole guard and resurrected #511 (mutations ran, caret
+    // never saved, never restored). saveCaretOffset's own containment check
+    // still returns null when the caret is outside THIS scope, so a pass over
+    // a paragraph the caret isn't in stays a no-op for selection.
+    const host = root.matches && root.matches('p')
+      ? (root.closest('#hypertranscript') || root) : root;
+    const hasFocus = document.activeElement === host;
     const caret = hasFocus ? saveCaretOffset(root) : null;
     // nbsp -> normal space (#339); flagged, because rewriting the caret's own
     // node is precisely the mutation that needs the restore afterwards

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -694,18 +694,24 @@
   // a draft was restored, so the saved state isn't what's on screen); unknown
   // stays dirty, which is the previous behaviour.
   let savedSignature = null;
-  // `modified` is stamped at every gather, so it would defeat any comparison;
-  // captions ride outside the project json and must be part of the identity —
-  // undoing the transcript back while a caption edit is pending is NOT clean.
-  function signatureOfParts(json, vtt) {
-    const project = JSON.parse(json);
+  // `modified` is stamped at every gather, so it would defeat any comparison.
+  // Captions ride outside the project json: with sync OFF they are curated
+  // content and part of the identity — undoing the transcript back while a
+  // caption edit is pending is NOT clean. With sync ON the vtt is a pure
+  // derivative of the transcript, regenerated on a deferred schedule (#517),
+  // so comparing it would only race the regen queue — the transcript json
+  // already carries the same information.
+  function signatureFor(project, vtt) {
     project.modified = '';
-    return JSON.stringify(project) + '\u001f' + (vtt || '');
+    const syncOn = !!(project.options && project.options.captions
+      && project.options.captions.updateFromTranscript !== false);
+    return JSON.stringify(project) + '\u001f' + (syncOn ? '' : (vtt || ''));
+  }
+  function signatureOfParts(json, vtt) {
+    return signatureFor(JSON.parse(json), vtt);
   }
   function stateSignature() {
-    const project = buildProjectJson(gather());
-    project.modified = '';
-    return JSON.stringify(project) + '\u001f' + (getCaptionsVtt() || '');
+    return signatureFor(buildProjectJson(gather()), getCaptionsVtt() || '');
   }
 
   // History and other same-document features must not infer identity from a

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2934,9 +2934,25 @@
     // and the project genuinely differs from the save. Restores that DON'T
     // land on the save re-dirty through the synthetic input the history
     // module dispatches, like any other edit.
-    document.addEventListener('hyperaudioTranscriptRestored', () => {
+    let restoreRecheckTimer = null;
+    const attemptCleanAfterRestore = () => {
       if (!session.active || savedSignature === null || !sessionEdited) return;
       if (stateSignature() !== savedSignature) return;
+      cleanAfterRestore();
+    };
+    document.addEventListener('hyperaudioTranscriptRestored', () => {
+      // Two attempts: now, and once more after the idle reconciliation
+      // window. The perf rework (#517) defers caption regeneration to a ~3s
+      // idle queue, so a restore that lands the TRANSCRIPT exactly on the
+      // saved state can still carry the pre-undo captions on the track when
+      // this event fires — the signature legitimately mismatches until the
+      // deferred pass catches the track up. The recheck re-runs the same
+      // guards fresh: an edit landing meanwhile keeps the dot on.
+      clearTimeout(restoreRecheckTimer);
+      attemptCleanAfterRestore();
+      restoreRecheckTimer = setTimeout(attemptCleanAfterRestore, 3400);
+    });
+    function cleanAfterRestore() {
       sessionEdited = false;
       clearTimeout(autosaveTimer);
       autosaveTimer = null;
@@ -2960,7 +2976,7 @@
           notifyLibraryChanged(false);
         }).catch((e) => console.warn('hyperaudio-save: draft retirement failed', e));
       }
-    });
+    }
     ['#remove-gaps-enabled', '#remove-gaps-threshold', '#remove-gaps-buffer', '#show-speakers', '#show-timecodes']
       .forEach((selector) => {
         const el = document.querySelector(selector);

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.2.5 — last changed in release 1.2.5
+ * @version 1.3.0 — last changed in release 1.3.0
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2371,6 +2371,7 @@
         t.innerHTML = pendingTranscription.loaderHtml;
       }
       t.setAttribute('aria-busy', 'true');
+      t.setAttribute('contenteditable', 'false'); // the loader is not for typing in
       // The transcription's own media on the player too — without this, the
       // pending view kept showing whatever project was on screen before.
       const player = document.getElementById('hyperplayer');
@@ -2410,6 +2411,10 @@
         pendingTranscription.fragment = fragment;
       }
       t.removeAttribute('aria-busy');
+      // busy(true) also turned editing OFF, and that must not follow us to
+      // the project either: left as-is, every transcript opened while a
+      // transcription runs has no caret and takes no edits.
+      t.setAttribute('contenteditable', 'true');
     }
     return true;
   }

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -2290,6 +2290,12 @@
             // transcribe entry points grey on this class, so the gate holds
             // while the engine runs in the background too.
             document.documentElement.classList.add('ha-transcribing');
+            // The player already holds the transcription's media, but the
+            // caption <track> still holds the PREVIOUS project's vtt — left
+            // alone, playing the transcribing video shows the old captions.
+            // The one door also arms the late-write guard, so caption.js
+            // can't re-apply the stale vtt on the new media's loadedmetadata.
+            applyCaptionTrack('', { mode: 'disabled' });
             notifyLibraryChanged(false);
           } else if (busy === false && pendingTranscription !== null) {
             // success is announced by hyperaudioInit (the birth clears the row
@@ -2372,6 +2378,9 @@
           && player.src !== pendingIdentity.playerSrc) {
         player.src = pendingIdentity.playerSrc;
       }
+      // ... and the project we came FROM applied its captions at open; the
+      // transcribing media has none yet.
+      applyCaptionTrack('', { mode: 'disabled' });
     } finally {
       suppressCapture = false;
     }

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -1304,10 +1304,23 @@
   // In the native wrapper the bridge receives the built container instead
   // (#449: one save path for web and native); without OPFS the explicit
   // export download is the only durable copy, so Save falls back to it.
+  function flushTranscriptMaintenanceBarrier(origin) {
+    if (typeof window.hyperaudioFlushTranscriptMaintenance !== 'function') return;
+    const state = typeof window.hyperaudioInspectTranscriptMaintenance === 'function'
+      ? window.hyperaudioInspectTranscriptMaintenance() : null;
+    if (state && !state.pendingGlobal && !state.local.dirty
+        && !state.reconciliation.dirty) return;
+    window.hyperaudioFlushTranscriptMaintenance(origin, {
+      force: true,
+      global: true,
+    });
+  }
+
   async function saveProject() {
     if (saveInFlight) return false;
     saveInFlight = true;
     try {
+      flushTranscriptMaintenanceBarrier('sanitise-save');
       const bridge = window.hyperaudioProjectBridge;
       if (bridge && typeof bridge.save === 'function') {
         return await exportProject({ asSave: true }); // the bridge intercepts the built container
@@ -1804,6 +1817,7 @@
     exportInFlight = true;
     const token = beginProgress();
     try {
+      flushTranscriptMaintenanceBarrier('sanitise-project-export');
       return await exportProjectInner(!!(opts && opts.asSave), token);
     } finally {
       exportInFlight = false;

--- a/js/transcript-bench.js
+++ b/js/transcript-bench.js
@@ -4,7 +4,7 @@
  * synthetic timed transcripts at several sizes in the live editor and
  * measures, on THIS device and THIS browser:
  *
- *   - typing cost per keystroke (includes history's per-key pre-snapshot);
+ *   - typing cost per keystroke (includes history capture and commit);
  *   - the sanitise pass (runs on a 1 s debounce while typing);
  *   - snapshot weight → the undo depth actually available at that size;
  *   - undo latency;
@@ -119,8 +119,25 @@
 
     const typing = [];
     for (let i = 0; i < 5; i += 1) {
+      // execCommand does not consistently emit beforeinput in headless
+      // browsers. Drive the same observable transaction as a real collapsed
+      // insertText edit so the benchmark measures the production fast path.
       const t0 = performance.now();
-      document.execCommand('insertText', false, 'x');
+      mid.dispatchEvent(new InputEvent('beforeinput', {
+        bubbles: true,
+        inputType: 'insertText',
+        data: 'x',
+      }));
+      const selection = window.getSelection();
+      const node = selection.anchorNode;
+      const offset = selection.anchorOffset;
+      node.nodeValue = node.nodeValue.slice(0, offset) + 'x' + node.nodeValue.slice(offset);
+      selection.collapse(node, offset + 1);
+      mid.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        inputType: 'insertText',
+        data: 'x',
+      }));
       typing.push(performance.now() - t0);
       await wait(600); // outside the coalesce window → each keystroke is a full commit
     }

--- a/js/transcript-bench.js
+++ b/js/transcript-bench.js
@@ -102,6 +102,16 @@
     const t = document.getElementById('hypertranscript');
     await prepareDocument(words, first);
 
+    // Document replacement is a global-dirty event. Settle it outside every
+    // timed sample so the pass below measures steady-state paragraph editing,
+    // not benchmark setup or project birth.
+    if (typeof window.hyperaudioFlushTranscriptMaintenance === 'function') {
+      window.hyperaudioFlushTranscriptMaintenance('benchmark-prepare', {
+        force: true,
+        global: true,
+      });
+    }
+
     const spans = t.querySelectorAll('span[data-m]');
     const mid = spans[Math.floor(spans.length / 2)];
     t.focus();
@@ -116,9 +126,23 @@
     }
 
     const sanitise = [];
+    if (window.transcriptReconciliation
+        && typeof window.transcriptReconciliation.cancel === 'function') {
+      window.transcriptReconciliation.cancel();
+    }
     for (let i = 0; i < 3; i += 1) {
+      // Measure the pass that really runs during editing. On editors with
+      // scoped maintenance this requests the current paragraph and suppresses
+      // the longer settle reconciliation; older builds fall back to the
+      // history-restore hook, which was the only exposed sanitise barrier.
+      if (typeof window.hyperaudioRequestTranscriptMaintenance === 'function') {
+        window.hyperaudioRequestTranscriptMaintenance(mid.closest('p'),
+          'benchmark-sanitise', { reconcile: false });
+      }
       const t0 = performance.now();
-      if (typeof window.hyperaudioNormalizeAfterHistoryRestore === 'function') {
+      if (typeof window.hyperaudioFlushTranscriptMaintenance === 'function') {
+        window.hyperaudioFlushTranscriptMaintenance('benchmark-sanitise');
+      } else if (typeof window.hyperaudioNormalizeAfterHistoryRestore === 'function') {
         window.hyperaudioNormalizeAfterHistoryRestore();
       }
       sanitise.push(performance.now() - t0);

--- a/js/transcript-gateway.js
+++ b/js/transcript-gateway.js
@@ -110,6 +110,7 @@
       id: ++transactionId,
       origin: opts.origin || 'unknown',
       foldPolicy: opts.foldPolicy || null,
+      captureHistory: opts.captureHistory !== false,
     });
     currentTransaction = transaction;
     mutationDepth = 1;
@@ -130,6 +131,7 @@
         id: transaction.id,
         origin: transaction.origin,
         foldPolicy: transaction.foldPolicy,
+        captureHistory: transaction.captureHistory,
         error,
       }));
     }

--- a/js/transcript-history.js
+++ b/js/transcript-history.js
@@ -23,6 +23,8 @@
   let compositionTimer = null;
   let shortcutToken = null;
   let shortcutSerial = 0;
+  let fullSnapshotCount = 0;
+  let reusedSnapshotCount = 0;
 
   function transcript() {
     return document.getElementById('hypertranscript');
@@ -163,6 +165,7 @@
   function snapshot(origin) {
     const root = validTranscript();
     if (!root) return null;
+    fullSnapshotCount += 1;
     const clone = cleanClone(root);
     const html = clone.innerHTML;
     // The fingerprint is only ever compared for EQUALITY (the fold decisions
@@ -180,6 +183,28 @@
       origin: origin || 'unknown',
       timestamp: Date.now(),
       bytes: html.length * 2,
+    });
+  }
+
+  // Every controlled document mutation commits an "after" snapshot before the
+  // next edit can begin, so the current history entry already IS the next
+  // edit's document-level "before" state. Reuse its immutable HTML/fingerprint
+  // and refresh only the live selection. This removes one full clone + semantic
+  // walk from every key without changing entry shape or undo granularity.
+  // If history has no usable head (initialisation/identity edge cases), retain
+  // the original full-snapshot fallback.
+  function snapshotFromCurrent(origin) {
+    const root = validTranscript();
+    const current = position >= 0 ? entries[position] : null;
+    if (!root || !current) return snapshot(origin);
+    reusedSnapshotCount += 1;
+    return Object.freeze({
+      html: current.html,
+      semanticFingerprint: current.semanticFingerprint,
+      selection: captureSelection(root),
+      origin: origin || 'unknown',
+      timestamp: Date.now(),
+      bytes: current.bytes,
     });
   }
 
@@ -347,7 +372,7 @@
       gatewayBefore = null;
       return;
     }
-    gatewayBefore = snapshot(`before-${transaction.origin}`);
+    gatewayBefore = snapshotFromCurrent(`before-${transaction.origin}`);
     rememberPreEditSelection(gatewayBefore);
   });
 
@@ -386,7 +411,10 @@
       return;
     }
     if (gateway.isRestoring || gateway.isMutating || composing || event.isComposing) return;
-    pendingNative = { before: snapshot(`before-${event.inputType}`), inputType: event.inputType || 'native' };
+    pendingNative = {
+      before: snapshotFromCurrent(`before-${event.inputType}`),
+      inputType: event.inputType || 'native',
+    };
     rememberPreEditSelection(pendingNative.before);
     if (boundaryInput(pendingNative.inputType)) lastNative = null;
   }, true);
@@ -413,7 +441,7 @@
     if (!inTranscript(event.target) || captionMode()) return;
     composing = true;
     clearPending();
-    compositionBefore = snapshot('before-composition');
+    compositionBefore = snapshotFromCurrent('before-composition');
     rememberPreEditSelection(compositionBefore);
   }, true);
 
@@ -501,6 +529,12 @@
     reset,
     flushPending: clearPending,
     // Diagnostics used by bounded-history and cross-engine protocol tests.
-    inspect: () => ({ length: entries.length, position, totalBytes }),
+    inspect: () => ({
+      length: entries.length,
+      position,
+      totalBytes,
+      fullSnapshotCount,
+      reusedSnapshotCount,
+    }),
   });
 })();

--- a/js/transcript-history.js
+++ b/js/transcript-history.js
@@ -343,11 +343,20 @@
 
   gateway.onBeforeMutate((transaction) => {
     clearPending();
+    if (transaction.captureHistory === false) {
+      gatewayBefore = null;
+      return;
+    }
     gatewayBefore = snapshot(`before-${transaction.origin}`);
     rememberPreEditSelection(gatewayBefore);
   });
 
   gateway.onAfterMutate((transaction) => {
+    if (transaction.captureHistory === false) {
+      gatewayBefore = null;
+      updateControls();
+      return;
+    }
     const before = gatewayBefore;
     gatewayBefore = null;
     const after = snapshot(transaction.origin);

--- a/js/transcript-history.js
+++ b/js/transcript-history.js
@@ -227,6 +227,28 @@
     return entry.kind === 'paragraph' ? entry.afterSelection : entry.selection;
   }
 
+  function paragraphSelectionInRoot(root, paragraphIndex, saved) {
+    if (!saved) return saved;
+    // Paragraph entries use offsets relative to their own scope. Full entries
+    // are restored against the transcript root, so promotion must add the
+    // preceding transcript text exactly once.
+    const paragraph = root.querySelectorAll('p')[paragraphIndex];
+    if (!paragraph) return null;
+    const base = pointOffset(root, paragraph, 0);
+    if (base === null) return null;
+    return {
+      anchor: base + saved.anchor,
+      focus: base + saved.focus,
+      backward: saved.backward,
+    };
+  }
+
+  function entrySelectionInRoot(root, entry, selection) {
+    return entry.kind === 'paragraph'
+      ? paragraphSelectionInRoot(root, entry.paragraphIndex, selection)
+      : selection;
+  }
+
   function replaceParagraph(container, paragraphIndex, html) {
     const paragraph = container.querySelectorAll('p')[paragraphIndex];
     if (!paragraph) return false;
@@ -262,7 +284,7 @@
       kind: 'full',
       html,
       semanticFingerprint: fingerprintHash(semanticFingerprint(container)),
-      selection: entryAfterSelection(source),
+      selection: entrySelectionInRoot(container, source, entryAfterSelection(source)),
       origin: 'history-checkpoint',
       timestamp: Date.now(),
       bytes: html.length * 2,
@@ -346,7 +368,8 @@
       kind: 'full',
       html,
       semanticFingerprint: fingerprintHash(semanticFingerprint(container)),
-      selection: entryAfterSelection(entries[position]),
+      selection: entrySelectionInRoot(container, entries[position],
+        entryAfterSelection(entries[position])),
       origin: origin || 'history-state',
       timestamp: Date.now(),
       bytes: html.length * 2,
@@ -536,8 +559,19 @@
       if (position === 0) replaceCurrent(after);
       else {
         const current = entries[position];
+        let beforeSelection = current.beforeSelection;
+        if (current.kind === 'paragraph') {
+          const previousHtml = materialize(position - 1);
+          if (previousHtml === null) beforeSelection = null;
+          else {
+            const previous = document.createElement('div');
+            previous.innerHTML = previousHtml;
+            beforeSelection = entrySelectionInRoot(previous, current,
+              current.beforeSelection);
+          }
+        }
         replaceCurrent(Object.freeze({
-          ...fullEntry({ selection: current.beforeSelection }, after),
+          ...fullEntry({ selection: beforeSelection }, after),
           origin: transaction.origin,
         }));
       }

--- a/js/transcript-history.js
+++ b/js/transcript-history.js
@@ -1,14 +1,12 @@
-/* Bounded snapshot undo/redo for the live transcript DOM (#400). */
+/* Bounded hybrid undo/redo for the live transcript DOM (#400, #517). */
 
 (function () {
   'use strict';
 
   const MAX_ENTRIES = 100;
-  // 48MB, from 12 (#510): entries are proportional to document size, so a
-  // byte cap is really a depth dial — at 12MB a one-hour interview transcript
-  // (~1.4MB per entry once the fingerprint is hashed) kept undo ~8 deep, and
-  // before the hashing, ~3. 48MB holds ~30+ entries there; MAX_ENTRIES still
-  // governs small documents. The durable fix is delta entries — #510.
+  // 48MB, raised from 12MB in #510. Full checkpoints remain proportional to
+  // document size; ordinary collapsed typing now stores paragraph deltas, so
+  // this cap mainly bounds mixed histories and large structural operations.
   const MAX_BYTES = 48 * 1024 * 1024;
   const COALESCE_MS = 500;
   const gateway = window.transcriptGateway;
@@ -24,7 +22,7 @@
   let shortcutToken = null;
   let shortcutSerial = 0;
   let fullSnapshotCount = 0;
-  let reusedSnapshotCount = 0;
+  let paragraphSnapshotCount = 0;
 
   function transcript() {
     return document.getElementById('hypertranscript');
@@ -177,6 +175,7 @@
     // rides along as a collision guard.
     const fingerprint = fingerprintHash(semanticFingerprint(clone));
     return Object.freeze({
+      kind: 'full',
       html,
       semanticFingerprint: fingerprint,
       selection: captureSelection(root),
@@ -186,25 +185,28 @@
     });
   }
 
-  // Every controlled document mutation commits an "after" snapshot before the
-  // next edit can begin, so the current history entry already IS the next
-  // edit's document-level "before" state. Reuse its immutable HTML/fingerprint
-  // and refresh only the live selection. This removes one full clone + semantic
-  // walk from every key without changing entry shape or undo granularity.
-  // If history has no usable head (initialisation/identity edge cases), retain
-  // the original full-snapshot fallback.
-  function snapshotFromCurrent(origin) {
+  function paragraphBefore(origin) {
     const root = validTranscript();
-    const current = position >= 0 ? entries[position] : null;
-    if (!root || !current) return snapshot(origin);
-    reusedSnapshotCount += 1;
+    const selection = window.getSelection();
+    if (!root || !selection || selection.rangeCount !== 1 || !selection.isCollapsed) return null;
+    const node = selection.anchorNode;
+    const element = node && node.nodeType === Node.ELEMENT_NODE ? node : node && node.parentElement;
+    const paragraph = element && element.closest ? element.closest('p') : null;
+    if (!paragraph || !root.contains(paragraph)) return null;
+    const paragraphs = Array.from(root.querySelectorAll('p'));
+    const paragraphIndex = paragraphs.indexOf(paragraph);
+    if (paragraphIndex < 0) return null;
+    const clone = cleanClone(paragraph);
+    paragraphSnapshotCount += 1;
     return Object.freeze({
-      html: current.html,
-      semanticFingerprint: current.semanticFingerprint,
-      selection: captureSelection(root),
+      kind: 'paragraph-before',
+      paragraph,
+      paragraphIndex,
+      paragraphCount: paragraphs.length,
+      html: clone.outerHTML,
+      selection: captureSelection(paragraph),
       origin: origin || 'unknown',
       timestamp: Date.now(),
-      bytes: current.bytes,
     });
   }
 
@@ -221,10 +223,58 @@
     if (redoButton) redoButton.disabled = disabled || position < 0 || position >= entries.length - 1;
   }
 
+  function entryAfterSelection(entry) {
+    return entry.kind === 'paragraph' ? entry.afterSelection : entry.selection;
+  }
+
+  function replaceParagraph(container, paragraphIndex, html) {
+    const paragraph = container.querySelectorAll('p')[paragraphIndex];
+    if (!paragraph) return false;
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    const replacement = template.content.firstElementChild;
+    if (!replacement || !replacement.matches('p')) return false;
+    paragraph.replaceWith(replacement);
+    return true;
+  }
+
+  function materialize(wantedPosition) {
+    if (wantedPosition < 0 || wantedPosition >= entries.length) return null;
+    let checkpoint = wantedPosition;
+    while (checkpoint >= 0 && entries[checkpoint].kind !== 'full') checkpoint -= 1;
+    if (checkpoint < 0) return null;
+    const container = document.createElement('div');
+    container.innerHTML = entries[checkpoint].html;
+    for (let index = checkpoint + 1; index <= wantedPosition; index += 1) {
+      const entry = entries[index];
+      if (entry.kind === 'full') container.innerHTML = entry.html;
+      else if (!replaceParagraph(container, entry.paragraphIndex, entry.afterHtml)) return null;
+    }
+    return container.innerHTML;
+  }
+
+  function checkpointFrom(positionToMaterialize, source) {
+    const html = materialize(positionToMaterialize);
+    if (html === null) return null;
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    return Object.freeze({
+      kind: 'full',
+      html,
+      semanticFingerprint: fingerprintHash(semanticFingerprint(container)),
+      selection: entryAfterSelection(source),
+      origin: 'history-checkpoint',
+      timestamp: Date.now(),
+      bytes: html.length * 2,
+    });
+  }
+
   function prune() {
     while (entries.length > 1 && (entries.length > MAX_ENTRIES || totalBytes > MAX_BYTES)) {
-      totalBytes -= entries[0].bytes;
-      entries.shift();
+      const nextBaseline = checkpointFrom(1, entries[1]);
+      if (!nextBaseline) break;
+      totalBytes += nextBaseline.bytes - entries[0].bytes - entries[1].bytes;
+      entries.splice(0, 2, nextBaseline);
       position -= 1;
     }
   }
@@ -237,22 +287,8 @@
     updateControls();
   }
 
-  function rememberPreEditSelection(before) {
-    if (before && position >= 0
-        && entries[position].semanticFingerprint === before.semanticFingerprint
-        && !sameSelection(entries[position].selection, before.selection)) {
-      replaceCurrent(before);
-    }
-  }
-
   function push(next) {
     if (!next) return false;
-    const current = entries[position];
-    if (current && current.semanticFingerprint === next.semanticFingerprint) {
-      // Selection is useful even when the document did not change.
-      replaceCurrent(next);
-      return false;
-    }
     if (position < entries.length - 1) {
       entries.slice(position + 1).forEach((entry) => { totalBytes -= entry.bytes; });
       entries.length = position + 1;
@@ -263,6 +299,58 @@
     prune();
     updateControls();
     return true;
+  }
+
+  function fullEntry(before, after) {
+    return Object.freeze({
+      kind: 'full',
+      html: after.html,
+      semanticFingerprint: after.semanticFingerprint,
+      beforeSelection: before.selection,
+      selection: after.selection,
+      origin: after.origin,
+      timestamp: after.timestamp,
+      bytes: after.bytes,
+    });
+  }
+
+  function localEntry(before, origin) {
+    const root = validTranscript();
+    if (!root || !before.paragraph.isConnected) return null;
+    const paragraphs = root.querySelectorAll('p');
+    if (paragraphs.length !== before.paragraphCount
+        || paragraphs[before.paragraphIndex] !== before.paragraph) return null;
+    const clone = cleanClone(before.paragraph);
+    const afterHtml = clone.outerHTML;
+    if (afterHtml === before.html) return null;
+    return Object.freeze({
+      kind: 'paragraph',
+      paragraphIndex: before.paragraphIndex,
+      beforeHtml: before.html,
+      afterHtml,
+      beforeSelection: before.selection,
+      afterSelection: captureSelection(before.paragraph),
+      origin: origin || before.origin,
+      timestamp: Date.now(),
+      bytes: (before.html.length + afterHtml.length) * 2,
+    });
+  }
+
+  function stateSnapshot(origin) {
+    const root = validTranscript();
+    const html = materialize(position);
+    if (!root || html === null) return snapshot(origin);
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    return Object.freeze({
+      kind: 'full',
+      html,
+      semanticFingerprint: fingerprintHash(semanticFingerprint(container)),
+      selection: entryAfterSelection(entries[position]),
+      origin: origin || 'history-state',
+      timestamp: Date.now(),
+      bytes: html.length * 2,
+    });
   }
 
   function clearPending() {
@@ -299,6 +387,40 @@
   }
 
   function commitNative(before, inputType, origin) {
+    if (before && before.kind === 'paragraph-before') {
+      const local = localEntry(before, origin || inputType);
+      if (local) {
+        const category = inputCategory(inputType);
+        const now = Date.now();
+        const coalesce = lastNative
+          && lastNative.category === category
+          && now - lastNative.at <= COALESCE_MS
+          && lastNative.generation === (window.transcriptLifecycle
+            ? window.transcriptLifecycle.generation() : 0)
+          && sameSelection(lastNative.selection, local.beforeSelection)
+          && position === entries.length - 1
+          && entries[position].kind === 'paragraph'
+          && entries[position].paragraphIndex === local.paragraphIndex;
+        if (coalesce) {
+          const current = entries[position];
+          replaceCurrent(Object.freeze({
+            ...current,
+            afterHtml: local.afterHtml,
+            afterSelection: local.afterSelection,
+            timestamp: local.timestamp,
+            bytes: (current.beforeHtml.length + local.afterHtml.length) * 2,
+          }));
+        } else push(local);
+        lastNative = {
+          category,
+          at: now,
+          selection: local.afterSelection,
+          generation: window.transcriptLifecycle ? window.transcriptLifecycle.generation() : 0,
+        };
+        return;
+      }
+      before = stateSnapshot(`before-${inputType}`);
+    }
     const after = snapshot(origin || inputType);
     if (!after || !before || before.semanticFingerprint === after.semanticFingerprint) return;
     const category = inputCategory(inputType);
@@ -310,8 +432,13 @@
         ? window.transcriptLifecycle.generation() : 0)
       && sameSelection(lastNative.selection, before.selection)
       && position === entries.length - 1;
-    if (coalesce) replaceCurrent(after);
-    else push(after);
+    const entry = fullEntry(before, after);
+    if (coalesce && entries[position].kind === 'full' && position > 0) {
+      replaceCurrent(Object.freeze({
+        ...entry,
+        beforeSelection: entries[position].beforeSelection,
+      }));
+    } else push(entry);
     lastNative = {
       category,
       at: now,
@@ -325,12 +452,29 @@
     clearPending();
     const nextPosition = position + direction;
     if (nextPosition < 0 || nextPosition >= entries.length) return false;
-    const target = entries[nextPosition];
+    const operation = direction < 0 ? entries[position] : entries[nextPosition];
     const root = transcript();
     const origin = direction < 0 ? 'undo' : 'redo';
     gateway.restoring(() => {
-      root.innerHTML = target.html;
-      restoreSelection(root, target.selection, !!(options && options.focus));
+      let selectionRoot = root;
+      let savedSelection;
+      if (operation.kind === 'paragraph') {
+        const html = direction < 0 ? operation.beforeHtml : operation.afterHtml;
+        if (replaceParagraph(root, operation.paragraphIndex, html)) {
+          selectionRoot = root.querySelectorAll('p')[operation.paragraphIndex];
+          savedSelection = direction < 0
+            ? operation.beforeSelection : operation.afterSelection;
+        } else {
+          root.innerHTML = materialize(nextPosition) || root.innerHTML;
+          savedSelection = entryAfterSelection(entries[nextPosition]);
+        }
+      } else {
+        root.innerHTML = direction < 0
+          ? (materialize(nextPosition) || root.innerHTML) : operation.html;
+        savedSelection = direction < 0 ? operation.beforeSelection : operation.selection;
+      }
+      if (options && options.focus) root.focus({ preventScroll: true });
+      restoreSelection(selectionRoot, savedSelection, false);
       root.dispatchEvent(new InputEvent('input', {
         bubbles: true,
         inputType: origin === 'undo' ? 'historyUndo' : 'historyRedo',
@@ -372,8 +516,7 @@
       gatewayBefore = null;
       return;
     }
-    gatewayBefore = snapshotFromCurrent(`before-${transaction.origin}`);
-    rememberPreEditSelection(gatewayBefore);
+    gatewayBefore = snapshot(`before-${transaction.origin}`);
   });
 
   gateway.onAfterMutate((transaction) => {
@@ -389,11 +532,17 @@
       updateControls();
       return;
     }
-    if (transaction.foldPolicy === 'normalization' && position >= 0
-        && entries[position].semanticFingerprint === before.semanticFingerprint) {
-      replaceCurrent(after); // deliberately preserves redo
+    if (transaction.foldPolicy === 'normalization' && position >= 0) {
+      if (position === 0) replaceCurrent(after);
+      else {
+        const current = entries[position];
+        replaceCurrent(Object.freeze({
+          ...fullEntry({ selection: current.beforeSelection }, after),
+          origin: transaction.origin,
+        }));
+      }
     } else {
-      push(after);
+      push(fullEntry(before, after));
     }
   });
 
@@ -411,11 +560,13 @@
       return;
     }
     if (gateway.isRestoring || gateway.isMutating || composing || event.isComposing) return;
+    const inputType = event.inputType || 'native';
     pendingNative = {
-      before: snapshotFromCurrent(`before-${event.inputType}`),
-      inputType: event.inputType || 'native',
+      before: inputType === 'insertText'
+        ? (paragraphBefore(`before-${inputType}`) || snapshot(`before-${inputType}`))
+        : snapshot(`before-${inputType}`),
+      inputType,
     };
-    rememberPreEditSelection(pendingNative.before);
     if (boundaryInput(pendingNative.inputType)) lastNative = null;
   }, true);
 
@@ -433,7 +584,7 @@
     }
     const pending = pendingNative;
     pendingNative = null;
-    commitNative(pending ? pending.before : entries[position],
+    commitNative(pending ? pending.before : stateSnapshot(`before-${event.inputType || 'native'}`),
       pending ? pending.inputType : (event.inputType || 'native'), event.inputType || 'native');
   }, true);
 
@@ -441,8 +592,7 @@
     if (!inTranscript(event.target) || captionMode()) return;
     composing = true;
     clearPending();
-    compositionBefore = snapshotFromCurrent('before-composition');
-    rememberPreEditSelection(compositionBefore);
+    compositionBefore = snapshot('before-composition');
   }, true);
 
   document.addEventListener('compositionend', (event) => {
@@ -534,7 +684,11 @@
       position,
       totalBytes,
       fullSnapshotCount,
-      reusedSnapshotCount,
+      paragraphSnapshotCount,
+      // Compatibility alias for point-1 benchmark reports.
+      reusedSnapshotCount: paragraphSnapshotCount,
+      localEntries: entries.filter((entry) => entry.kind === 'paragraph').length,
+      fullEntries: entries.filter((entry) => entry.kind === 'full').length,
     }),
   });
 })();

--- a/js/transcript-maintenance.js
+++ b/js/transcript-maintenance.js
@@ -1,0 +1,110 @@
+/* Collapsed maintenance queue for expensive transcript-wide derived work. */
+
+(function (root) {
+  'use strict';
+
+  function createTranscriptMaintenanceQueue(options) {
+    const opts = options || {};
+    if (typeof opts.run !== 'function') {
+      throw new TypeError('createTranscriptMaintenanceQueue expects a run function');
+    }
+
+    const delay = Number.isFinite(opts.delay) ? Math.max(0, opts.delay) : 1000;
+    const canRun = typeof opts.canRun === 'function' ? opts.canRun : () => true;
+    const setTimer = opts.setTimer || setTimeout;
+    const clearTimer = opts.clearTimer || clearTimeout;
+    let timer = null;
+    let dirty = false;
+    let running = false;
+    let destroyed = false;
+    let scheduledCount = 0;
+    let runCount = 0;
+    let lastReason = null;
+
+    function cancelTimer() {
+      if (timer === null) return;
+      clearTimer(timer);
+      timer = null;
+    }
+
+    function schedule(reason) {
+      if (destroyed || !dirty) return false;
+      cancelTimer();
+      lastReason = reason || lastReason || 'scheduled';
+      if (!canRun()) return false;
+      scheduledCount += 1;
+      timer = setTimer(() => {
+        timer = null;
+        flush(lastReason || 'scheduled');
+      }, delay);
+      return true;
+    }
+
+    function markDirty(reason) {
+      if (destroyed) return false;
+      dirty = true;
+      return schedule(reason || 'dirty');
+    }
+
+    function flush(reason, flushOptions) {
+      const force = !!(flushOptions && flushOptions.force);
+      if (destroyed || running || (!dirty && !force)) return false;
+      cancelTimer();
+      if (!canRun()) {
+        dirty = true;
+        return false;
+      }
+
+      dirty = false;
+      running = true;
+      lastReason = reason || lastReason || 'flush';
+      try {
+        opts.run(lastReason);
+        runCount += 1;
+      } catch (error) {
+        dirty = true;
+        throw error;
+      } finally {
+        running = false;
+        if (dirty) schedule('reentrant');
+      }
+      return true;
+    }
+
+    function destroy() {
+      cancelTimer();
+      dirty = false;
+      destroyed = true;
+    }
+
+    function cancel() {
+      if (destroyed) return false;
+      const hadWork = dirty || timer !== null;
+      cancelTimer();
+      dirty = false;
+      return hadWork;
+    }
+
+    return Object.freeze({
+      markDirty,
+      schedule,
+      flush,
+      cancel,
+      destroy,
+      inspect: () => Object.freeze({
+        dirty,
+        pending: timer !== null,
+        running,
+        destroyed,
+        scheduledCount,
+        runCount,
+        lastReason,
+      }),
+    });
+  }
+
+  if (root) root.createTranscriptMaintenanceQueue = createTranscriptMaintenanceQueue;
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { createTranscriptMaintenanceQueue };
+  }
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
Performance and correctness work on the editing core, plus fixes found in day-of-use testing.

**Transcript performance rework** (adopting scarsellifi's `perf/517-transcript-performance`, with merge-time fixes): maintenance after a keystroke is now paragraph-local, driven by MutationObserver dirty scopes, with global reconciliation deferred to a ~3s idle queue; undo history stores paragraph deltas for plain typing and full checkpoints for structural edits. Keystroke maintenance drops from ~65ms to ~3ms on a 40k-word transcript, and practical undo depth rises from 9 to 72 steps. Paste boundaries (#514 semantics) are preserved through the new history paths.

- The caret no longer jumps after typing then pausing — the paragraph-local pass now resolves its host for the focus check (regression of the #511 guard, caught before release).
- The caret restore is block-aware, so Enter/split boundaries resolve to the right paragraph (#530).
- Undoing back to the last save clears the dirty save indicator immediately, however many undo steps it takes — with caption sync on, the derived VTT no longer races the deferred regeneration in the saved-state comparison.
- A transcription in flight no longer plays the previous project's captions over its video, on both the engine-start and switch-back paths.
- Projects opened while a transcription runs are editable again (missing `contenteditable` restore, present since 1.2.5).

Fixes #530. Addresses the scoped-scan half of #398 (via the #517 rework); the incremental `wordArr` splice on split/merge remains open there.

New e2e coverage across all of the above; 196 tests green (1 known Playwright-WebKit OPFS skip).
