### PR TITLE
Version 1.3.2

### DIFF
--- a/__TEST__/e2e/parakeet-cache.spec.mjs
+++ b/__TEST__/e2e/parakeet-cache.spec.mjs
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+
+// #477 — a poisoned model cache must heal itself. Field report: a corrupt
+// cached Parakeet model (truncated first download, or artifacts of earlier
+// code versions) failed session creation on EVERY run, and the only cure was
+// the user clearing browser storage by hand. Two defences now exist in
+// js/parakeet.worker.js:
+//   1. validate on read — the cached byte count is checked against the
+//      length sidecar recorded at download time; a mismatch evicts and
+//      re-downloads instead of serving the bad bytes;
+//   2. self-heal on create — when session creation throws on bytes that came
+//      from the cache, the entry is evicted and fetched fresh for one retry.
+//
+// The real models are ~GB downloads, so the network is stubbed at the
+// Playwright routing layer: the onnxruntime CDN module is replaced with a
+// stub whose InferenceSession.create always throws (we test the cache
+// machinery, not ONNX), and the HuggingFace model URLs serve a small
+// distinctive byte pattern so "refetched from network" is observable in the
+// cache afterwards.
+
+const CACHE = 'parakeet-models-v1';
+const MEL = 'https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/nemo128.onnx';
+const LEN = '.expected-length';
+const SERVED = 0x0a; // every network-served byte — distinct from seeded 0x07
+const SERVED_SIZE = 12;
+
+const ORT_STUB = `
+export const env = { wasm: {} };
+export const InferenceSession = {
+  create: async () => { throw new Error('stub refuses every model'); },
+};
+`;
+
+async function stubNetwork(context) {
+  await context.route('**/ort.all.min.mjs', (route) => route.fulfill({
+    status: 200, contentType: 'text/javascript', body: ORT_STUB,
+  }));
+  await context.route('https://huggingface.co/**', (route) => route.fulfill({
+    status: 200, contentType: 'application/octet-stream',
+    body: Buffer.alloc(SERVED_SIZE, SERVED),
+  }));
+}
+
+// Seed the cache as a previous (interrupted or buggy) session might have
+// left it, run the worker until its first error surfaces, and report the
+// cache's state plus the worker's console lines.
+async function runWorkerAgainstSeededCache(page, seedBytes, seedSidecar) {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  return page.evaluate(async ({ CACHE, MEL, LEN, seedBytes, seedSidecar }) => {
+    const cache = await caches.open(CACHE);
+    await cache.put(MEL, new Response(new Uint8Array(seedBytes).fill(7),
+      { headers: { 'content-length': String(seedBytes) } }));
+    if (seedSidecar !== null) {
+      await cache.put(MEL + LEN, new Response(String(seedSidecar)));
+    }
+
+    const logs = [];
+    const worker = new Worker('js/parakeet.worker.js', { type: 'module' });
+    const errorMessage = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('worker never errored; logs: ' + logs.join(' | '))), 30000);
+      worker.addEventListener('message', (e) => {
+        if (e.data && e.data.type === 'error') { clearTimeout(timer); resolve(e.data.message); }
+      });
+      worker.addEventListener('error', (e) => { clearTimeout(timer); resolve(e.message); });
+      const audio = new Float32Array(16000);
+      worker.postMessage({ type: 'INFERENCE_REQUEST', audio }, [audio.buffer]);
+    });
+    worker.terminate();
+
+    const stored = await cache.match(MEL);
+    const buf = stored ? new Uint8Array(await stored.arrayBuffer()) : null;
+    const sidecar = await cache.match(MEL + LEN);
+    return {
+      errorMessage,
+      storedSize: buf ? buf.length : null,
+      storedByte: buf && buf.length ? buf[0] : null,
+      sidecarText: sidecar ? await sidecar.text() : null,
+    };
+  }, { CACHE, MEL, LEN, seedBytes, seedSidecar });
+}
+
+test('a truncated cached model is evicted on read and re-downloaded (#477)', async ({ page, context }) => {
+  await stubNetwork(context);
+  const consoles = [];
+  page.on('console', (m) => consoles.push(m.text()));
+
+  // 5 bytes on disk, 999 promised: the interrupted-download shape
+  const result = await runWorkerAgainstSeededCache(page, 5, 999);
+
+  // the bad entry was replaced by the network's bytes, sidecar updated
+  expect(result.storedSize).toBe(SERVED_SIZE);
+  expect(result.storedByte).toBe(SERVED);
+  expect(result.sidecarText).toBe(String(SERVED_SIZE));
+  // the stub refuses even fresh bytes, so the run still errs — but on the
+  // MODEL, not on a silently-served corrupt cache
+  expect(result.errorMessage).toContain('stub refuses');
+  const evictionLine = consoles.find((t) => t.includes('corrupt cached') && t.includes('evicted'));
+  expect(evictionLine).toBeTruthy();
+});
+
+test('session-create failure on cached bytes evicts and retries from the network (#477)', async ({ page, context }) => {
+  await stubNetwork(context);
+  const consoles = [];
+  page.on('console', (m) => consoles.push(m.text()));
+
+  // plausible cache: sizes agree, so read-time validation passes — only the
+  // create-failure path can catch this one
+  const result = await runWorkerAgainstSeededCache(page, SERVED_SIZE, SERVED_SIZE);
+
+  // the seeded 0x07 bytes are gone; the cache now holds the network's 0x0a —
+  // proof the heal path evicted and refetched rather than giving up
+  expect(result.storedByte).toBe(SERVED);
+  expect(result.errorMessage).toContain('stub refuses');
+  const healLine = consoles.find((t) => t.includes('session creation failed on cached') && t.includes('retrying from network'));
+  expect(healLine).toBeTruthy();
+});

