### PR TITLE
Version 1.3.1

### DIFF
--- a/__TEST__/e2e/caption-track-reset.spec.mjs
+++ b/__TEST__/e2e/caption-track-reset.spec.mjs
@@ -369,8 +369,8 @@ test('Regenerate turns caption sync back on until the next caption edit', async 
   await page.waitForFunction(() => document.querySelectorAll('#captions-display .caption').length > 0);
   // entering with sync off raises the "Captions have been edited" notice,
   // which sits over the first rows and intercepts clicks (#506)
-  const alertBox = page.locator('#captionsource-alert');
-  if (await alertBox.isVisible()) await page.click('#captionsource-alert-ok');
+  const divergence = page.locator('#project-dialog.modal-open');
+  if (await divergence.isVisible()) await page.click('#project-dialog-confirm');
   // the real flow: the floating Regenerate opens the confirm modal, Confirm
   // fires the handler and closes it (both are modal-toggle labels)
   await page.click('#regenerate-float-btn');
@@ -382,4 +382,61 @@ test('Regenerate turns caption sync back on until the next caption edit', async 
   await page.locator('#captions-display .caption input.line1').first().click();
   await page.keyboard.type('X');
   expect(await page.evaluate(() => updateCaptionsFromTranscript)).toBe(false);
+});
+
+// #506 — the divergence notice rides the shared dialog chassis: a real modal
+// in the warning dress, raised on caption-editor ENTRY when captions are
+// curated (raising at project open blocked the whole app behind a backdrop,
+// boot included). The old absolute-positioned alert silently ate clicks on
+// the caption rows beneath it, and its loud pink button was the one with
+// lasting consequences. Now only the explicit button press persists the
+// "don't tell me again" choice; OK and ✕/Escape just acknowledge.
+test('the caption divergence notice is a house-style warning modal (#506)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  await page.evaluate(() => { updateCaptionsFromTranscript = false; });
+
+  const enterCaptions = async () => {
+    await page.click('#caption-editor-btn');
+    await page.waitForFunction(() => document.querySelectorAll('#captions-display .caption').length > 0);
+  };
+  const leaveCaptions = () => page.click('#transcript-editor-btn');
+
+  await enterCaptions();
+  const dialog = page.locator('#project-dialog.modal-open');
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator('.modal-box')).toHaveClass(/modal-warning/);
+  await expect(dialog.locator('#project-dialog-title')).toContainText('Captions have been edited');
+
+  // OK acknowledges without persisting: the notice returns next entry
+  await page.click('#project-dialog-confirm');
+  await expect(dialog).not.toBeVisible();
+  expect(await page.evaluate(() => localStorage.getItem('noCaptionAlert'))).toBeNull();
+  await leaveCaptions();
+  await enterCaptions();
+  await expect(dialog).toBeVisible();
+
+  // Escape is a shrug, not a choice — nothing persists either
+  await page.keyboard.press('Escape');
+  await expect(dialog).not.toBeVisible();
+  expect(await page.evaluate(() => localStorage.getItem('noCaptionAlert'))).toBeNull();
+
+  // the explicit button is the only thing that persists the choice
+  await leaveCaptions();
+  await enterCaptions();
+  await expect(dialog).toBeVisible();
+  await page.click('#project-dialog-cancel');
+  await expect(dialog).not.toBeVisible();
+  expect(await page.evaluate(() => localStorage.getItem('noCaptionAlert'))).toBe('true');
+  await leaveCaptions();
+  await enterCaptions();
+  await page.waitForTimeout(400);
+  await expect(dialog).not.toBeVisible();
+
+  // ...and the warning dress does not leak onto ordinary dialogs
+  await page.evaluate(() => { window.HyperaudioSave.dialog('plain', { cancel: false }); });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator('.modal-box')).not.toHaveClass(/modal-warning/);
+  await expect(dialog.locator('#project-dialog-title')).toBeHidden();
+  await page.click('#project-dialog-confirm');
 });

