### PR TITLE
Version 1.3.5

### DIFF
--- a/__TEST__/e2e/search.spec.mjs
+++ b/__TEST__/e2e/search.spec.mjs
@@ -232,3 +232,29 @@ test('a hand correction keeps your place in the matches (#559)', async ({ page }
   await expect(page.locator('#replace-panel')).toBeVisible();
   await expect(page.locator('#find-match-count')).toHaveText('4 / 4');
 });
+
+// The group size must follow the VENDORED search's needles, not raw
+// whitespace tokens: it strips punctuation per word and drops any that
+// empties. "big , pharma" is two needles — grouping by three misaligned
+// every match after the first.
+test('a query with a punctuation-only token still groups correctly (#557)', async ({ page }) => {
+  await page.evaluate(() => {
+    const spans = document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)');
+    spans[0].textContent = 'big '; spans[1].textContent = 'pharma ';
+    spans[4].textContent = 'big '; spans[5].textContent = 'pharma ';
+  });
+  await page.evaluate(() => {
+    const sb = document.querySelector('#search-box');
+    sb.value = 'big , pharma';           // three tokens, two needles
+    sb.dispatchEvent(new KeyboardEvent('keyup'));
+    document.getElementById('find-replace-toggle').click();
+    document.getElementById('replace-box').value = 'Big Pharma';
+  });
+  await expect(page.locator('#find-match-count')).toHaveText('1 / 2');
+  await page.click('#replace-all');
+  const words = await page.evaluate(() =>
+    [...document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)')]
+      .slice(0, 6).map((s) => s.textContent.trim()));
+  expect([words[0], words[1]]).toEqual(['Big', 'Pharma']);
+  expect([words[4], words[5]]).toEqual(['Big', 'Pharma']);
+});

--- a/__TEST__/e2e/search.spec.mjs
+++ b/__TEST__/e2e/search.spec.mjs
@@ -258,3 +258,67 @@ test('a query with a punctuation-only token still groups correctly (#557)', asyn
   expect([words[0], words[1]]).toEqual(['Big', 'Pharma']);
   expect([words[4], words[5]]).toEqual(['Big', 'Pharma']);
 });
+
+// #568 — the vendored search walks one needle per consecutive span, so a
+// phrase living wholly inside ONE span never matched: every multi-word
+// speaker label, making speaker renames impossible.
+const plantLabel = (page, openPanel = true) => page.evaluate((open) => {
+  document.querySelector('#hypertranscript span.speaker').textContent = '[Teon Brooks] ';
+  if (open) document.getElementById('find-replace-toggle').click();
+}, openPanel);
+
+// Searching is the common case and does NOT involve the replace panel: the
+// pass must run for plain search too. (It was panel-gated at first, and
+// every test opened the panel — so nothing caught it.)
+test('a multi-word phrase inside one span matches with the panel CLOSED (#568)', async ({ page }) => {
+  await plantLabel(page, false);
+  for (const query of ['[Teon Brooks]', 'Teon Brooks']) {
+    const marks = await search(page, query);
+    expect(marks, query).toEqual([query.startsWith('[') ? '[Teon Brooks]' : 'Teon Brooks']);
+  }
+  expect(await page.evaluate(() =>
+    document.getElementById('replace-panel').hasAttribute('hidden'))).toBe(true); // never opened
+});
+
+test('a multi-word phrase inside one span matches, brackets and all (#568)', async ({ page }) => {
+  await plantLabel(page);
+  for (const query of ['[Teon Brooks]', 'Teon Brooks', 'teon brooks']) {
+    const marks = await search(page, query);
+    expect(marks, query).toEqual([query.startsWith('[') ? '[Teon Brooks]' : 'Teon Brooks']);
+  }
+  await expect(page.locator('#find-match-count')).toHaveText('1 / 1');
+});
+
+test('a speaker label can be renamed through replace (#568)', async ({ page }) => {
+  await plantLabel(page);
+  await search(page, '[Teon Brooks]');
+  await page.evaluate(() => { document.getElementById('replace-box').value = '[Teon]'; });
+  await page.click('#replace-one');
+  expect(await page.evaluate(() =>
+    document.querySelector('#hypertranscript span.speaker').textContent.trim())).toBe('[Teon]');
+});
+
+test('the single-span pass leaves ordinary cross-span phrases alone (#568)', async ({ page }) => {
+  await page.evaluate(() => {
+    const spans = document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)');
+    spans[0].textContent = 'big '; spans[1].textContent = 'pharma ';
+    document.getElementById('find-replace-toggle').click();
+  });
+  const marks = await search(page, 'big pharma');
+  expect(marks).toEqual(['big', 'pharma']); // still two marks, one per span
+  await expect(page.locator('#find-match-count')).toHaveText('1 / 1'); // ...one match
+});
+
+// The panel needs a visible exit: clicking away still closes it, but since
+// transcript clicks deliberately keep it open (#559), most of the screen no
+// longer dismisses it.
+test('the replace panel has a close button', async ({ page }) => {
+  await page.click('#find-replace-toggle');
+  await expect(page.locator('#replace-panel')).toBeVisible();
+  await page.click('#replace-close');
+  await expect(page.locator('#replace-panel')).toBeHidden();
+  // the toggle agrees it is shut, so one click reopens it
+  await expect(page.locator('#find-replace-toggle')).toHaveAttribute('aria-expanded', 'false');
+  await page.click('#find-replace-toggle');
+  await expect(page.locator('#replace-panel')).toBeVisible();
+});

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -852,6 +852,9 @@ html:has(#hypertranscript[aria-busy="true"]) #transcript-redo { display: none; }
   white-space: nowrap;
 }
 .replace-spacer { flex: 1; }