--- a/__TEST__/e2e/parakeet-protocol.spec.mjs
+++ b/__TEST__/e2e/parakeet-protocol.spec.mjs
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+
+// #529 — the worker's error protocol: only the request's own try/catch may
+// declare a request dead ({type:"error"}). In the field, ort's jsep runtime
+// threw a TypeError OUTSIDE that scope while the planned GPU→int8 fallback
+// carried on — the uncaught error reached the page as worker.onerror, painted
+// the fatal "reload the page" screen and killed the in-progress Recents row,
+// and the transcription then SUCCEEDED behind the error screen. The worker
+// now suppresses its own uncaught errors/rejections (logging them); the
+// page-side onerror stays fatal because with suppression in place it can only
+// mean the worker script itself failed to load or parse.
+//
+// Same stubbing technique as parakeet-cache.spec.mjs: the onnxruntime CDN is
+// replaced by a stub, HuggingFace serves tiny bytes. The stub's create()
+// first schedules an uncaught async TypeError — the field crash's shape —
+// and then throws synchronously, so the request errors through the correct
+// channel while the async landmine goes off outside it.
+
+const ORT_STUB = `
+export const env = { wasm: {} };
+export const InferenceSession = {
+  create: async () => {
+    queueMicrotask(() => { throw new TypeError("simulated jsep crash outside the request scope"); });
+    await new Promise((r) => setTimeout(r, 20)); // let the microtask detonate first
+    throw new Error('stub refuses every model');
+  },
+};
+`;
+
+test('an uncaught worker error is suppressed; the request errors through its own channel (#529)', async ({ page, context }) => {
+  await context.route('**/ort.all.min.mjs', (route) => route.fulfill({
+    status: 200, contentType: 'text/javascript', body: ORT_STUB,
+  }));
+  await context.route('https://huggingface.co/**', (route) => route.fulfill({
+    status: 200, contentType: 'application/octet-stream', body: Buffer.alloc(12, 7),
+  }));
+  const consoles = [];
+  page.on('console', (m) => consoles.push(m.text()));
+
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  const result = await page.evaluate(async () => {
+    const worker = new Worker('js/parakeet.worker.js', { type: 'module' });
+    const onerrorEvents = [];
+    worker.addEventListener('error', (e) => onerrorEvents.push(e.message || 'crash'));
+    const errorMessage = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('no terminal message')), 30000);
+      worker.addEventListener('message', (e) => {
+        if (e.data && e.data.type === 'error') { clearTimeout(timer); resolve(e.data.message); }
+      });
+      const audio = new Float32Array(16000);
+      worker.postMessage({ type: 'INFERENCE_REQUEST', audio }, [audio.buffer]);
+    });
+    // the async landmine has already fired (create awaited past it); a beat
+    // for any straggler error event to reach this thread
+    await new Promise((r) => setTimeout(r, 300));
+    worker.terminate();
+    return { errorMessage, onerrorEvents };
+  });
+
+  // the request died through the protocol — with the real reason...
+  expect(result.errorMessage).toContain('stub refuses');
+  // ...and the uncaught TypeError never became a page-visible crash, so the
+  // fatal screen and the Recents row teardown cannot be triggered by it
+  expect(result.onerrorEvents).toEqual([]);
+  // the suppression is loud in the console, not silent
+  expect(consoles.find((t) => t.includes('uncaught worker error (suppressed'))).toBeTruthy();
+});

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-editor-parakeet.js?v=0.8.2"></script>
   <script src="js/transcribe-prefs.js?v=0.8.2"></script>
   <script src="js/hyperaudio-lite-editor-whisper.js?v=1.1.2"></script>
