### PR TITLE
saveProject: a registered bridge composes with the OPFS commit

### DIFF
--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -1327,8 +1327,15 @@
     saveInFlight = true;
     try {
       flushTranscriptMaintenanceBarrier('sanitise-save');
+      // With a bridge registered AND OPFS available, the bridge COMPOSES with
+      // the silent commit instead of replacing it: the commit runs below and
+      // the finished container is additionally handed to the bridge at the
+      // end. The bridge-only short-circuit remains for OPFS-less contexts,
+      // where the handed-over container IS the save. (#449 predates the
+      // project library; as shipped, registering the bridge silently
+      // disabled the library's own saved.json/draft semantics.)
       const bridge = window.hyperaudioProjectBridge;
-      if (bridge && typeof bridge.save === 'function') {
+      if (bridge && typeof bridge.save === 'function' && !opfsAvailable) {
         return await exportProject({ asSave: true }); // the bridge intercepts the built container
       }
       if (!opfsAvailable) {
@@ -1368,6 +1375,16 @@
       if (identityGeneration === identityAtStart && editGeneration === editAtGather) {
         sessionEdited = false;
         updateSaveIndicator();
+      }
+      // The commit succeeded — now also hand the finished container to the
+      // bridge (see the note above). Failures here are the bridge's to
+      // report; the commit already stands.
+      if (bridge && typeof bridge.save === 'function') {
+        try {
+          await exportProject({ asSave: true });
+        } catch (e) {
+          console.warn('hyperaudio-save: bridge save failed after commit', e);
+        }
       }
       return true;
     } finally {


### PR DESCRIPTION
The native bridge hook (#449) predates the project library (#456), and their interaction shipped wrong: registering `hyperaudioProjectBridge` makes `saveProject()` **skip the OPFS commit entirely** — an embedder that accepts the container hand-off silently loses `saved.json`/draft semantics, the undo-aware dirty state, restore-on-reload, and everything else the library's save provides. The hook was designed for OPFS-less wrappers; any embedder that *has* OPFS gets the worse of both worlds.

With a bridge **and** OPFS available, save now commits first and hands the finished container to the bridge afterwards. A bridge failure is the bridge's to report and never un-commits. The bridge-only short-circuit remains for OPFS-less contexts, where the hand-off genuinely *is* the save. Behaviour without a bridge is untouched, and `asSave`'s clean-marking rules apply unchanged.

Three lines of logic plus comments; in production use in a native wrapper where every ⌘S runs this path.