+/* The panel's explicit exit, set a little apart from the actions it follows */
+#replace-close { margin-left: 4px; opacity: 0.6; }
+#replace-close:hover { opacity: 1; }
 /* Outranks both the general hit above and upstream's .search-mark on specificity
    rather than on source order, so reordering this sheet cannot silently lose the
    active-match colour. */

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.4">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.4.1">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -553,6 +553,7 @@ If you are creating an open source application under a license compatible with t
                     <span class="replace-spacer"></span>
                     <button id="replace-one" type="button" class="btn btn-xs">Replace</button>
                     <button id="replace-all" type="button" class="btn btn-xs btn-primary">All</button>
+                    <button id="replace-close" type="button" class="btn btn-xs btn-ghost" aria-label="Close find and replace" title="Close">✕</button>
                   </div>
                 </div>
               </div>
@@ -1084,7 +1085,7 @@ If you are creating an open source application under a license compatible with t
 
   </style>
   <script src="js/editor-main.js?v=1.3.1"></script>
-  <script src="js/find-replace.js?v=1.3.4"></script>
+  <script src="js/find-replace.js?v=1.3.4.3"></script>
   <script src="js/transcript-history.js?v=1.3.1"></script>
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.3.4 (last changed in release 1.3.4) -->
+<!--  Hyperaudio Lite Editor - Version 1.3.5 (last changed in release 1.3.5) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.3.4">
+  <meta name="version" content="1.3.5">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.4.1">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.5">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1085,7 +1085,7 @@ If you are creating an open source application under a license compatible with t
 
   </style>
   <script src="js/editor-main.js?v=1.3.1"></script>
-  <script src="js/find-replace.js?v=1.3.4.3"></script>
+  <script src="js/find-replace.js?v=1.3.5"></script>
   <script src="js/transcript-history.js?v=1.3.1"></script>
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>

--- a/js/find-replace.js
+++ b/js/find-replace.js
@@ -36,6 +36,7 @@
   const replaceOneBtn = document.getElementById('replace-one');
   const replaceAllBtn = document.getElementById('replace-all');
   const clearBtn = document.getElementById('search-clear');
+  const closeBtn = document.getElementById('replace-close');
 
   if (searchBox === null || toggle === null || panel === null) return;
 
