### PR TITLE
Version 1.3.4

### DIFF
--- a/__TEST__/e2e/library.spec.mjs
+++ b/__TEST__/e2e/library.spec.mjs
@@ -106,11 +106,12 @@ test('rows list by last edit with the current project highlighted; editing reord
   // name and duration ONLY — the stored summary lives in the Info modal, not
   // the glance (a long one, e.g. the benchmark report, swallowed the card)
   await expect(popout).not.toContainText('summary of Project A');
+  // ...and FLUSH with the panel's right edge, not floated off it
   expect(await page.evaluate(() => {
     const pane = document.getElementById('recents-pane').getBoundingClientRect();
     const pop = document.getElementById('recents-popout').getBoundingClientRect();
-    return pop.left >= pane.right;
-  })).toBe(true);
+    return Math.round(pop.left - pane.right);
+  })).toBe(0);
   await page.locator('#hypertranscript').hover(); // leaving the row dismisses it
   await expect(popout).toHaveCount(0);
 
@@ -537,4 +538,48 @@ test('the has-projects hint tracks the library (#473)', async ({ page }, testInf
   await del.click();
   await del.click();
   await pollPage(page, () => localStorage.getItem('hyperaudioHasProjects') === null);
+});
+
+
+// A long title used to run to five lines and stretch the card past the poster
+// it sits above: the name clamps to two lines with an ellipsis (the full name
+// lives in the ⓘ). The clip must be real — an earlier attempt drew the
+// ellipsis but still rendered a third line below it.
+test('a long project name clamps to two lines in the hover popout', async ({ page }, testInfo) => {
+  await openProject(page, testInfo, 'Project A');
+  await page.evaluate(async () => {
+    const lib = window.HyperaudioSave.library;
+    await lib.rename(lib.currentId(),
+      'David A. Kochalski (July 28th, 1994) interview master file final v3 EXTENDED.mp4');
+  });
+  await expect(page.locator('#file-picker .file-item').first()).toContainText('Kochalski');
+
+  await page.locator('#file-picker .recents-row').first().hover();
+  await expect(page.locator('#recents-popout')).toBeVisible();
+  const name = await page.evaluate(() => {
+    const el = document.querySelector('#recents-popout .recents-popout-name');
+    const cs = getComputedStyle(el);
+    const lineHeight = parseFloat(cs.lineHeight);
+    return {
+      lines: Math.round(el.getBoundingClientRect().height / lineHeight),
+      clipped: el.scrollHeight > el.clientHeight + 1, // text really is cut off
+    };
+  });
+  expect(name.lines).toBe(2);
+  expect(name.clipped).toBe(true);
+
+  // the card's width is FIXED — it must not shrink or grow with the title,
+  // or moving down the list makes it jump about
+  const wide = await page.evaluate(() =>
+    Math.round(document.getElementById('recents-popout').getBoundingClientRect().width));
+  await page.locator('#hypertranscript').hover();
+  await page.evaluate(async () => {
+    const lib = window.HyperaudioSave.library;
+    await lib.rename(lib.currentId(), 'Short.mp4');
+  });
+  await page.locator('#file-picker .recents-row').first().hover();
+  await expect(page.locator('#recents-popout')).toBeVisible();
+  const narrow = await page.evaluate(() =>
+    Math.round(document.getElementById('recents-popout').getBoundingClientRect().width));
+  expect(narrow).toBe(wide);
 });

--- a/__TEST__/e2e/media-first-frame.spec.mjs
+++ b/__TEST__/e2e/media-first-frame.spec.mjs
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+import { ladderWav } from './helpers.mjs';
+
+// #556 — first-frame display for video media. Video drops the generic demo
+// poster and takes an epsilon seek so the real first frame paints; audio
+// keeps the poster; the aspect-ratio pin follows the medium. The video
+// fixture is synthesized in-page (canvas.captureStream + MediaRecorder), so
+// no binary fixture is checked in.
+const makeWebm = () => new Promise((resolve) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 320; canvas.height = 240;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = '#3a6'; ctx.fillRect(0, 0, 320, 240);
+  const stream = canvas.captureStream(10);
+  const rec = new MediaRecorder(stream, { mimeType: 'video/webm' });
+  const chunks = [];
+  rec.ondataavailable = (e) => chunks.push(e.data);
+  rec.onstop = () => resolve(URL.createObjectURL(new Blob(chunks, { type: 'video/webm' })));
+  rec.start();
+  let frames = 0;
+  const tick = setInterval(() => {
+    ctx.fillRect(0, 0, 320, 240); // keep frames flowing
+    if (++frames >= 12) { clearInterval(tick); rec.stop(); }
+  }, 100);
+});
+
+test('video media drops the poster, paints frame one, and pins its aspect (#556)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  // the demo is audio: the generic poster must be present at boot
+  await expect(page.locator('#hyperplayer')).toHaveAttribute('poster', /poster/);
+
+  await page.evaluate(`(${makeWebm.toString()})().then((url) => {
+    document.getElementById('hyperplayer').src = url;
+  })`);
+  const player = page.locator('#hyperplayer');
+  await expect(player).not.toHaveAttribute('poster', /.*/, { timeout: 10000 }); // poster dropped
+  const state = await page.evaluate(() => {
+    const p = document.getElementById('hyperplayer');
+    return { aspect: p.style.aspectRatio, time: p.currentTime, paused: p.paused };
+  });
+  expect(state.aspect).toBe('320 / 240');
+  expect(state.time).toBeGreaterThan(0);   // the epsilon nudge decoded frame one
+  expect(state.time).toBeLessThan(0.1);    // ...and stayed at the start
+  expect(state.paused).toBe(true);
+});
+
+test('audio media keeps the poster and clears the aspect pin (#556)', async ({ page }, testInfo) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  // video first, so the poster is gone and the pin is set...
+  await page.evaluate(`(${makeWebm.toString()})().then((url) => {
+    document.getElementById('hyperplayer').src = url;
+  })`);
+  const player = page.locator('#hyperplayer');
+  await expect(player).not.toHaveAttribute('poster', /.*/, { timeout: 10000 });
+
+  // ...then audio: the generic poster returns and the pin releases
+  const wavPath = testInfo.outputPath('tone.wav');
+  (await import('node:fs')).writeFileSync(wavPath, ladderWav(1));
+  const buf = (await import('node:fs')).readFileSync(wavPath);
+  await page.evaluate((b64) => {
+    const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+    const url = URL.createObjectURL(new Blob([bytes], { type: 'audio/wav' }));
+    document.getElementById('hyperplayer').src = url;
+  }, buf.toString('base64'));
+  await expect(player).toHaveAttribute('poster', /poster/, { timeout: 10000 });
+  expect(await page.evaluate(() => document.getElementById('hyperplayer').style.aspectRatio)).toBe('');
+});