-  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=1.1.2"></script>
+  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=1.3.1.1"></script>
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js?v=1.1.9"></script>
   <script src="js/transcript-to-ionosphere.js?v=1.1.1"></script>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.3.1 (last changed in release 1.3.1) -->
+<!--  Hyperaudio Lite Editor - Version 1.3.2 (last changed in release 1.3.2) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.3.1">
+  <meta name="version" content="1.3.2">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -47,7 +47,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-editor-parakeet.js?v=0.8.2"></script>
   <script src="js/transcribe-prefs.js?v=0.8.2"></script>
   <script src="js/hyperaudio-lite-editor-whisper.js?v=1.1.2"></script>
-  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=1.3.1.2"></script>
+  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=1.3.2"></script>
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js?v=1.1.9"></script>
   <script src="js/transcript-to-ionosphere.js?v=1.1.1"></script>
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.1.1">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.2">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/hyperaudio-lite-editor-parakeet.js?v=0.8.2"></script>
   <script src="js/transcribe-prefs.js?v=0.8.2"></script>
   <script src="js/hyperaudio-lite-editor-whisper.js?v=1.1.2"></script>
-  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=1.3.1.1"></script>
+  <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=1.3.1.2"></script>
   <script src="js/word-alignment.js"></script>
   <script src="js/html-json-converter.js?v=1.1.9"></script>
   <script src="js/transcript-to-ionosphere.js?v=1.1.1"></script>

--- a/js/hyperaudio-lite-editor-parakeet-local.js
+++ b/js/hyperaudio-lite-editor-parakeet-local.js
@@ -61,7 +61,7 @@ function loadParakeetClient(modal, workerBaseUrl) {
     workerBaseUrl = "./";
   }
 
-  const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=1.1.2";
+  const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=1.3.1.1";
 
   // On Chrome (Chromium) Parakeet runs fp16 on the GPU (WebGPU) – fast, and the
   // default. Firefox's WebGPU underperforms here and Safari's can exhaust memory

--- a/js/hyperaudio-lite-editor-parakeet-local.js
+++ b/js/hyperaudio-lite-editor-parakeet-local.js
@@ -61,7 +61,7 @@ function loadParakeetClient(modal, workerBaseUrl) {
     workerBaseUrl = "./";
   }
 
-  const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=1.3.1.1";
+  const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=1.3.1.2";
 
   // On Chrome (Chromium) Parakeet runs fp16 on the GPU (WebGPU) – fast, and the
   // default. Firefox's WebGPU underperforms here and Safari's can exhaust memory