@@ -87,7 +88,15 @@
     const flat = Array.from(document.querySelectorAll('#hypertranscript mark.search-mark'));
     const per = queryWordCount();
     matches = [];
-    for (let i = 0; i < flat.length; i += per) matches.push(flat.slice(i, i + per));
+    for (let i = 0; i < flat.length; ) {
+      if (flat[i].hasAttribute(WHOLE)) {
+        matches.push([flat[i]]); // the whole phrase in one span: a match by itself
+        i += 1;
+      } else {
+        matches.push(flat.slice(i, i + per));
+        i += per;
+      }
+    }
     if (matches.length === 0) {
       activeIndex = -1;
     } else if (!keepIndex || activeIndex < 0) {
@@ -98,11 +107,76 @@
     renderActive();
   };
 
+  // The vendored search walks ONE needle per consecutive span, so a phrase
+  // whose words all sit inside a single span never matches — which is every
+  // multi-word speaker label ("[Teon Brooks] " is one span), making speaker
+  // renames impossible (#568). This supplementary pass marks those
+  // whole-in-one-span occurrences the vendored pass cannot see. The mark
+  // carries data-whole-phrase so collectMatches treats it as a COMPLETE
+  // match rather than chunking it by needle count.
+  const WHOLE = 'data-whole-phrase';
+  const markWholePhraseSpans = () => {
+    const needles = searchBox.value
+      .toLowerCase()
+      .split(/\s+/)
+      .map((w) => w.replace(QUERY_PUNCT, ''))
+      .filter(Boolean);
+    if (needles.length < 2) return; // single needles are the vendored pass's job
+    const joined = needles.join('');
+    document.querySelectorAll('#hypertranscript [data-m]').forEach((span) => {
+      if (span.querySelector('mark.search-mark') !== null) return; // already marked
+      const raw = span.textContent;
+      const normalised = raw.toLowerCase().replace(QUERY_PUNCT, '');
+      if (!normalised.includes(joined)) return;
+      // Walk the raw text consuming the needle characters, skipping the
+      // punctuation and spaces between them, so the mark covers the phrase
+      // exactly as written — "[Teon Brooks]" including its space.
+      let start = -1;
+      let ni = 0;
+      for (let i = 0; i < raw.length && ni < joined.length; i += 1) {
+        const ch = raw[i].toLowerCase();
+        if (ch === joined[ni]) {
+          if (ni === 0) start = i;
+          ni += 1;
+        } else if (QUERY_PUNCT.test(ch)) {
+          QUERY_PUNCT.lastIndex = 0; // the /g regex is stateful in .test()
+          if (ni > 0) continue;      // punctuation inside the phrase is skipped
+        } else {
+          QUERY_PUNCT.lastIndex = 0;
+          ni = 0;
+          start = -1;
+        }
+        QUERY_PUNCT.lastIndex = 0;
+      }
+      if (ni < joined.length || start < 0) return;
+      let end = start;
+      let consumed = 0;
+      while (end < raw.length && consumed < joined.length) {
+        const ch = raw[end].toLowerCase();
+        if (ch === joined[consumed]) consumed += 1;
+        end += 1;
+      }
+      const before = raw.slice(0, start);
+      const hit = raw.slice(start, end);
+      const after = raw.slice(end);
+      span.textContent = '';
+      if (before) span.append(before);
+      const mark = document.createElement('mark');
+      mark.className = 'search-mark';
+      mark.setAttribute(WHOLE, '');
+      mark.textContent = hit;
+      span.append(mark);
+      if (after) span.append(after);
+      span.classList.add('search-match');
+    });
+  };
+
   // Run the existing search, then pick up its marks.
   const runSearch = (keepIndex) => {
     if (typeof searchPhrase === 'function') {
       searchPhrase(searchBox.value);
     }
+    markWholePhraseSpans();
     collectMatches(keepIndex);
   };
 
@@ -332,10 +406,21 @@
   });
   document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && isOpen()) closePanel(); });
 