--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -318,6 +318,9 @@ test('edit tracking survives the caption-mode round trip (#448 delegation)', asy
   // the round trip that REPLACES #hypertranscript — direct listeners died here
   await page.click('#caption-editor-btn');
   await page.waitForTimeout(400);
+  // curated captions raise the divergence notice on entry (#506) — dismiss
+  const divergence = page.locator('#project-dialog.modal-open');
+  if (await divergence.isVisible()) await page.click('#project-dialog-confirm');
   await page.click('#transcript-editor-btn');
   await page.waitForTimeout(400);
 
@@ -1018,9 +1021,9 @@ const enterCaptionMode = async (page) => {
   // been edited" notice, and it sits OVER the first caption rows, intercepting
   // clicks — dismiss it the way a user must (see #506, which is about that
   // notice's design).
-  const alertBox = page.locator('#captionsource-alert');
-  if (await alertBox.isVisible()) await page.click('#captionsource-alert-ok');
-  await expect(alertBox).toBeHidden();
+  const divergence = page.locator('#project-dialog.modal-open');
+  if (await divergence.isVisible()) await page.click('#project-dialog-confirm');
+  await expect(divergence).toBeHidden();
 };
 
 for (const action of ['insert', 'merge', 'delete']) {

--- a/__TEST__/e2e/responsive.spec.mjs
+++ b/__TEST__/e2e/responsive.spec.mjs
@@ -105,6 +105,23 @@ test.describe('touch devices', () => {
   test.use({ isMobile: true, hasTouch: true });
 
   test('undo/redo float on the card edge, clear of the copy button and the text', async ({ page }) => {
+    // Since #524 a button with nothing to do is hidden, so earn both first:
+    // an edit makes undo available, undoing it makes redo available.
+    await page.evaluate(() => {
+      const t = document.querySelector('#hypertranscript');
+      t.focus();
+      const span = t.querySelector('span[data-m]');
+      const sel = window.getSelection();
+      const r = document.createRange();
+      r.setStart(span.firstChild, 1);
+      r.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(r);
+    });
+    await page.keyboard.type('X');
+    await page.waitForTimeout(1700); // fold boundary: the next run is its own entry
+    await page.keyboard.type('Y');
+    await page.click('#transcript-undo'); // one entry back: both directions live
     const boxes = await page.evaluate(() => {
       const box = (s) => {
         const el = document.querySelector(s);
@@ -132,5 +149,46 @@ test.describe('touch devices', () => {
     // ↶ ↷ 📋 in a row, no overlaps
     expect(boxes.undo.right).toBeLessThanOrEqual(boxes.redo.left);
     if (boxes.copy !== null) expect(boxes.redo.right).toBeLessThanOrEqual(boxes.copy.left);
+  });
+
+  // #524 — a disabled button earns no corner space: it disappears rather than
+  // greying. Slots stay fixed — a slid-in neighbour would land under the
+  // finger mid-undo-run; a vanished button leaves the finger over nothing.
+  test('only actionable undo/redo buttons occupy the corner (#524)', async ({ page }) => {
+    const undo = page.locator('#transcript-undo');
+    const redo = page.locator('#transcript-redo');
+    // a fresh page has nothing to undo or redo: a clean two-button corner
+    await expect(undo).toBeHidden();
+    await expect(redo).toBeHidden();
+
+    await page.evaluate(() => {
+      const t = document.querySelector('#hypertranscript');
+      t.focus();
+      const span = t.querySelector('span[data-m]');
+      const sel = window.getSelection();
+      const r = document.createRange();
+      r.setStart(span.firstChild, 1);
+      r.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(r);
+    });
+    await page.keyboard.type('X');
+    await expect(undo).toBeVisible();  // something to undo now
+    await expect(redo).toBeHidden();   // still nothing to redo
+
+    await page.click('#transcript-undo');
+    await expect(redo).toBeVisible();  // the undo made redo actionable
+    const redoSlot = await redo.boundingBox();
+
+    // undo history exhausted: ↶ vanishes, ↷ HOLDS ITS SLOT (no sliding)
+    await expect(undo).toBeHidden({ timeout: 6000 });
+    const redoSlotAfter = await redo.boundingBox();
+    expect(Math.abs(redoSlotAfter.x - redoSlot.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(redoSlotAfter.y - redoSlot.y)).toBeLessThanOrEqual(1);
+
+    // and redoing brings ↶ back while ↷ empties and vanishes
+    await page.click('#transcript-redo');
+    await expect(undo).toBeVisible();
+    await expect(redo).toBeHidden();
   });
 });

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -1606,3 +1606,25 @@ html.ha-transcribing #upload-transcribe-btn {
   pointer-events: none;
   opacity: 0.4;
 }
+
+/* Warning dress for the shared dialog (#506): reserved for state-divergence
+   warnings ("captions have been edited") — an amber left border and a tinted
+   title band on the standard modal chassis. Bold enough that the warning
+   registers, without the full-bleed cyan alert this replaces. --wa is
+   DaisyUI's per-theme warning colour (v4: OKLCH components, so oklch() not
+   hsl()), so both themes get a fitting amber. */
+#project-dialog .modal-box.modal-warning {
+  border-left: 6px solid oklch(var(--wa));
+}
+#project-dialog .project-dialog-title {
+  background: oklch(var(--wa) / 0.18);
+  color: inherit;
+  font-weight: 700;
+  /* bleed the band to the box edges (modal-box padding is 1.5rem) */
+  margin: -1.5rem -1.5rem 1rem -1.5rem;
+  padding: 0.9rem 3rem 0.9rem 1.5rem; /* right clears the ✕ button */
+  border-radius: 1rem 1rem 0 0; /* match --rounded-box on the top corners */
+}
+#project-dialog .modal-box.modal-warning .project-dialog-title {
+  border-radius: 0.6rem 1rem 0 0; /* inner top-left sits against the border */
+}

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -716,6 +716,15 @@ html:has(#hypertranscript[aria-busy="true"]) #transcript-redo { display: none; }
   #transcript-undo { right: 92px; }   /* copy at 12px on this band */
   #transcript-redo { right: 52px; }
 }
+/* Only show what can act (#524): a disabled ↶/↷ earns no corner space on a
+   phone — it disappears instead of greying. Slots stay FIXED (no sliding
+   into the neighbour's spot): during a rapid undo-tap run, a slid-in redo
+   would land exactly under the finger the moment redo becomes available.
+   A vanished button leaves the finger over nothing, which is harmless —
+   and the common nothing-to-undo state gets its clean two-button corner
+   back. The history module sets [disabled]; this just honours it. */
+#transcript-undo[disabled],
+#transcript-redo[disabled] { display: none; }
 /* Desktop: the keyboard owns undo. Hidden entirely — the top bar stays clear
    and the corner cluster stays two buttons on the devices that don't need
    these. Must stay LAST in this block so it wins over the float rules. */

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -1637,3 +1637,12 @@ html.ha-transcribing #upload-transcribe-btn {
 #project-dialog .modal-box.modal-warning .project-dialog-title {
   border-radius: 0.6rem 1rem 0 0; /* inner top-left sits against the border */
 }
+
+/* Transcribe modal: the URL source is the rare path (and the sharp one — CORS),
+   so it sits behind a plain-disclosure reveal under the file picker instead of
+   competing with it. Native <details>: no JS, and the engines' listeners on
+   the inputs inside are untouched. */
+.url-source summary { cursor: pointer; font-size: 0.85rem; opacity: 0.7; user-select: none; width: fit-content; }
+.url-source summary:hover { opacity: 1; }
+.url-source[open] summary { margin-bottom: 10px; }
+.url-source { margin-top: 4px; }

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.0.2">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.0.3">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -149,9 +149,11 @@ If you are creating an open source application under a license compatible with t
           <span class="label-text" style="font-size:0.85rem; opacity:0.85">Remember key on this device</span>
         </label>
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
-        <input id="deepgram-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
-        <span class="label-text">or</span>
         <input id="deepgram-file" name="file" type="file" class="file-input w-full max-w-xs" aria-label="Media file to transcribe" title="" />
+        <details class="url-source">
+          <summary class="label-text">Transcribe from a URL instead</summary>
+          <input id="deepgram-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
+        </details>
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
   
         <label class="label-text" for="language-model">Model</label>
@@ -186,9 +188,11 @@ If you are creating an open source application under a license compatible with t
           <span class="label-text" style="font-size:0.85rem; opacity:0.85">Remember key on this device</span>
         </label>
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
-        <input id="assemblyai-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
-        <span class="label-text">or</span>
         <input id="assemblyai-file" name="file" type="file" class="file-input w-full max-w-xs" aria-label="Media file to transcribe" title="" />
+        <details class="url-source">
+          <summary class="label-text">Transcribe from a URL instead</summary>
+          <input id="assemblyai-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
+        </details>
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
 
         <label class="label-text" for="assemblyai-model">Model</label>
@@ -219,9 +223,11 @@ If you are creating an open source application under a license compatible with t
         </label>
         <span class="label-text" style="font-size:0.8rem; opacity:0.7">Create a free token at huggingface.co/settings/tokens</span>
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
-        <input id="parakeet-hf-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
-        <span class="label-text">or</span>
         <input id="parakeet-hf-file" name="file" type="file" class="file-input w-full max-w-xs" aria-label="Media file to transcribe" title="" />
+        <details class="url-source">
+          <summary class="label-text">Transcribe from a URL instead</summary>
+          <input id="parakeet-hf-media" type="text" placeholder="Link to media" class="input input-bordered w-full max-w-xs" />
+        </details>
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
 
         <label class="label-text" for="parakeet-hf-language">Language</label>
@@ -236,10 +242,12 @@ If you are creating an open source application under a license compatible with t
   <template id="whisper-client-template">
     <form>
       <div class="mb-3">
-        <input id="media" type="text" placeholder="Media or HLS (.m3u8) URL" class="input input-bordered w-full max-w-xs" />
-        <span style="display:block; padding:6px 0 0; font-size:80%; opacity:0.7" class="label-text">The source must allow cross-origin access (CORS).</span>
-        <span style="display:block; padding:16px" class="label-text">or</span>
         <input id="file-input" name="file" type="file" class="file-input w-full max-w-xs" aria-label="Media file to transcribe" title="" />
+        <details class="url-source" style="margin-top:1rem">
+          <summary class="label-text">Transcribe from a URL instead</summary>
+          <input id="media" type="text" placeholder="Media or HLS (.m3u8) URL" class="input input-bordered w-full max-w-xs" />
+          <span style="display:block; padding:6px 0 0; font-size:80%; opacity:0.7" class="label-text">The source must allow cross-origin access (CORS).</span>
+        </details>
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
       </div>
       <div class="mb-3">
@@ -301,10 +309,12 @@ If you are creating an open source application under a license compatible with t
   <template id="parakeet-local-template">
     <form>
       <div class="mb-3">
-        <input id="parakeet-media" type="text" placeholder="Media or HLS (.m3u8) URL" class="input input-bordered w-full max-w-xs" />
-        <span style="display:block; padding:6px 0 0; font-size:80%; opacity:0.7" class="label-text">The source must allow cross-origin access (CORS).</span>
-        <span style="display:block; padding:16px" class="label-text">or</span>
         <input id="parakeet-file-input" name="file" type="file" class="file-input w-full max-w-xs" aria-label="Media file to transcribe" title="" />
+        <details class="url-source" style="margin-top:1rem">
+          <summary class="label-text">Transcribe from a URL instead</summary>
+          <input id="parakeet-media" type="text" placeholder="Media or HLS (.m3u8) URL" class="input input-bordered w-full max-w-xs" />
+          <span style="display:block; padding:6px 0 0; font-size:80%; opacity:0.7" class="label-text">The source must allow cross-origin access (CORS).</span>
+        </details>
         <hr class="my-2 h-0 border border-t-0 border-solid border-neutral-700 opacity-50 dark:border-neutral-200" />
       </div>
       <div class="form-text" style="font-size: 90%;">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.3.0 (last changed in release 1.3.0) -->
+<!--  Hyperaudio Lite Editor - Version 1.3.1 (last changed in release 1.3.1) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.3.0">
+  <meta name="version" content="1.3.1">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.0.3">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.1">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1042,7 +1042,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.3.0"></script>
   <script src="js/transcript-maintenance.js?v=1.3.0"></script>
-  <script src="js/editor-core.js?v=1.3.0.1"></script>
+  <script src="js/editor-core.js?v=1.3.1"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1079,9 +1079,9 @@ If you are creating an open source application under a license compatible with t
     }
 
   </style>
-  <script src="js/editor-main.js?v=1.3.0.1"></script>
+  <script src="js/editor-main.js?v=1.3.1"></script>
   <script src="js/find-replace.js?v=1.2.0"></script>
-  <script src="js/transcript-history.js?v=1.3.0.1"></script>
+  <script src="js/transcript-history.js?v=1.3.1"></script>
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
@@ -1101,7 +1101,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.3.0.1"></script>
+  <script src="js/hyperaudio-save.js?v=1.3.1"></script>
   <script src="js/hyperaudio-library.js?v=1.2.5.3"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.0.1">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.0.2">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1071,7 +1071,7 @@ If you are creating an open source application under a license compatible with t
   </style>
   <script src="js/editor-main.js?v=1.3.0.1"></script>
   <script src="js/find-replace.js?v=1.2.0"></script>
-  <script src="js/transcript-history.js?v=1.3.0"></script>
+  <script src="js/transcript-history.js?v=1.3.0.1"></script>
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.2.5.2">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.0.1">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -787,18 +787,8 @@ If you are creating an open source application under a license compatible with t
         <option value="0.8">0.8×</option>
       </select>
     </div>
-    <div id="captionsource-alert" class="alert alert-info shadow-lg" style="visibility:hidden; z-index:2; position:absolute; top:50%; left:50%; width:480px; height:140px; margin: -240px 0 0 -240px;">
-      <div>
-        <div style="margin-top:-60px; width:400px">
-          <h3 class="font-bold">Captions have been edited.</h3>
-          <div class="text-xs">These captions may differ from the transcript. You can re-generate captions from the transcript in the Caption Editor.</div>
-        </div>
-      </div>
-      <div class="modal-action" style="margin-top:80px; margin-left:-120px">
-        <button id="captionsource-alert-cancel" class="btn btn-sm btn-secondary">don't tell me again</button>
-        <button id="captionsource-alert-ok" class="btn btn-sm btn-primary">ok</button>
-      </div>
-    </div>
+    <!-- The "captions have been edited" notice lived here until #506 — it now
+         rides the shared #project-dialog chassis (hyperaudio-save.js). -->
   </div>
 
   <!-- Media export modal (#289/#291/#292) — wired by js/media-export.js -->
@@ -1042,7 +1032,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.3.0"></script>
   <script src="js/transcript-maintenance.js?v=1.3.0"></script>
-  <script src="js/editor-core.js?v=1.3.0"></script>
+  <script src="js/editor-core.js?v=1.3.0.1"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1079,7 +1069,7 @@ If you are creating an open source application under a license compatible with t
     }
 
   </style>
-  <script src="js/editor-main.js?v=1.2.5"></script>
+  <script src="js/editor-main.js?v=1.3.0.1"></script>
   <script src="js/find-replace.js?v=1.2.0"></script>
   <script src="js/transcript-history.js?v=1.3.0"></script>
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
@@ -1101,7 +1091,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.3.0"></script>
+  <script src="js/hyperaudio-save.js?v=1.3.0.1"></script>
   <script src="js/hyperaudio-library.js?v=1.2.5.3"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -73,18 +73,8 @@
     return fn();
   }
 
-  let alertOkBtn = document.querySelector('#captionsource-alert-ok');
-
-  alertOkBtn.addEventListener('click', function() {
-    document.querySelector('#captionsource-alert').style.visibility = "hidden";
-  });
-
-  let alertCancelBtn = document.querySelector('#captionsource-alert-cancel');
-
-  alertCancelBtn.addEventListener('click', function() {
-    document.querySelector('#captionsource-alert').style.visibility = "hidden";
-    localStorage.setItem("noCaptionAlert", "true");
-  });
+  // (The #captionsource-alert wiring lived here until #506 — the divergence
+  // warning now rides the shared dialog chassis, raised from editor-main.)
 
   let editableDiv = document.querySelector('#hypertranscript');
 
@@ -281,6 +271,27 @@
     captionMode = true;
     hyperaudioGenerateCaptionsFromTranscript();
     reflectViewSwitch();
+    // The divergence warning (#506), raised where it's relevant: entering the
+    // caption editor while the captions are curated. It rides the shared
+    // dialog chassis — the old absolute-positioned alert silently ate clicks
+    // on the caption rows underneath it. Only the explicit button press
+    // persists the "don't tell me again" choice; OK/✕/Escape acknowledge.
+    if (updateCaptionsFromTranscript === false
+        && localStorage.getItem('noCaptionAlert') !== 'true'
+        && window.HyperaudioSave && typeof window.HyperaudioSave.dialog === 'function') {
+      window.HyperaudioSave.dialog(
+        'These captions may differ from the transcript. You can re-generate captions from the transcript below.',
+        {
+          title: 'Captions have been edited',
+          warning: true,
+          confirmLabel: 'OK',
+          cancelLabel: "Don't tell me again",
+          dismissResult: true,
+        }
+      ).then((result) => {
+        if (result === false) localStorage.setItem('noCaptionAlert', 'true');
+      });
+    }
   });
 
   transcriptViewBtn.addEventListener('click', () => {

--- a/js/editor-main.js
+++ b/js/editor-main.js
@@ -160,9 +160,10 @@
 
       populateCaptionEditor(data);
 
-      if (updateCaptionsFromTranscript === false && localStorage.getItem("noCaptionAlert") !== "true") {
-        document.querySelector('#captionsource-alert').style.visibility = 'visible';
-      }
+      // (Until #506 this function raised the divergence notice — so opening
+      // any curated project, including at boot, threw an alert. The notice
+      // now raises on caption-editor ENTRY (editor-core), where it's
+      // relevant; a real modal at open would block the whole app.)
     }
 
     const cap2 = caption();

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -1534,6 +1534,7 @@
     dialogEl.setAttribute('aria-modal', 'true');
     dialogEl.innerHTML = '<div class="modal-box" style="position:relative">'
       + '<button type="button" id="project-dialog-close" class="btn btn-sm btn-circle absolute right-2 top-2" aria-label="Close">✕</button>'
+      + '<div id="project-dialog-title" class="project-dialog-title" style="display:none"><span aria-hidden="true">⚠</span> <span id="project-dialog-title-text"></span></div>'
       + '<div id="project-dialog-message" style="line-height:1.6; margin-top:22px; padding-right:30px"></div>'
       + '<div class="modal-action">'
       + '<button type="button" id="project-dialog-cancel" class="btn btn-ghost">Cancel</button>'
@@ -1546,7 +1547,16 @@
   function projectDialog(message, opts) {
     opts = opts || {};
     const el = ensureDialog();
+    // The warning dress (#506): amber left border + tinted title band,
+    // reserved for state-divergence warnings — bold enough to register,
+    // on the same modal chassis as everything else.
+    const box = el.querySelector('.modal-box');
+    box.classList.toggle('modal-warning', opts.warning === true);
+    const title = el.querySelector('#project-dialog-title');
+    title.style.display = opts.title ? '' : 'none';
+    el.querySelector('#project-dialog-title-text').textContent = opts.title || '';
     const msg = el.querySelector('#project-dialog-message');
+    msg.style.marginTop = opts.title ? '0' : '22px';
     msg.textContent = '';
     String(message).split('\n\n').forEach((para, i) => {
       const pEl = document.createElement('p');
@@ -1584,11 +1594,16 @@
       const onOk = () => done(true);
       const onCancel = () => done(false);
       const onExtra = () => done('extra');
-      const onClose = () => done(opts.cancel === false); // dismissing an OK-alert acknowledges it
+      // Dismissing an OK-alert acknowledges it. dismissResult overrides for
+      // dialogs where the cancel button is a lasting choice ("don't tell me
+      // again") that a shrugged-off ✕/Escape must NOT silently make.
+      const dismissed = () => done(opts.dismissResult !== undefined
+        ? opts.dismissResult : opts.cancel === false);
+      const onClose = () => dismissed();
       const onKey = (e) => {
         if (e.key === 'Escape') {
           e.stopPropagation();
-          done(opts.cancel === false);
+          dismissed();
         }
       };
       confirmBtn.addEventListener('click', onOk);
@@ -3172,6 +3187,10 @@
     autosaveNow: writeDraft,
     isDirty,
     opfsAvailable,
+    // The one dialog chassis (#451/#506): other modules raise their notices
+    // through this rather than growing their own markup — the caption
+    // divergence warning (editor-main) is the first outside caller.
+    dialog: projectDialog,
     // The project library (#456) — everything the side panel
     // (hyperaudio-library.js) needs; re-renders ride the
     // 'hyperaudioLibraryChanged' document event.

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.3.0 — last changed in release 1.3.0
+ * @version 1.3.1 — last changed in release 1.3.1
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind

--- a/js/transcript-history.js
+++ b/js/transcript-history.js
@@ -709,19 +709,21 @@
     const undo = document.createElement('button');
     undo.id = 'transcript-undo';
     undo.type = 'button';
-    undo.className = 'btn btn-square btn-outline tooltip';
+    undo.className = 'btn btn-square btn-ghost tooltip';
     undo.dataset.tip = 'Undo';
     undo.setAttribute('aria-label', 'Undo transcript edit');
     undo.style.marginRight = '4px';
-    undo.textContent = '↶';
+    // House icon style (#524 follow-up): the same Lucide stroke family as the
+    // corner ⓘ/copy buttons, not a typographic glyph.
+    undo.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 14 4 9l5-5"/><path d="M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5a5.5 5.5 0 0 1-5.5 5.5H11"/></svg>';
     const redo = document.createElement('button');
     redo.id = 'transcript-redo';
     redo.type = 'button';
-    redo.className = 'btn btn-square btn-outline tooltip';
+    redo.className = 'btn btn-square btn-ghost tooltip';
     redo.dataset.tip = 'Redo';
     redo.setAttribute('aria-label', 'Redo transcript edit');
     redo.style.marginRight = '4px';
-    redo.textContent = '↷';
+    redo.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 14 5-5-5-5"/><path d="M20 9H9.5A5.5 5.5 0 0 0 4 14.5A5.5 5.5 0 0 0 9.5 20H13"/></svg>';
     strike.parentNode.insertBefore(redo, strike);
     strike.parentNode.insertBefore(undo, redo);
     undo.addEventListener('click', () => restore(-1, { focus: true }));


### PR DESCRIPTION
Three UX refinements.

- **The caption divergence notice joins the house dialog** (#506, option C): the standard modal chassis — backdrop, Escape, ✕, focus — with a warning dress reserved for state-divergence notices: amber left border and tinted title band, per-theme via the DaisyUI warning colour. It raises on caption-editor entry (not project open, which would have blocked every boot of a curated project), and only the explicit "Don't tell me again" press persists the opt-out — OK, ✕ and Escape merely acknowledge. The old absolute-positioned alert, which silently ate clicks on the caption rows beneath it, is gone.
- **Mobile undo/redo buttons appear only when they can act** (#524): a disabled ↶/↷ vanishes instead of greying, with fixed slots so a vanishing button never puts its neighbour under a mid-run fingertip. The pair also joins the corner family properly — Lucide stroke icons and ghost chassis, matching ⓘ/copy. In caption mode they hide too (the history is transcript-only; the missing caption undo path is #535).
- **Transcribe modal: the file is the way in.** The file picker now leads on every service tab, and the rarer, sharper URL path (CORS, HLS caveats) waits behind a "Transcribe from a URL instead" reveal.

Fixes #506. Fixes #524.

New e2e coverage for the notice semantics and the button visibility; 198 tests green (1 known Playwright-WebKit OPFS skip).