@@ -180,6 +180,12 @@ function loadParakeetClient(modal, workerBaseUrl) {
           videoPlayer.currentTime = 0;
           parakeetParseData(data.output);
           break;
+        case "fallback":
+          // The worker is switching engines, not dying (#529): keep the
+          // loader and the in-progress row; the CPU pass's own progress
+          // messages follow this line.
+          updateLoadingMessage(data.message || "Retrying on the CPU…");
+          break;
         case "error":
           handleError(data.message);
           break;
@@ -187,6 +193,10 @@ function loadParakeetClient(modal, workerBaseUrl) {
     };
 
     worker.onerror = (event) => {
+      // Since #529 the worker suppresses its own uncaught runtime errors
+      // (the request's try/catch reports real failures via {type:"error"}),
+      // so reaching here means the worker script itself failed to load or
+      // parse — that IS fatal, nothing will ever answer.
       console.error(event);
       handleError(event.message || "The transcription worker crashed.");
     };

--- a/js/hyperaudio-lite-editor-parakeet-local.js
+++ b/js/hyperaudio-lite-editor-parakeet-local.js
@@ -1,7 +1,7 @@
 /**
  * hyperaudio-lite-editor-parakeet-local.js
  * (C) The Hyperaudio Project
- * @version 1.1.2 — last changed in release 1.1.2
+ * @version 1.3.2 — last changed in release 1.3.2
  * @license MIT
  */
 
@@ -61,7 +61,7 @@ function loadParakeetClient(modal, workerBaseUrl) {
     workerBaseUrl = "./";
   }
 
-  const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=1.3.1.2";
+  const parakeetWorkerPath = workerBaseUrl + "js/parakeet.worker.js?v=1.3.2";
 
   // On Chrome (Chromium) Parakeet runs fp16 on the GPU (WebGPU) – fast, and the
   // default. Firefox's WebGPU underperforms here and Safari's can exhaust memory

--- a/js/parakeet.worker.js
+++ b/js/parakeet.worker.js
@@ -1,7 +1,7 @@
 /**
  * parakeet.worker.js
  * (C) The Hyperaudio Project
- * @version 1.1.2 — last changed in release 1.1.2
+ * @version 1.3.2 — last changed in release 1.3.2
  * @license MIT
  */
 

--- a/js/parakeet.worker.js
+++ b/js/parakeet.worker.js
@@ -9,6 +9,25 @@ import * as ort from "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0/dist/o
 ort.env.wasm.wasmPaths = "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.26.0/dist/";
 ort.env.wasm.numThreads = self.crossOriginIsolated ? (self.navigator?.hardwareConcurrency || 4) : 1;
 
+// The request's try/catch (the INFERENCE_REQUEST handler) is the ONE
+// authority on fatality: it posts {type:"error"} when a request truly dies.
+// ort's async internals can throw OUTSIDE that scope — the #529 field case
+// was a TypeError from the jsep runtime surfacing as an uncaught worker
+// error WHILE the planned GPU→int8 fallback carried on to a successful
+// transcript. Propagated to the page, that painted the fatal "reload"
+// screen and killed the in-progress Recents row for a request that was
+// recovering. Uncaught errors are therefore logged and suppressed here; a
+// worker that fails to even PARSE never installs these listeners, so a
+// genuinely broken worker still reaches the page's onerror.
+self.addEventListener("error", (e) => {
+  e.preventDefault();
+  console.warn("Parakeet: uncaught worker error (suppressed — the active request reports its own outcome):", e?.message || e);
+});
+self.addEventListener("unhandledrejection", (e) => {
+  e.preventDefault();
+  console.warn("Parakeet: unhandled rejection in worker (suppressed):", e?.reason?.message || e?.reason || e);
+});
+
 const SAMPLE_RATE = 16000;
 const WINDOW_S = 300;        // 5-minute windows to bound memory
 const OVERLAP_S = 10;        // each seam transcribed by both windows
@@ -337,6 +356,10 @@ async function loadSessions(forceGpu) {
       device = "webgpu"; dtype = "fp16";
     } catch (e) {
       console.warn("WebGPU encoder unavailable, falling back to WASM/int8:", e?.message || e);
+      // Non-fatal by definition — the int8 path is about to run (#529). Tell
+      // the page so the loader says so, instead of it inferring doom from
+      // stray uncaught errors the dying GPU path may have emitted.
+      self.postMessage({ type: "fallback", message: "GPU unavailable — retrying on the CPU" });
       encoder = null;
     }
   }

--- a/js/parakeet.worker.js
+++ b/js/parakeet.worker.js
@@ -29,6 +29,23 @@ const MODELS = {
   encoderFp16: `${HF}/ako101/parakeet-tdt-0.6b-v3-sherpa-onnx-fp16/resolve/main/encoder.fp16.onnx`,
 };
 const CACHE_NAME = "parakeet-models-v1";
+// Sidecar cache key carrying the byte count the download actually delivered
+// (#477). Never fetched — it only exists as a Cache Storage key.
+const LEN_SUFFIX = ".expected-length";
+
+// Drop a model's cache entry (and its length sidecar). Returns whether an
+// entry existed — the self-heal path uses that to tell "cached bytes were
+// bad" from "there was nothing cached to blame".
+async function evictCached(url) {
+  try {
+    const cache = await caches.open(CACHE_NAME);
+    const existed = await cache.delete(url);
+    await cache.delete(url + LEN_SUFFIX);
+    return existed;
+  } catch (_) {
+    return false;
+  }
+}
 
 let sessions = null;        // { mel, encoder, decoder, vocab, device }
 let sessionsForceGpu = null; // the forceGpu flag the current sessions were built with