--- a/__TEST__/e2e/media-posters.spec.mjs
+++ b/__TEST__/e2e/media-posters.spec.mjs
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import fs from 'node:fs';
+import { ladderWav } from './helpers.mjs';
+
+// #523 phase A — poster capture and the hover-card thumbnail. The video
+// fixture is synthesized in-page (canvas + MediaRecorder); the capture,
+// storage and display layers are exercised separately so no full
+// video-project flow is needed.
+
+const makeWebmBlob = () => new Promise((resolve) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 320; canvas.height = 180;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = '#a63'; ctx.fillRect(0, 0, 320, 180);
+  const stream = canvas.captureStream(10);
+  const rec = new MediaRecorder(stream, { mimeType: 'video/webm' });
+  const chunks = [];
+  rec.ondataavailable = (e) => chunks.push(e.data);
+  rec.onstop = () => resolve(new Blob(chunks, { type: 'video/webm' }));
+  rec.start();
+  let frames = 0;
+  const tick = setInterval(() => {
+    ctx.fillRect(0, 0, 320, 180);
+    if (++frames >= 12) { clearInterval(tick); rec.stop(); }
+  }, 100);
+});
+
+test('captureFrameBlob: a jpeg for video, null for audio (#523)', async ({ page }, testInfo) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  const wavPath = testInfo.outputPath('tone.wav');
+  fs.writeFileSync(wavPath, ladderWav(1));
+  const wavB64 = fs.readFileSync(wavPath).toString('base64');
+  const result = await page.evaluate(`(async () => {
+    const videoBlob = await (${makeWebmBlob.toString()})();
+    const videoUrl = URL.createObjectURL(videoBlob);
+    const jpeg = await window.MediaPosters.captureFrameBlob(videoUrl);
+    return { jpegType: jpeg ? jpeg.type : null, jpegSize: jpeg ? jpeg.size : 0 };
+  })()`);
+  expect(result.jpegType).toBe('image/jpeg');
+  expect(result.jpegSize).toBeGreaterThan(500);
+
+  const audioNull = await page.evaluate((b64) => {
+    const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+    const url = URL.createObjectURL(new Blob([bytes], { type: 'audio/wav' }));
+    return window.MediaPosters.captureFrameBlob(url);
+  }, wavB64);
+  expect(audioNull).toBeNull();
+});
+
+test('ensureProjectPoster writes poster.jpg from stored video media (#523)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  const written = await page.evaluate(`(async () => {
+    const blob = await (${makeWebmBlob.toString()})();
+    const root = await navigator.storage.getDirectory();
+    const work = await root.getDirectoryHandle('work', { create: true });
+    const dir = await work.getDirectoryHandle('poster-test-project', { create: true });
+    const media = await dir.getDirectoryHandle('media', { create: true });
+    const fh = await media.getFileHandle('clip.webm', { create: true });
+    const w = await fh.createWritable(); await w.write(blob); await w.close();
+
+    await window.MediaPosters.ensureProjectPoster('poster-test-project');
+    try {
+      const poster = await (await dir.getFileHandle('poster.jpg')).getFile();
+      return { size: poster.size, type: poster.type };
+    } catch (e) { return null; }
+  })()`);
+  expect(written).not.toBeNull();
+  expect(written.size).toBeGreaterThan(500);
+});
+
+test('the hover popout shows the stored poster, or the wave glyph without one (#523)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  await page.evaluate(async () => {
+    document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+    for (let i = 0; i < 50 && window.HyperaudioSave.library.currentId() === null; i += 1) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  });
+  const id = await page.evaluate(() => window.HyperaudioSave.library.currentId());
+  expect(id).not.toBeNull();
+
+  // no poster stored (the demo is audio): the wave glyph
+  await page.hover('#file-picker .recents-row .file-item');
+  await expect(page.locator('#recents-popout .recents-popout-thumb svg')).toBeVisible();
+  await page.mouse.move(10, 10);
+
+  // plant a poster; a fresh hover swaps the glyph for the image
+  await page.evaluate(`(async (id) => {
+    const blob = await (${makeWebmBlob.toString()})();
+    const jpeg = await window.MediaPosters.captureFrameBlob(URL.createObjectURL(blob));
+    const root = await navigator.storage.getDirectory();
+    const dir = await (await root.getDirectoryHandle('work')).getDirectoryHandle(id);
+    const fh = await dir.getFileHandle('poster.jpg', { create: true });
+    const w = await fh.createWritable(); await w.write(jpeg); await w.close();
+  })(${JSON.stringify(id)})`);
+  await page.hover('#file-picker .recents-row .file-item');
+  await expect(page.locator('#recents-popout img.recents-popout-poster')).toBeVisible({ timeout: 5000 });
+});

--- a/__TEST__/e2e/search.spec.mjs
+++ b/__TEST__/e2e/search.spec.mjs
@@ -180,3 +180,55 @@ test('Escape in the search box clears it (#558)', async ({ page }) => {
   await page.keyboard.press('Escape');
   await expect(page.locator('#replace-panel')).toBeHidden();
 });
+
+// #559 — correcting a match by hand must not cost you the panel or your
+// place in the matches. The click that places the caret used to close the
+// panel, and the re-search dumped you back at match 1.
+test('a click into the transcript leaves the replace panel open (#559)', async ({ page }) => {
+  await search(page, 'captions');
+  await page.click('#find-replace-toggle');
+  await expect(page.locator('#replace-panel')).toBeVisible();
+
+  await page.click('#hypertranscript span[data-m]:not(.speaker)');
+  await expect(page.locator('#replace-panel')).toBeVisible();
+
+  // a click genuinely elsewhere still closes it (the Recents heading is
+  // inert — the player is covered by its own play overlay)
+  await page.click('#recents-title');
+  await expect(page.locator('#replace-panel')).toBeHidden();
+});
+
+test('a hand correction keeps your place in the matches (#559)', async ({ page }) => {
+  // four occurrences of a word, so there is a middle to hold
+  await page.evaluate(() => {
+    const spans = document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)');
+    [0, 3, 6, 9].forEach((i) => { spans[i].textContent = 'widget '; });
+  });
+  await search(page, 'widget');
+  await page.click('#find-replace-toggle');
+  await expect(page.locator('#find-match-count')).toHaveText('1 / 4');
+
+  await page.click('#find-next');
+  await page.click('#find-next');
+  await expect(page.locator('#find-match-count')).toHaveText('3 / 4');
+
+  // hand-correct the THIRD occurrence's neighbour, as a user would
+  await page.evaluate(() => {
+    const spans = document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)');
+    const target = spans[7];
+    const range = document.createRange();
+    range.setStart(target.firstChild, 1);
+    range.collapse(true);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    document.getElementById('hypertranscript').focus();
+  });
+  await page.keyboard.type('X');
+  await page.waitForTimeout(1600); // the debounced re-search
+
+  // still open, still four matches, and anchored at the one we were on —
+  // not reset to 1 / 4
+  await expect(page.locator('#replace-panel')).toBeVisible();
+  await expect(page.locator('#find-match-count')).toHaveText('4 / 4');
+});

--- a/__TEST__/e2e/search.spec.mjs
+++ b/__TEST__/e2e/search.spec.mjs
@@ -72,3 +72,81 @@ test('unread words keep the accessibility contrast, not upstream\'s lighter grey
   // #666 from 5e37ad6 ("best practices and accessibility"), not upstream's #777
   if (colour !== null) expect(colour).toBe('rgb(102, 102, 102)');
 });
+
+// #557 — a phrase is ONE match. searchPhrase marks one span per query word,
+// so "big pharma" used to report two matches per occurrence and Replace
+// swapped a single word's mark: "big pharma" → "Big Pharma" was impossible.
+const openReplace = async (page, query, replacement) => {
+  await page.evaluate(({ q, r }) => {
+    const sb = document.querySelector('#search-box');
+    sb.value = q;
+    sb.dispatchEvent(new KeyboardEvent('keyup'));
+    document.getElementById('find-replace-toggle').click();
+    document.getElementById('replace-box').value = r;
+  }, { q: query, r: replacement });
+};
+const transcriptWords = (page) => page.evaluate(() =>
+  [...document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)')]
+    .map((s) => ({ text: s.textContent.trim(), m: s.getAttribute('data-m'), d: s.getAttribute('data-d') })));
+
+const plantPhrase = (page) => page.evaluate(() => {
+  const spans = document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)');
+  spans[0].textContent = 'big ';
+  spans[1].textContent = 'pharma ';
+  spans[4].textContent = 'big ';
+  spans[5].textContent = 'pharma ';
+});
+
+test('a phrase counts as one match, not one per word (#557)', async ({ page }) => {
+  await plantPhrase(page);
+  await openReplace(page, 'big pharma', 'Big Pharma');
+  await expect(page.locator('#find-match-count')).toHaveText('1 / 2'); // two occurrences
+});
+
+test('replacing a phrase rewrites every word and keeps each span\'s timing (#557)', async ({ page }) => {
+  await plantPhrase(page);
+  const before = (await transcriptWords(page)).slice(0, 6);
+  await openReplace(page, 'big pharma', 'Big Pharma');
+  await page.click('#replace-one');
+  const after = (await transcriptWords(page)).slice(0, 6);
+
+  expect(after[0].text).toBe('Big');
+  expect(after[1].text).toBe('Pharma');
+  // the timings the words were spoken at are untouched
+  expect(after[0].m).toBe(before[0].m);
+  expect(after[0].d).toBe(before[0].d);
+  expect(after[1].m).toBe(before[1].m);
+  expect(after[1].d).toBe(before[1].d);
+  // and the second occurrence is still there, awaiting its turn
+  expect(after[4].text).toBe('big');
+  expect(after[5].text).toBe('pharma');
+});
+
+test('Replace All rewrites every occurrence of a phrase (#557)', async ({ page }) => {
+  await plantPhrase(page);
+  await openReplace(page, 'big pharma', 'Big Pharma');
+  await page.click('#replace-all');
+  const after = (await transcriptWords(page)).slice(0, 6);
+  expect([after[0].text, after[1].text]).toEqual(['Big', 'Pharma']);
+  expect([after[4].text, after[5].text]).toEqual(['Big', 'Pharma']);
+});
+
+test('a shorter replacement drops the spans it empties (#557)', async ({ page }) => {
+  await plantPhrase(page);
+  const before = await transcriptWords(page);
+  await openReplace(page, 'big pharma', 'BigPharma');
+  await page.click('#replace-one');
+  const after = await transcriptWords(page);
+  expect(after[0].text).toBe('BigPharma');
+  expect(after[0].m).toBe(before[0].m);      // first span keeps its timing
+  expect(after.length).toBe(before.length - 1); // the emptied span is gone
+});
+
+test('a longer replacement keeps its surplus in the last span (#557)', async ({ page }) => {
+  await plantPhrase(page);
+  await openReplace(page, 'big pharma', 'the big pharmaceutical industry');
+  await page.click('#replace-one');
+  const after = (await transcriptWords(page)).slice(0, 2);
+  expect(after[0].text).toBe('the');
+  expect(after[1].text).toBe('big pharmaceutical industry');
+});

--- a/__TEST__/e2e/search.spec.mjs
+++ b/__TEST__/e2e/search.spec.mjs
@@ -150,3 +150,33 @@ test('a longer replacement keeps its surplus in the last span (#557)', async ({ 
   expect(after[0].text).toBe('the');
   expect(after[1].text).toBe('big pharmaceutical industry');
 });
+
+// #558 — a search you can clear. The ✕ appears only when there is something
+// to clear, and Escape in the box does the same without closing the panel's
+// world around it.
+test('the ✕ clears the query, the marks and the count (#558)', async ({ page }) => {
+  const clear = page.locator('#search-clear');
+  await expect(clear).toBeHidden(); // nothing to clear yet
+
+  await search(page, 'captions');
+  await expect(clear).toBeVisible();
+  expect(await page.locator('#hypertranscript mark.search-mark').count()).toBeGreaterThan(0);
+
+  await clear.click();
+  expect(await page.inputValue('#search-box')).toBe('');
+  await expect(page.locator('#hypertranscript mark.search-mark')).toHaveCount(0);
+  await expect(clear).toBeHidden();
+});
+
+test('Escape in the search box clears it (#558)', async ({ page }) => {
+  await search(page, 'captions');
+  await page.click('#find-replace-toggle');           // panel open
+  await page.focus('#search-box');
+  await page.keyboard.press('Escape');
+  expect(await page.inputValue('#search-box')).toBe('');
+  await expect(page.locator('#hypertranscript mark.search-mark')).toHaveCount(0);
+  // the first Escape cleared rather than closed; a second one closes
+  await expect(page.locator('#replace-panel')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#replace-panel')).toBeHidden();
+});

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -1370,7 +1370,9 @@ label[data-a11y-wired]:focus-visible {
 #recents-popout {
   position: fixed;
   z-index: 50;
-  max-width: 300px;
+  /* FIXED, not max-: a shrink-to-fit card changed width with every title,
+     so moving down the list made the card jump about. */
+  width: 300px;
   padding: 10px 14px;
   border-radius: 0.5rem;
   background-color: oklch(var(--b1));
@@ -1384,6 +1386,19 @@ label[data-a11y-wired]:focus-visible {
 #recents-popout .recents-popout-name {
   font-weight: 600;
   overflow-wrap: anywhere; /* full filenames without spaces must wrap, not clip */
+  /* ...but only so far: a long interview title ran to five lines and stretched
+     the card past the poster it sits above. Two lines, then ellipsis — the
+     full name is one click away in the ⓘ. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  /* The clamp draws the ellipsis; this CLIPS. (Chrome normalizes display away
+     from -webkit-box when the unprefixed line-clamp is also present, and a
+     third line then rendered below the ellipsis.) An explicit line-height
+     makes the two-line ceiling exact rather than inherited-dependent. */
+  line-height: 1.35;
+  max-height: 2.7em;
 }
 #recents-popout .recents-popout-topics {
   opacity: 0.7;
@@ -1665,3 +1680,24 @@ html.ha-transcribing #upload-transcribe-btn {
 .url-source summary:hover { opacity: 1; }
 .url-source[open] summary { margin-bottom: 10px; }
 .url-source { margin-top: 4px; }
+
+/* Popout poster thumbnail (#523 phase A): first-frame capture for video,
+   tinted wave glyph for audio. Fixed 16:9 box so the card doesn't reflow
+   when the async poster lands. */
+#recents-popout .recents-popout-thumb {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 6px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 8px;
+  color: #5b6472;
+}
+#recents-popout .recents-popout-poster {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -809,7 +809,20 @@ html:has(#hypertranscript[aria-busy="true"]) #transcript-redo { display: none; }
    it lines up with the search box (left edge and width) rather than the wider
    centred form-control */
 #search-wrap { position: relative; flex: 1 1 auto; min-width: 0; max-width: 230px; }
-#search-wrap #search-box { width: 100%; max-width: none; margin-right: 0; }
+#search-wrap #search-box { width: 100%; max-width: none; margin-right: 0; padding-right: 30px; }
+/* Clear control (#558): inside the box's right edge, above the input's own
+   padding so the text never runs under it. */
+#search-wrap #search-clear {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  opacity: 0.55;
+}
+#search-wrap #search-clear:hover { opacity: 1; }
+/* .btn's display:inline-flex outranks the hidden attribute's UA display:none */
+#search-wrap #search-clear[hidden] { display: none; }
 #replace-panel {
   position: absolute;
   top: calc(100% + 6px);

--- a/index.html
+++ b/index.html
@@ -1083,7 +1083,7 @@ If you are creating an open source application under a license compatible with t
 
   </style>
   <script src="js/editor-main.js?v=1.3.1"></script>
-  <script src="js/find-replace.js?v=1.2.0"></script>
+  <script src="js/find-replace.js?v=1.3.3.1"></script>
   <script src="js/transcript-history.js?v=1.3.1"></script>
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>

--- a/index.html
+++ b/index.html
@@ -1106,6 +1106,7 @@ If you are creating an open source application under a license compatible with t
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
   <script src="js/hyperaudio-save.js?v=1.3.3"></script>
   <script src="js/hyperaudio-library.js?v=1.3.3"></script>
+  <script src="js/media-first-frame.js?v=1.3.3.1"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>
 

--- a/index.html
+++ b/index.html
@@ -1084,7 +1084,7 @@ If you are creating an open source application under a license compatible with t
 
   </style>
   <script src="js/editor-main.js?v=1.3.1"></script>
-  <script src="js/find-replace.js?v=1.3.3.2"></script>
+  <script src="js/find-replace.js?v=1.3.3.3"></script>
   <script src="js/transcript-history.js?v=1.3.1"></script>
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.3.3 (last changed in release 1.3.3) -->
+<!--  Hyperaudio Lite Editor - Version 1.3.4 (last changed in release 1.3.4) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.3.3">
+  <meta name="version" content="1.3.4">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.3.3">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.4">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1084,7 +1084,7 @@ If you are creating an open source application under a license compatible with t
 
   </style>
   <script src="js/editor-main.js?v=1.3.1"></script>
-  <script src="js/find-replace.js?v=1.3.3.3"></script>
+  <script src="js/find-replace.js?v=1.3.4"></script>
   <script src="js/transcript-history.js?v=1.3.1"></script>
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>
@@ -1106,9 +1106,9 @@ If you are creating an open source application under a license compatible with t
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
   <script src="js/hyperaudio-save.js?v=1.3.3"></script>
-  <script src="js/hyperaudio-library.js?v=1.3.3.1"></script>
-  <script src="js/media-first-frame.js?v=1.3.3.1"></script>
-  <script src="js/media-posters.js?v=1.3.3.1"></script>
+  <script src="js/hyperaudio-library.js?v=1.3.4"></script>
+  <script src="js/media-first-frame.js?v=1.3.4"></script>
+  <script src="js/media-posters.js?v=1.3.4"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>
 

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.3">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.3.2">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1105,8 +1105,9 @@ If you are creating an open source application under a license compatible with t
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
   <script src="js/hyperaudio-save.js?v=1.3.3"></script>
-  <script src="js/hyperaudio-library.js?v=1.3.3"></script>
+  <script src="js/hyperaudio-library.js?v=1.3.3.1"></script>
   <script src="js/media-first-frame.js?v=1.3.3.1"></script>
+  <script src="js/media-posters.js?v=1.3.3.1"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>
 

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.3.2">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.3.3">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -543,6 +543,7 @@ If you are creating an open source application under a license compatible with t
             <div id="find-row">
               <div id="search-wrap">
                 <input id="search-box" type="text" placeholder="Search" class="input input-bordered" />
+                <button id="search-clear" type="button" class="btn btn-xs btn-ghost btn-circle" aria-label="Clear search" hidden>✕</button>
                 <div id="replace-panel" hidden>
                   <input id="replace-box" type="text" placeholder="Replace with…" class="input input-bordered input-sm" />
                   <div id="replace-actions">
@@ -1083,7 +1084,7 @@ If you are creating an open source application under a license compatible with t
 
   </style>
   <script src="js/editor-main.js?v=1.3.1"></script>
-  <script src="js/find-replace.js?v=1.3.3.1"></script>
+  <script src="js/find-replace.js?v=1.3.3.2"></script>
   <script src="js/transcript-history.js?v=1.3.1"></script>
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>

--- a/js/find-replace.js
+++ b/js/find-replace.js
@@ -1,7 +1,7 @@
 /**
  * find-replace.js
  * (C) The Hyperaudio Project
- * @version 0.6.29 — last changed in release 0.6.29
+ * @version 1.3.3 — last changed in release 1.3.3
  * @license MIT
  *
  * Find & replace for the transcript (#25). "Find" reuses the vendored
@@ -15,8 +15,14 @@
  *    distinct colour (mark.search-mark.active) and scrolled into view.
  *
  * Each match is a <mark> inside a word span; replacing swaps only the mark's text
- * and leaves the span's data-m / data-d timing intact. Works best on single
- * terms — a multi-word phrase is highlighted per word, so stepping is per word.
+ * and leaves the span's data-m / data-d timing intact.
+ *
+ * A PHRASE is one match, not one per word (#557). searchPhrase marks exactly
+ * one span per query word, in consecutive [data-m] spans, for every hit — so
+ * the flat mark list groups cleanly into runs of that length. Stepping, the
+ * counter and the active highlight all work on groups, and replacing a group
+ * distributes the replacement's words across its spans so each keeps its own
+ * timing.
  */
 
 (function () {
@@ -32,8 +38,14 @@
 
   if (searchBox === null || toggle === null || panel === null) return;
 
-  let matches = [];       // ordered mark.search-mark elements in the transcript
+  let matches = [];       // groups of marks: one group per phrase occurrence
   let activeIndex = -1;
+
+  // How many spans searchPhrase marks per hit — the query's word count.
+  const queryWordCount = () => {
+    const words = searchBox.value.trim().split(/\s+/).filter(Boolean);
+    return Math.max(1, words.length);
+  };
 
   const isOpen = () => !panel.hasAttribute('hidden');
 
@@ -43,10 +55,10 @@
   };
 
   const renderActive = () => {
-    matches.forEach((m, i) => m.classList.toggle('active', i === activeIndex));
+    matches.forEach((group, i) => group.forEach((m) => m.classList.toggle('active', i === activeIndex)));
     const active = activeIndex >= 0 ? matches[activeIndex] : null;
     if (active) {
-      active.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      active[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
     }
     countEl.textContent = matches.length ? `${activeIndex + 1} / ${matches.length}` : '0 / 0';
     const has = matches.length > 0;
@@ -57,7 +69,13 @@
 
   // Re-read the highlighted matches after a search run (or a replace).
   const collectMatches = (keepIndex) => {
-    matches = Array.from(document.querySelectorAll('#hypertranscript mark.search-mark'));
+    // Chunk the marks into one group per occurrence. (An overlapping hit —
+    // "a a" against "a a a" — can leave a short final group; it is kept
+    // rather than dropped, so nothing becomes unreachable.)
+    const flat = Array.from(document.querySelectorAll('#hypertranscript mark.search-mark'));
+    const per = queryWordCount();
+    matches = [];
+    for (let i = 0; i < flat.length; i += per) matches.push(flat.slice(i, i + per));
     if (matches.length === 0) {
       activeIndex = -1;
     } else if (!keepIndex || activeIndex < 0) {
@@ -89,10 +107,34 @@
     if (ht !== null) ht.dispatchEvent(new Event('input', { bubbles: true }));
   };
 
-  const replaceMark = (mark) => {
-    const span = mark.closest('[data-m]') || mark.parentNode;
-    mark.replaceWith(document.createTextNode(replaceBox.value));
-    if (span && typeof span.normalize === 'function') span.normalize();
+  // Replace one occurrence — a group of marks spanning consecutive word spans.
+  // The replacement's words are distributed across the group so every span
+  // keeps its own data-m / data-d: equal counts give one word per span (the
+  // "big pharma" -> "Big Pharma" case, timings untouched); a longer
+  // replacement puts the surplus in the last span; a shorter one empties the
+  // spans left over, and any span reduced to nothing is removed with them.
+  const replaceGroup = (group) => {
+    const words = replaceBox.value.trim().split(/\s+/).filter(Boolean);
+    const n = group.length;
+    group.forEach((mark, i) => {
+      const span = mark.closest('[data-m]') || mark.parentNode;
+      let chunk;
+      if (words.length === 0) {
+        chunk = '';
+      } else if (i < n - 1) {
+        chunk = i < words.length ? words[i] : '';
+      } else {
+        chunk = words.slice(n - 1).join(' '); // the last span takes any surplus
+      }
+      mark.replaceWith(document.createTextNode(chunk));
+      if (span && typeof span.normalize === 'function') span.normalize();
+      // A span whose text is now empty holds no word: drop it rather than
+      // leave a timed span with nothing in it for the sanitiser to trip on.
+      if (span && span.hasAttribute && span.hasAttribute('data-m')
+          && span.textContent.trim() === '') {
+        span.remove();
+      }
+    });
   };
 
   const mutateTranscript = (fn, origin) => {
@@ -106,7 +148,7 @@
     if (activeIndex < 0 || !matches[activeIndex]) return;
     const at = activeIndex;
     mutateTranscript(() => {
-      replaceMark(matches[activeIndex]);
+      replaceGroup(matches[activeIndex]);
       markDirty();
     }, 'replace-one');
     runSearch(true);           // refresh; keep position so we land on the next hit
@@ -119,7 +161,7 @@
   const replaceAll = () => {
     if (matches.length === 0) return;
     mutateTranscript(() => {
-      matches.forEach(replaceMark);
+      matches.forEach(replaceGroup);
       markDirty();
     }, 'replace-all');
     activeIndex = -1;

--- a/js/find-replace.js
+++ b/js/find-replace.js
@@ -35,6 +35,7 @@
   const nextBtn = document.getElementById('find-next');
   const replaceOneBtn = document.getElementById('replace-one');
   const replaceAllBtn = document.getElementById('replace-all');
+  const clearBtn = document.getElementById('search-clear');
 
   if (searchBox === null || toggle === null || panel === null) return;
 
@@ -191,6 +192,35 @@
     activeIndex = -1;
     renderActive();
   });
+
+  // Clearing the search (#558): searchPhrase('') unwraps every mark before
+  // its empty-query early return, so one call retires the highlights, the
+  // groups and the count together. The ✕ only shows when there is something
+  // to clear; Escape in the search box does the same from the keyboard.
+  const reflectClearBtn = () => {
+    if (clearBtn !== null) clearBtn.hidden = searchBox.value === '';
+  };
+  const clearSearch = () => {
+    searchBox.value = '';
+    if (typeof searchPhrase === 'function') searchPhrase('');
+    collectMatches(false);
+    reflectClearBtn();
+    searchBox.focus();
+  };
+  if (clearBtn !== null) clearBtn.addEventListener('click', clearSearch);
+  // input covers typing/paste/cut; keyup is what the vendored search itself
+  // hooks, and the only signal a programmatically-set value produces.
+  searchBox.addEventListener('input', reflectClearBtn);
+  searchBox.addEventListener('keyup', reflectClearBtn);
+  searchBox.addEventListener('keydown', (e) => {
+    // Escape clears a non-empty box; an empty one falls through to the
+    // document handler, which closes the replace panel as before.
+    if (e.key === 'Escape' && searchBox.value !== '') {
+      e.stopPropagation();
+      clearSearch();
+    }
+  });
+  reflectClearBtn();
 
   toggle.addEventListener('click', () => { isOpen() ? closePanel() : openPanel(); });
 

--- a/js/find-replace.js
+++ b/js/find-replace.js
@@ -1,7 +1,7 @@
 /**
  * find-replace.js
  * (C) The Hyperaudio Project
- * @version 1.3.3 — last changed in release 1.3.3
+ * @version 1.3.4 — last changed in release 1.3.4
  * @license MIT
  *
  * Find & replace for the transcript (#25). "Find" reuses the vendored

--- a/js/find-replace.js
+++ b/js/find-replace.js
@@ -184,6 +184,92 @@
     clearActive();
   };
 
+  // A hand correction changes the very spans the marks live in, so the match
+  // list goes stale. Re-run the search once the edit settles (past the 1s
+  // maintenance pass), then re-anchor to the first match at or after the
+  // caret instead of dumping the user back at match 1 (#559).
+  //
+  // Re-running rewrites those spans, so the caret is measured as a character
+  // offset within the transcript beforehand and restored after — the offset
+  // survives the unwrap/re-wrap that node references would not.
+  let editTimer = null;
+  let selfEdit = false;
+
+  const caretOffset = () => {
+    const ht = document.getElementById('hypertranscript');
+    const sel = window.getSelection();
+    if (ht === null || sel === null || sel.rangeCount === 0) return null;
+    const range = sel.getRangeAt(0);
+    if (!ht.contains(range.startContainer)) return null;
+    const probe = range.cloneRange();
+    probe.selectNodeContents(ht);
+    probe.setEnd(range.startContainer, range.startOffset);
+    return probe.toString().length;
+  };
+
+  const restoreCaret = (offset) => {
+    const ht = document.getElementById('hypertranscript');
+    if (ht === null || offset === null) return;
+    const walker = document.createTreeWalker(ht, NodeFilter.SHOW_TEXT);
+    let seen = 0;
+    let node = walker.nextNode();
+    while (node !== null) {
+      const len = node.textContent.length;
+      if (seen + len >= offset) {
+        const range = document.createRange();
+        range.setStart(node, Math.max(0, Math.min(len, offset - seen)));
+        range.collapse(true);
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+        return;
+      }
+      seen += len;
+      node = walker.nextNode();
+    }
+  };
+
+  // Which group sits at or after the caret — the match the user was working
+  // on, or the next one down if their edit consumed it.
+  const anchorToCaret = (offset) => {
+    if (matches.length === 0 || offset === null) return;
+    const ht = document.getElementById('hypertranscript');
+    let seen = 0;
+    const walker = document.createTreeWalker(ht, NodeFilter.SHOW_TEXT);
+    const markStart = new Map();
+    for (let node = walker.nextNode(); node !== null; node = walker.nextNode()) {
+      const mark = node.parentNode && node.parentNode.closest
+        ? node.parentNode.closest('mark.search-mark') : null;
+      if (mark !== null && !markStart.has(mark)) markStart.set(mark, seen);
+      seen += node.textContent.length;
+    }
+    const at = matches.findIndex((group) => {
+      const start = markStart.get(group[0]);
+      return start !== undefined && start >= offset;
+    });
+    activeIndex = at === -1 ? matches.length - 1 : at;
+    renderActive();
+  };
+
+  const transcriptEl = document.getElementById('hypertranscript');
+  if (transcriptEl !== null) {
+    transcriptEl.addEventListener('input', () => {
+      if (!isOpen() || selfEdit || searchBox.value === '') return;
+      clearTimeout(editTimer);
+      editTimer = setTimeout(() => {
+        const offset = caretOffset();
+        selfEdit = true;
+        try {
+          runSearch(false);
+          anchorToCaret(offset);
+          restoreCaret(offset);
+        } finally {
+          selfEdit = false;
+        }
+      }, 1200); // past the maintenance pass, so the DOM has settled
+    });
+  }
+
   // A history restore replaces transcript.innerHTML, invalidating every mark
   // reference held in matches. Search is view state: clear its UI cache and do
   // not persist or automatically recreate highlights in the restored document.
@@ -224,9 +310,14 @@
 
   toggle.addEventListener('click', () => { isOpen() ? closePanel() : openPanel(); });
 
-  // Click anywhere outside the find/replace widget closes the panel; Escape too.
+  // Click outside the widget closes the panel — EXCEPT in the transcript
+  // (#559). Correcting a match by hand starts with a click to place the
+  // caret, and closing there punished exactly the flow the panel exists to
+  // support. Clicks anywhere else still close it.
   document.addEventListener('click', (e) => {
-    if (isOpen() && e.target.closest && !e.target.closest('#find-replace')) closePanel();
+    if (!isOpen() || !e.target.closest) return;
+    if (e.target.closest('#find-replace') || e.target.closest('#hypertranscript')) return;
+    closePanel();
   });
   document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && isOpen()) closePanel(); });
 

--- a/js/hyperaudio-library.js
+++ b/js/hyperaudio-library.js
@@ -3,7 +3,7 @@
  * PROJECT LIBRARY PANEL (#456) — the side panel over the OPFS library
  * ============================================================================
  *
- * @version 1.3.3 — last changed in release 1.3.3
+ * @version 1.3.4 — last changed in release 1.3.4
  *
  * The management UX of the former Recents (#434/#435/#440), resurrected from
  * its pre-#451 history and rewired: rows list the library index that

--- a/js/hyperaudio-library.js
+++ b/js/hyperaudio-library.js
@@ -108,6 +108,15 @@
      in the small-screen drawer, where there is no useful hover and no room
      beside the panel. ---- */
 
+  // deterministic per-project hue for the glyph background, so audio rows
+  // differ at a glance without storing anything
+  function hashHue(id) {
+    let h = 0;
+    for (let i = 0; i < id.length; i += 1) h = (h * 31 + id.charCodeAt(i)) % 360;
+    return h;
+  }
+  const WAVE_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 10v3"/><path d="M6 6v11"/><path d="M10 3v18"/><path d="M14 8v7"/><path d="M18 5v13"/><path d="M22 10v3"/></svg>';
+
   const drawerQuery = window.matchMedia('(max-width: 948px)');
   let popoutEl = null;
   let popoutTimer = null;
@@ -128,6 +137,29 @@
     popoutEl = document.createElement('div');
     popoutEl.id = 'recents-popout';
     popoutEl.setAttribute('aria-hidden', 'true'); // hover-only duplicate of kebab→Info
+    // Poster thumbnail (#523 phase A): the stored first-frame capture when
+    // media-posters has one (or the embedder provides one); a generated
+    // wave glyph for audio and everything else. The async fill guards on
+    // popout identity — the card may be gone before the poster arrives.
+    if (entry.media && entry.media.kind !== 'none') {
+      const thumb = document.createElement('div');
+      thumb.className = 'recents-popout-thumb';
+      thumb.style.background = 'hsl(' + (hashHue(entry.id || '')) + ' 30% 88%)';
+      thumb.innerHTML = WAVE_SVG;
+      popoutEl.appendChild(thumb);
+      const posters = window.MediaPosters;
+      if (posters && typeof posters.urlFor === 'function') {
+        const owner = popoutEl;
+        posters.urlFor(entry.id, entry).then((url) => {
+          if (url === null || popoutEl !== owner) return;
+          const img = document.createElement('img');
+          img.className = 'recents-popout-poster';
+          img.alt = '';
+          img.src = url;
+          img.addEventListener('load', () => { if (popoutEl === owner) thumb.replaceChildren(img); });
+        }).catch(() => {});
+      }
+    }
     const name = document.createElement('p');
     name.className = 'recents-popout-name';
     name.textContent = entry.name || 'project';
@@ -151,7 +183,7 @@
     document.body.appendChild(popoutEl);
     const paneRect = pane.getBoundingClientRect();
     const rowRect = rowEl.getBoundingClientRect();
-    popoutEl.style.left = Math.round(paneRect.right + 8) + 'px';
+    popoutEl.style.left = Math.round(paneRect.right) + 'px'; // flush with the panel's right edge
     const size = popoutEl.getBoundingClientRect();
     popoutEl.style.top = Math.round(Math.max(8,
       Math.min(rowRect.top, window.innerHeight - size.height - 8))) + 'px';

--- a/js/media-first-frame.js
+++ b/js/media-first-frame.js
@@ -1,7 +1,7 @@
 /**
  * media-first-frame.js
  * (C) The Hyperaudio Project
- * @version 1.3.3 — new in 1.3.x
+ * @version 1.3.4 — new in 1.3.4
  * @license MIT
  *
  * First-frame display for video media (#556). A <video> shows its poster —

--- a/js/media-first-frame.js
+++ b/js/media-first-frame.js
@@ -1,0 +1,54 @@
+/**
+ * media-first-frame.js
+ * (C) The Hyperaudio Project
+ * @version 1.3.3 — new in 1.3.x
+ * @license MIT
+ *
+ * First-frame display for video media (#556). A <video> shows its poster —
+ * or nothing — until a frame is decoded, which with preload=metadata never
+ * happens on its own: opened video projects sat on the generic demo poster
+ * or a black box until played. On metadata, video media drops the generic
+ * poster and takes an epsilon seek so the real first frame paints; audio
+ * media keeps the poster (better than a black box). The player's
+ * aspect-ratio is pinned from the incoming dimensions so the layout stops
+ * shifting on project switches. Dimensions can arrive late on some sources
+ * (MSE/HLS), so the reveal listens across every event they can appear on.
+ *
+ * Self-contained and removable: no other module depends on this file.
+ */
+(function firstFrameForVideo() {
+  function wire() {
+    const player = document.getElementById('hyperplayer');
+    if (player === null) { setTimeout(wire, 500); return; }
+    const defaultPoster = player.getAttribute('poster');
+    let nudged = false;
+
+    player.addEventListener('loadstart', () => {
+      // A new medium is loading: back to the generic poster until it proves
+      // itself video; a previous video's aspect pin must not squeeze it.
+      nudged = false;
+      if (defaultPoster !== null && player.getAttribute('poster') === null) {
+        player.setAttribute('poster', defaultPoster);
+      }
+      player.style.aspectRatio = '';
+    });
+
+    function reveal() {
+      if (player.videoWidth <= 0) return; // audio, or dimensions not known yet
+      player.style.aspectRatio = player.videoWidth + ' / ' + player.videoHeight;
+      if (player.getAttribute('poster') !== null) player.removeAttribute('poster');
+      if (!nudged && player.paused && player.currentTime === 0) {
+        nudged = true;
+        try { player.currentTime = 0.0001; } catch (e) { /* decoder not ready — harmless */ }
+      }
+    }
+    ['loadedmetadata', 'loadeddata', 'resize', 'canplay'].forEach((ev) => {
+      player.addEventListener(ev, reveal);
+    });
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', wire);
+  } else {
+    wire();
+  }
+})();

--- a/js/media-posters.js
+++ b/js/media-posters.js
@@ -1,0 +1,145 @@
+/**
+ * media-posters.js
+ * (C) The Hyperaudio Project
+ * @version 1.3.3 — new in 1.3.x
+ * @license MIT
+ *
+ * Project posters (#523 phase A): a first-frame JPEG captured from each
+ * video project's media, stored as poster.jpg beside the project's other
+ * OPFS files (work/<id>/ — the layout hyperaudio-save owns; this module is
+ * a read/write guest there and touches nothing else). Capture is lazy and
+ * idempotent: whenever the library changes, the CURRENT project's poster is
+ * ensured — covering birth, open and media attach — so pre-existing
+ * projects grow posters as they are visited. Audio media captures nothing
+ * (the wave glyph in the hover popout is generated, not stored).
+ *
+ * Embedder seam: a host application may provide ready-made posters by
+ * defining window.hyperaudioMediaPoster(entry) → url|null|Promise thereof;
+ * when it yields a url, that wins and no canvas capture happens.
+ *
+ * Self-contained and removable: the library popout probes this module via
+ * window.MediaPosters and degrades to its glyph when absent.
+ */
+(function mediaPosters() {
+  const POSTER_NAME = 'poster.jpg';
+  const CAPTURE_WIDTH = 320;
+  const CAPTURE_TIMEOUT_MS = 8000;
+  const urlCache = new Map(); // id → object URL of poster.jpg (or null probe result)
+
+  async function projectDir(id, create) {
+    const root = await navigator.storage.getDirectory();
+    const work = await root.getDirectoryHandle('work', { create: false });
+    return work.getDirectoryHandle(id, { create: create === true });
+  }
+
+  async function readPoster(id) {
+    try {
+      const dir = await projectDir(id, false);
+      const handle = await dir.getFileHandle(POSTER_NAME);
+      return await handle.getFile();
+    } catch (e) {
+      return null;
+    }
+  }
+
+  async function firstMediaFile(id) {
+    try {
+      const dir = await projectDir(id, false);
+      const mediaDir = await dir.getDirectoryHandle('media');
+      for await (const [, handle] of mediaDir.entries()) {
+        if (handle.kind === 'file') return handle.getFile();
+      }
+    } catch (e) { /* no media stored */ }
+    return null;
+  }
+
+  // First-frame capture. Resolves null for audio (videoWidth 0), decode
+  // failure, CORS taint, or timeout — null means "no poster", never throws.
+  function captureFrameBlob(objectUrl) {
+    return new Promise((resolve) => {
+      const video = document.createElement('video');
+      video.muted = true;
+      video.playsInline = true;
+      video.preload = 'auto';
+      let settled = false;
+      const done = (blob) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        video.removeAttribute('src');
+        video.load();
+        resolve(blob || null);
+      };
+      const timer = setTimeout(() => done(null), CAPTURE_TIMEOUT_MS);
+      const tryDraw = () => {
+        if (video.videoWidth <= 0 || video.readyState < 2 /* HAVE_CURRENT_DATA */) return;
+        const canvas = document.createElement('canvas');
+        canvas.width = CAPTURE_WIDTH;
+        canvas.height = Math.max(1, Math.round(CAPTURE_WIDTH * video.videoHeight / video.videoWidth));
+        try {
+          canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
+          canvas.toBlob((blob) => done(blob), 'image/jpeg', 0.75);
+        } catch (e) {
+          done(null); // tainted canvas or draw failure
+        }
+      };
+      video.addEventListener('loadeddata', () => {
+        // decode the true first frame, then draw on the seek's completion
+        try { video.currentTime = 0.0001; } catch (e) { tryDraw(); }
+      });
+      video.addEventListener('seeked', tryDraw);
+      video.addEventListener('canplay', tryDraw);
+      video.addEventListener('error', () => done(null));
+      video.src = objectUrl;
+    });
+  }
+
+  let ensureChain = Promise.resolve(); // captures serialize; they're heavy
+  function ensureProjectPoster(id) {
+    ensureChain = ensureChain.then(async () => {
+      if (!id) return;
+      if (await readPoster(id) !== null) return; // once is enough
+      const media = await firstMediaFile(id);
+      if (media === null) return;
+      const url = URL.createObjectURL(media);
+      try {
+        const blob = await captureFrameBlob(url);
+        if (blob === null) return; // audio or uncapturable — the glyph serves
+        const dir = await projectDir(id, false);
+        const handle = await dir.getFileHandle(POSTER_NAME, { create: true });
+        const w = await handle.createWritable();
+        await w.write(blob);
+        await w.close();
+        urlCache.delete(id); // next urlFor sees the fresh file
+      } finally {
+        URL.revokeObjectURL(url);
+      }
+    }).catch(() => { /* ensure never breaks a caller */ });
+    return ensureChain;
+  }
+
+  // Poster URL for an entry: the embedder's poster wins; else the stored
+  // capture; else null (caller shows its glyph). Cached per project id.
+  async function urlFor(id, entry) {
+    const hook = window.hyperaudioMediaPoster;
+    if (typeof hook === 'function') {
+      try {
+        const hooked = await hook(entry || { id });
+        if (hooked) return hooked;
+      } catch (e) { /* the embedder's problem — fall through */ }
+    }
+    if (urlCache.has(id)) return urlCache.get(id);
+    const file = await readPoster(id);
+    if (file === null) return null; // a miss is not cached — posters arrive late
+    const url = URL.createObjectURL(file);
+    urlCache.set(id, url);
+    return url;
+  }
+
+  document.addEventListener('hyperaudioLibraryChanged', () => {
+    const lib = window.HyperaudioSave && window.HyperaudioSave.library;
+    if (lib && typeof lib.currentId === 'function') ensureProjectPoster(lib.currentId());
+  });
+
+  window.MediaPosters = Object.freeze({ ensureProjectPoster, urlFor, captureFrameBlob });
+})();

--- a/js/media-posters.js
+++ b/js/media-posters.js
@@ -1,7 +1,7 @@
 /**
  * media-posters.js
  * (C) The Hyperaudio Project
- * @version 1.3.3 — new in 1.3.x
+ * @version 1.3.4 — new in 1.3.4
  * @license MIT
  *
  * Project posters (#523 phase A): a first-frame JPEG captured from each


### PR DESCRIPTION
Find & replace grows up, and projects show their faces.

- **A phrase is one match** (#557): the search marks one span per query word, so "big pharma" counted as two matches per occurrence and Replace swapped a single word — "big pharma" → "Big Pharma" was impossible. Matches now group per occurrence, and replacing distributes the replacement's words across the group so every word keeps its own timing; a longer replacement puts the surplus in the last span, a shorter one removes the spans it empties.
- **A search you can clear** (#558): a ✕ in the search box, and Escape while it's focused.
- **A hand correction no longer costs you the panel or your place** (#559): the click that places your caret used to close the replace panel; now the panel stays and, once the edit settles, the search re-runs and re-anchors to the match at or after your caret instead of resetting to the first.
- **Project posters** (#523 phase A): each video project captures a first-frame poster, shown in the Recents hover card; audio projects get a tinted wave glyph. Long titles clamp to two lines and the card holds a fixed width, so it no longer jumps about as you move down the list. Hosts embedding the editor can supply their own posters via `window.hyperaudioMediaPoster`.
- **Opening a video project shows its first frame** (#556) rather than black or the demo poster, with the player's aspect ratio pinned so the layout stops shifting on switches.

Fixes #556. Fixes #557. Fixes #558. Fixes #559.

#523 stays open for phase B (thumbnails in the rows themselves).

Suite: 81 unit + 222 e2e green (1 known Playwright-WebKit OPFS skip).