-  // The extension already runs searchPhrase on search-box keyup; collect after
-  // it so the match list and active highlight stay in sync while typing.
-  searchBox.addEventListener('keyup', () => { if (isOpen()) collectMatches(false); });
+  // The extension already runs searchPhrase on search-box keyup — which
+  // CLEARS every mark and re-applies only what it can see — so the
+  // single-span pass has to run again after it, not just collect (#568).
+  searchBox.addEventListener('keyup', () => {
+    // The single-span pass belongs to SEARCH, not to the replace panel:
+    // plain searching is the common case and must find the same phrases.
+    // (Only the match bookkeeping below is panel-only.)
+    markWholePhraseSpans();
+    if (isOpen()) collectMatches(false);
+  });
 
+  // An explicit way out. Clicking away still closes the panel, but since
+  // transcript clicks deliberately keep it open (#559) most of the screen no
+  // longer dismisses it — so the exit has to be visible.
+  if (closeBtn) closeBtn.addEventListener('click', () => { closePanel(); searchBox.focus(); });
   if (prevBtn) prevBtn.addEventListener('click', () => step(-1));
   if (nextBtn) nextBtn.addEventListener('click', () => step(1));
   if (replaceOneBtn) replaceOneBtn.addEventListener('click', replaceOne);

--- a/js/find-replace.js
+++ b/js/find-replace.js
@@ -42,10 +42,21 @@
   let matches = [];       // groups of marks: one group per phrase occurrence
   let activeIndex = -1;
 
-  // How many spans searchPhrase marks per hit — the query's word count.
+  // How many spans searchPhrase marks per hit. This must count the needles
+  // the VENDORED search derives, not raw whitespace tokens: it strips
+  // punctuation from each word and drops any that empties, so a query like
+  // "big - pharma" yields two needles, not three. Counting tokens instead
+  // grouped the marks in threes and misaligned every match after the first.
+  // (Mirrors SEARCH_PUNCT in hyperaudio-lite-extension.js, which is vendored
+  // and must not be imported from.)
+  const QUERY_PUNCT = /[.,\-\/#!$%\^&\*;:{}=_`~()\?\s]/g;
   const queryWordCount = () => {
-    const words = searchBox.value.trim().split(/\s+/).filter(Boolean);
-    return Math.max(1, words.length);
+    const needles = searchBox.value
+      .toLowerCase()
+      .split(/\s+/)
+      .map((w) => w.replace(QUERY_PUNCT, ''))
+      .filter(Boolean);
+    return Math.max(1, needles.length);
   };
 
   const isOpen = () => !panel.hasAttribute('hidden');

--- a/js/find-replace.js
+++ b/js/find-replace.js
@@ -1,7 +1,7 @@
 /**
  * find-replace.js
  * (C) The Hyperaudio Project
- * @version 1.3.4 — last changed in release 1.3.4
+ * @version 1.3.5 — last changed in release 1.3.5
  * @license MIT
  *
  * Find & replace for the transcript (#25). "Find" reuses the vendored


### PR DESCRIPTION
A point release for two find & replace fixes found in live use straight after 1.3.4.

- **A phrase inside a single word span can be found and replaced** (#568): the vendored search walks one needle per *consecutive* span, so a phrase whose words all live in one span never matched — which is every multi-word speaker label, making speaker renames impossible. A supplementary pass marks those occurrences, tagged so the phrase grouping treats each as one complete match; the mark covers the phrase exactly as written, brackets and internal spaces included. Two things the first attempt got wrong, both caught in live testing: the vendored search re-runs on every keyup and clears all marks, so the pass must re-apply after it; and the pass was gated on the replace panel being open, so plain searching — the common case — never saw it.
- **The replace panel has a visible way out** (#569): a ✕ at the end of the action row. Escape and clicking away still work, but since #559 transcript clicks deliberately keep the panel open, most of the screen no longer dismisses it.

Fixes #568. Fixes #569.

Suite: 81 unit + 228 e2e green (1 known Playwright-WebKit OPFS skip).