@@ -130,22 +147,41 @@ async function hasGpuAdapter() {
 const MAX_DOWNLOAD_ATTEMPTS = 5;
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// Returns { bytes, fromCache } — provenance feeds the self-heal decision in
+// createSessionWithHeal (#477): only bytes that came from cache implicate the
+// cache when session creation fails.
 async function fetchModel(url, onProgress) {
   const name = url.split("/").pop();
   const cache = await caches.open(CACHE_NAME);
   const hit = await cache.match(url);
   if (hit) {
-    console.log(`Parakeet: ${name} — from cache`);
-    onProgress(url, 1, 1);
-    return new Uint8Array(await hit.arrayBuffer());
+    // Validate before trusting (#477): a truncated or unreadable entry — an
+    // interrupted first download, artifacts of earlier code versions — used
+    // to be served as-is and fail EVERY subsequent run, unrecoverable short
+    // of the user clearing browser storage by hand.
+    try {
+      const buf = await hit.arrayBuffer();
+      const sidecar = await cache.match(url + LEN_SUFFIX);
+      const expected = (sidecar && Number(await sidecar.text()))
+        || Number(hit.headers.get("content-length")) || null;
+      if (expected !== null && buf.byteLength !== expected) {
+        throw new Error(`${buf.byteLength} bytes where ${expected} were expected`);
+      }
+      console.log(`Parakeet: ${name} — from cache`);
+      onProgress(url, 1, 1);
+      return { bytes: new Uint8Array(buf), fromCache: true };
+    } catch (e) {
+      console.warn(`Parakeet: corrupt cached ${name} (${e?.message || e}) — cache entry evicted, re-downloading`);
+      await evictCached(url);
+    }
   }
   console.log(`Parakeet: downloading ${name}…`);
   if (await streamDownloadToCache(cache, url, onProgress)) {
     const stored = await cache.match(url);
-    if (stored) return new Uint8Array(await stored.arrayBuffer());
+    if (stored) return { bytes: new Uint8Array(await stored.arrayBuffer()), fromCache: false };
   }
   console.warn("Cache Storage unavailable — downloading model to memory for this session.");
-  return downloadToMemory(url, onProgress);
+  return { bytes: await downloadToMemory(url, onProgress), fromCache: false };
 }
 
 // Common request setup: bypass the browser HTTP cache (we keep our own copy in
@@ -190,9 +226,14 @@ async function streamDownloadToCache(cache, url, onProgress) {
         headers: total ? { "content-length": String(total) } : {},
       });
       await cache.put(url, body);
