### PR TITLE
Embedder link schemes: media served by a host application's own URL scheme

### DIFF
--- a/__TEST__/unit/hyperaudio-save.test.mjs
+++ b/__TEST__/unit/hyperaudio-save.test.mjs
@@ -130,6 +130,22 @@ test('validateProjectJson: link kind needs an http(s) url, and nothing else', ()
   assert.ok(save.validateProjectJson(p).errors.some((e) => e.code === 'media'));
 });
 
+test('validateProjectJson: a declared embedder scheme is accepted for link urls', () => {
+  const p = save.buildProjectJson(sampleState());
+  p.media = { kind: 'link', path: null, url: 'app-media://token/file.mp4', filename: 'file.mp4', mimeType: '', durationSeconds: 62.5, sizeBytes: 0 };
+  // Undeclared: rejected exactly as before.
+  assert.ok(save.validateProjectJson(p).errors.some((e) => e.code === 'media'));
+  globalThis.hyperaudioLinkSchemes = ['app-media:'];
+  try {
+    assert.deepEqual(save.validateProjectJson(p), { ok: true, errors: [] });
+    // Declaring one scheme does not open the door to others.
+    p.media.url = 'other-scheme://x/y';
+    assert.ok(save.validateProjectJson(p).errors.some((e) => e.code === 'media'));
+  } finally {
+    delete globalThis.hyperaudioLinkSchemes;
+  }
+});
+
 /* ---------- converter: struck round-trip (writer side) ---------- */
 
 test('jsonToHTML: struck word carries the line-through style, others do not', () => {

--- a/docs/hyperaudio-format.md
+++ b/docs/hyperaudio-format.md
@@ -562,8 +562,9 @@ minor bump:
 
 ### 7.2.1 `kind: "link"` (since 1.1)
 
-- `url` **MUST** be an http(s) URL; `path` is `null`; the container has no
-  `media/` entry.
+- `url` **MUST** be an http(s) URL — or, in a host application that has
+  declared its own media scheme(s) (below), a URL in a declared scheme;
+  `path` is `null`; the container has no `media/` entry.
 - The file is **not self-contained**, and readers state so openly on open.
 - Writers **SHOULD** prefer embedding over linking: attempt to download the
   remote media and save it as `kind: "original"` (whether this works is the
@@ -571,6 +572,16 @@ minor bump:
 - Readers open a link project by playing the URL directly (playback does not
   require CORS). If the URL is unreachable, § 7.3 applies — degraded mode
   with reconciliation is the recommended behaviour.
+
+**Embedder-declared schemes.** An application embedding the editor MAY declare
+the URL scheme(s) it serves media over (`window.hyperaudioLinkSchemes`), and a
+link URL in a declared scheme is then valid wherever http(s) is. The embedder
+owns that URL's stability: it must keep resolving across file renames, moves,
+and application relaunches — every miss surfaces to the user as a § 7.3
+reconciliation offer they didn't earn. Embedder-scheme links are expected in
+*working copies*; for interchange, writers embed (`kind: "original"`) as § 7.2.1
+already prefers, so shared files stay openable everywhere. In a plain browser
+no scheme is declared and nothing changes.
 
 ### 7.2.2 `kind: "none"` (since 1.2)
 

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -57,6 +57,24 @@
   };
   const MEDIA_DIR = 'media/';
 
+  // Embedder link schemes (#449's bridge, extended to media): a native
+  // wrapper that serves media over its own URL scheme declares those schemes
+  // here, and kind-"link" media accepts them wherever http(s) is accepted.
+  // Embedder-scheme links are the embedder's responsibility: they are never
+  // cached into the OPFS working copy (see exportProjectInner), so the
+  // project stays kind "link" and the media bytes live only on the native
+  // side — the embedder owns that URL's stability across renames, moves and
+  // relaunches (spec § 7.2).
+  function embedderLinkSchemes() {
+    return Array.isArray(window.hyperaudioLinkSchemes) ? window.hyperaudioLinkSchemes : [];
+  }
+  function isEmbedderLinkUrl(src) {
+    return typeof src === 'string' && embedderLinkSchemes().some((s) => src.startsWith(s));
+  }
+  function isLinkUrl(src) {
+    return typeof src === 'string' && (/^https?:/i.test(src) || isEmbedderLinkUrl(src));
+  }
+
   // Reader security (spec § 10): cap on text entries before/after inflating
   // (anti zip-bomb — an hour of speech is hundreds of KB, 50 MB is generous).
   const TEXT_ENTRY_MAX_BYTES = 50 * 1024 * 1024;
@@ -178,7 +196,7 @@
         fail('media-path', `media.path "${media.path}" violates the media/<filename> pattern`);
       }
     } else if (media.kind === 'link') {
-      if (typeof media.url !== 'string' || !/^https?:/i.test(media.url)) {
+      if (!isLinkUrl(media.url)) { // http(s) or a declared embedder scheme
         fail('media', 'media.kind "link" requires an http(s) url');
       }
     } else if (media.kind === 'none') {
@@ -833,7 +851,7 @@
     const duration = player && Number.isFinite(player.duration)
       ? Math.round(player.duration * 1000) / 1000 : 0;
     const src = player !== null ? player.src : '';
-    if (/^https?:/i.test(src)) {
+    if (isLinkUrl(src)) { // http(s) or a declared embedder scheme
       // The player is on a remote URL (URL-mode transcription): a File captured
       // for a PREVIOUS project is stale — the URL wins. The exception is a file
       // fetched from this very URL (opportunistic embed, § 7.2): that IS this
@@ -850,7 +868,11 @@
           sizeBytes: session.mediaFile.size,
         };
       }
-      return { kind: 'link', path: null, url: src, filename: '', mimeType: '', durationSeconds: duration, sizeBytes: 0 };
+      // Name link media from its URL leaf — otherwise a link-kind birth
+      // falls through gather()'s title chain (title field → session.title →
+      // media.filename → 'project') and every URL-mode transcription is
+      // christened "project".
+      return { kind: 'link', path: null, url: src, filename: mediaDisplayName2(src) || '', mimeType: '', durationSeconds: duration, sizeBytes: 0 };
     }
     if (session.mediaFile !== null) {
       const safeName = sanitizeMediaFilename(session.mediaFile.name);
@@ -882,7 +904,7 @@
     const src = player !== null ? player.src : '';
     // A remote URL in the player means URL-mode: any previously captured File
     // belongs to an older project and must not be saved as this one's media.
-    if (!src || /^https?:/i.test(src)) return null;
+    if (!src || isLinkUrl(src)) return null;
     if (session.mediaFile !== null) return session.mediaFile;
     try {
       const blob = await (await fetch(src)).blob();
@@ -1878,9 +1900,34 @@
     showProgress('Preparing the project file…', 0, token);
     let mediaFile = await resolveMediaFile();
     const player = document.querySelector('#hyperplayer');
+    // Media on an embedder scheme exports self-contained — the bytes are
+    // fetched through the embedder's scheme handler for THIS archive only.
+    // Deliberately no session.mediaFile / session.mediaFileFromUrl caching
+    // and no writeMediaOnce(): the OPFS working copy must stay kind "link"
+    // (the media's one durable copy lives on the embedder's side).
+    const embedderSrc = player !== null && isEmbedderLinkUrl(player.src) ? player.src : null;
     const remoteSrc = player !== null && /^https?:/i.test(player.src) ? player.src : null;
     let saveAsLink = false;
+    let embedderMedia = null;
+    let deferEmbedToBridge = null;
 
+    if (mediaFile === null && embedderSrc !== null) {
+      const embedBridge = window.hyperaudioProjectBridge;
+      if (embedBridge && typeof embedBridge.save === 'function') {
+        // With a bridge registered, do NOT pull the media through the page —
+        // a full-file fetch through the embedder's scheme handler contends
+        // with the player's own streaming and starves playback right after a
+        // save. The container is built link-kind with no media entry; the
+        // bridge embeds the bytes natively (it has the file) and flips the
+        // descriptor to "original" before the archive lands.
+        deferEmbedToBridge = embedderSrc;
+        saveAsLink = true; // container carries the link; the bridge upgrades it
+      } else {
+        showProgress('Reading the media…', 0, token);
+        mediaFile = await fetchRemoteMediaFile(embedderSrc);
+        embedderMedia = mediaFile;
+      }
+    }
     if (mediaFile === null && remoteSrc !== null) {
       if (session.mediaFile !== null && session.mediaFileFromUrl === remoteSrc) {
         mediaFile = session.mediaFile; // already embedded by a previous save of this project
@@ -1920,6 +1967,22 @@
 
     const editAtGather = editGeneration;
     const state = gather();
+    // In-page fallback (no bridge): the gathered descriptor says "link"
+    // (the session cache was never touched), but this archive carries the
+    // bytes — so the CONTAINER's descriptor becomes a normal self-contained
+    // "original". The working copy keeps gathering "link".
+    if (embedderMedia !== null && state.media && state.media.kind === 'link') {
+      const safeName = sanitizeMediaFilename(embedderMedia.name);
+      state.media = {
+        kind: 'original',
+        path: MEDIA_DIR + safeName,
+        url: null,
+        filename: safeName,
+        mimeType: embedderMedia.type || '',
+        durationSeconds: state.media.durationSeconds,
+        sizeBytes: embedderMedia.size,
+      };
+    }
     // The origin travels in every save (spec § 5): the in-memory copy is the
     // primary source (also covers browsers without OPFS); work/ carries it
     // across reloads.
@@ -1962,7 +2025,11 @@
     if (bridge && typeof bridge.save === 'function') {
       let handled = false;
       try {
-        handled = (await bridge.save(blob, suggestedName)) !== false;
+        // The third argument tells the bridge which media to embed natively
+        // (see deferEmbedToBridge above). Bridges that don't understand it
+        // simply ignore the extra argument.
+        handled = (await bridge.save(blob, suggestedName,
+          deferEmbedToBridge !== null ? { embedMediaFromUrl: deferEmbedToBridge } : undefined)) !== false;
       } catch (e) {
         console.warn('hyperaudio-save: bridge save failed, falling back to download', e);
       }
@@ -2126,6 +2193,21 @@
   let reconcileInput = null;
 
   async function offerMediaReconciliation(desc) {
+    // Embedder-scheme links reconcile on the embedder's side. The in-page
+    // re-attach cannot run in every embedded WebView (a programmatic
+    // file-input click is blocked in WKWebView), and attaching in-page would
+    // writeMediaOnce() the bytes into OPFS — embedder media deliberately
+    // lives outside the browser. The embedder re-points its scheme handler
+    // and reloads the player instead.
+    if (isEmbedderLinkUrl(desc.url) && typeof window.hyperaudioMediaReconcileHandler === 'function') {
+      window.hyperaudioMediaReconcileHandler({
+        url: desc.url,
+        filename: desc.filename || '',
+        sizeBytes: desc.sizeBytes || 0,
+        durationSeconds: desc.durationSeconds || 0,
+      });
+      return;
+    }
     const why = desc.url
       ? 'The media URL this project points to cannot be played (offline, moved, or gone).'
       : 'The media file is missing from the project container.';
@@ -2271,7 +2353,7 @@
     if (session.mediaFile !== null && session.mediaFile.name) return session.mediaFile.name;
     const player = document.getElementById('hyperplayer');
     const src = player !== null ? player.src : '';
-    if (/^https?:/i.test(src)) {
+    if (isLinkUrl(src)) { // http(s) or a declared embedder scheme
       try {
         const leaf = decodeURIComponent(new URL(src).pathname.split('/').pop() || '');
         if (leaf !== '') return leaf;
@@ -2360,6 +2442,38 @@
     }
   }
   window.clearPendingTranscription = clearPendingTranscription;
+
+  // An engine that only obtains its media AFTER starting (URL modes that
+  // download or resolve first) reports the media src once known. The pending
+  // identity and (when the pending view owns the screen) the player follow,
+  // exactly as if the src had been on the player before setTranscriptBusy(true).
+  window.hyperaudioUpdatePendingMediaSrc = function (url) {
+    if (pendingIdentity === null) return false;
+    // Canonical (percent-encoded, resolved) form — player.src always reads
+    // back canonical, and a raw-vs-canonical mismatch means needless media
+    // reloads later (identity restore compares against player.src).
+    let canon = url || '';
+    try { canon = url ? new URL(url, window.location.href).href : ''; } catch (e) { /* keep raw */ }
+    pendingIdentity.playerSrc = canon;
+    if (pendingTranscription !== null) {
+      pendingTranscription.name = mediaDisplayName2(canon) || pendingTranscription.name;
+    }
+    const t = document.getElementById('hypertranscript');
+    const player = document.getElementById('hyperplayer');
+    if (player !== null && canon && t !== null && t.getAttribute('aria-busy') === 'true'
+        && player.src !== canon) {
+      player.src = canon;
+    }
+    notifyLibraryChanged(false);
+    return true;
+  };
+  // Name helper for the late-media case: leaf of the reported URL.
+  function mediaDisplayName2(url) {
+    try {
+      const leaf = decodeURIComponent(new URL(url).pathname.split('/').pop() || '');
+      return leaf !== '' ? leaf : null;
+    } catch (e) { return null; }
+  }
 
   // Clicking the in-progress row: hand the screen back to the transcription.
   // The current project's pending edits flush to its own draft first; the

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -66,7 +66,10 @@
   // side — the embedder owns that URL's stability across renames, moves and
   // relaunches (spec § 7.2).
   function embedderLinkSchemes() {
-    return Array.isArray(window.hyperaudioLinkSchemes) ? window.hyperaudioLinkSchemes : [];
+    // Reached from the pure layer (validateProjectJson) — globalThis, not
+    // window, so the node context (module.exports of `pure`) stays clean.
+    const declared = globalThis.hyperaudioLinkSchemes;
+    return Array.isArray(declared) ? declared : [];
   }
   function isEmbedderLinkUrl(src) {
     return typeof src === 'string' && embedderLinkSchemes().some((s) => src.startsWith(s));


### PR DESCRIPTION
An application embedding the editor (the audience #449's bridge was built for) that serves media over its own URL scheme can now declare it — `window.hyperaudioLinkSchemes = ['myscheme:']` — and `kind: "link"` media accepts a declared scheme wherever http(s) is accepted: validation, the gathered media descriptor, `resolveMediaFile`, `mediaDisplayName`.

**The contract** (now in spec § 7.2.1): declared-scheme links are the embedder's responsibility — the URL must keep resolving across file renames, moves and application relaunches, because every miss is a § 7.3 reconciliation offer the user didn't earn. Declared-scheme media is never cached into the OPFS working copy: the working copy stays `kind: "link"` and the media's one durable copy lives on the host side.

**Export stays self-contained either way.** With a bridge registered, the container is built without the media entry and `bridge.save()` receives `{embedMediaFromUrl}` as a third argument, so the host embeds the bytes natively — sparing the page a full-media fetch that measurably contends with the player's own streaming right after a save. Without a bridge, the bytes are fetched through the scheme for the archive and the descriptor flips to `"original"`, exactly like the opportunistic embed of remote URLs.

**Rides along, each useful with no embedder anywhere:**
- Link media is named from its URL leaf — URL-mode transcriptions stop being christened "project" (the link descriptor carried `filename: ''`, so `gather()`'s title chain fell through).
- `hyperaudioUpdatePendingMediaSrc(url)` — an engine that only obtains its media after starting reports the src to the pending-transcription identity, canonicalised so the identity restore never reloads the player over a raw-vs-encoded string mismatch.
- Media reconciliation hands off to `window.hyperaudioMediaReconcileHandler` for declared-scheme links — the in-page re-attach is a programmatic file-input click, which some embedded WebViews block outright.

**Spec**: § 7.2.1 amended (declared schemes valid where http(s) is; embedder owns URL stability; interchange files still embed per the existing SHOULD). No format version bump: in a plain browser no scheme is declared and nothing changes.

In production use in a native wrapper; the naming fix and the pending-src report are exercised on every transcription there.