+      // cache.put resolved, so the stream is fully consumed and `loaded` is
+      // the delivered byte count — the sidecar the read-time validation
+      // compares against (#477). Content-length can be absent or wrong
+      // through HF's redirects; what we counted is the truth.
+      try { await cache.put(url + LEN_SUFFIX, new Response(String(loaded))); } catch (_) {}
       return true;
     } catch (e) {
-      try { await cache.delete(url); } catch (_) {}   // drop any partial entry
+      try { await evictCached(url); } catch (_) {}   // drop any partial entry
       if (e?.name === "QuotaExceededError" || /quota|internal error/i.test(e?.message || "")) {
         return false;   // cache can't hold it — let the caller use memory
       }
@@ -273,21 +314,25 @@ async function loadSessions(forceGpu) {
   // progress callback: counting them would make the bar race to 100% and then
   // reset to ~0 once the encoder's far larger content-length enters the total.
   const noProgress = () => {};
-  const [melBytes, decBytes, vocabBytes] = await Promise.all([
+  const [melFetched, decFetched, vocabFetched] = await Promise.all([
     fetchModel(MODELS.mel, noProgress),
     fetchModel(MODELS.decoder, noProgress),
     fetchModel(MODELS.vocab, noProgress),
   ]);
-  const mel = await ort.InferenceSession.create(melBytes, { executionProviders: ["wasm"] });
-  const decoder = await ort.InferenceSession.create(decBytes, { executionProviders: ["wasm"] });
-  const vocab = new TextDecoder().decode(vocabBytes).split("\n").map((l) => l.slice(0, l.lastIndexOf(" ")));
+  const mel = await createSessionWithHeal(MODELS.mel, melFetched, { executionProviders: ["wasm"] });
+  const decoder = await createSessionWithHeal(MODELS.decoder, decFetched, { executionProviders: ["wasm"] });
+  const vocab = new TextDecoder().decode(vocabFetched.bytes).split("\n").map((l) => l.slice(0, l.lastIndexOf(" ")));
 
   let encoder, device, dtype;
   if (useWebGpu) {
     try {
-      const encBytes = await fetchModel(MODELS.encoderFp16, onProgress);
+      const encFetched = await fetchModel(MODELS.encoderFp16, onProgress);
       self.postMessage({ type: "progress", phase: "prepare", kind: "GPU" });
-      encoder = await ort.InferenceSession.create(encBytes, { executionProviders: ["webgpu"] });
+      // create-failure heals the cache (#477); a warm-up failure is a
+      // CAPABILITY problem (#459) and falls through to int8 as before —
+      // healing there would re-download 1.2 GB to hit the same wall.
+      encoder = await createSessionWithHeal(MODELS.encoderFp16, encFetched,
+        { executionProviders: ["webgpu"] }, onProgress);
       await warmUp(encoder);
       device = "webgpu"; dtype = "fp16";
     } catch (e) {
@@ -299,15 +344,33 @@ async function loadSessions(forceGpu) {
     // Fresh CPU-labelled progress so a GPU→CPU fallback reads as a distinct
     // "Downloading CPU model…" pass rather than continuing the GPU one.
     const onProgressCpu = makeDownloadProgress("CPU");
-    const encBytes = await fetchModel(MODELS.encoderInt8, onProgressCpu);
+    const encFetched = await fetchModel(MODELS.encoderInt8, onProgressCpu);
     self.postMessage({ type: "progress", phase: "prepare", kind: "CPU" });
-    encoder = await ort.InferenceSession.create(encBytes, { executionProviders: ["wasm"] });
+    encoder = await createSessionWithHeal(MODELS.encoderInt8, encFetched,
+      { executionProviders: ["wasm"] }, onProgressCpu);
     device = "wasm"; dtype = "int8";
   }
 
   console.log(`Parakeet ready on ${device} (${dtype})`);
   self.postMessage({ type: "device", device, dtype });
   return { mel, encoder, decoder, vocab, device };
+}
+
+// Session creation that heals a poisoned cache (#477): if create throws on
+// bytes that CAME FROM the cache, the entry is evicted and fetched fresh from
+// the network for one more attempt — corruption with a plausible length
+// passes the read-time check and lands here. Bytes that were just downloaded
+// implicate the network or the model itself, not the cache: no retry.
+async function createSessionWithHeal(url, fetched, opts, onProgress) {
+  try {
+    return await ort.InferenceSession.create(fetched.bytes, opts);
+  } catch (e) {
+    if (!fetched.fromCache) throw e;
+    console.warn(`Parakeet: session creation failed on cached ${url.split("/").pop()} — cache entry evicted, retrying from network (${e?.message || e})`);
+    await evictCached(url);
+    const fresh = await fetchModel(url, onProgress || (() => {}));
+    return await ort.InferenceSession.create(fresh.bytes, opts);
+  }
 }
 
 // Push a short silent clip through the encoder so WebGPU shader compilation


### PR DESCRIPTION
A transcription-reliability release.

- **The Parakeet model cache heals itself** (#477): every download records the byte count it delivered; a cached model that doesn't match is evicted and re-downloaded instead of being served corrupt, and a session-creation failure on cached bytes evicts and retries once from the network. The field failure — a poisoned cache breaking transcription permanently until the user cleared browser storage by hand — now recovers automatically. Field-verified against a deliberately corrupted cache.
- **Only the request may declare a transcription dead** (#529): uncaught errors inside the worker (ort's async internals) no longer paint the fatal "reload the page" screen while a planned GPU→CPU fallback is busy succeeding — the worker suppresses and logs them, and the request's own error channel remains the one authority on failure. The fallback also announces itself in the loader ("GPU unavailable — retrying on the CPU"). The underlying `Kd` crash investigation remains with #478.
- **The FILE menu out-stacks the docked play bar** (#539): `.main-panel` is a stacking context, so its old `z-index: 2` pinned the whole navbar beneath the play bar — the open menu's lower entries rendered behind it on short viewports and their clicks fell through to the seek slider. The navbar now holds a documented rung (40) in the z-ladder.

Fixes #477. Fixes #529. Fixes #539.

Two new specs drive the real worker against a stubbed network (no gigabyte downloads): cache validation and self-heal, and the error-suppression protocol — all teeth-checked. Suite: 202 tests green (1 known Playwright-WebKit OPFS skip).
