### PR TITLE
Version 1.3.6

### DIFF
--- a/__TEST__/e2e/export-copy-button.spec.mjs
+++ b/__TEST__/e2e/export-copy-button.spec.mjs
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+
+// #564 — the exported page carries the editor's copy contract (#467): the
+// WHOLE transcript, always; a plain-text and a conservative HTML flavour;
+// struck words excluded (they are speech the author removed); and visible
+// confirmation, because a clipboard write is otherwise invisible.
+//
+// The exported page is driven directly here, with its CDN dependencies
+// stubbed — this tests OUR script, not hyperaudio-lite's.
+test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+
+const exportedPage = async (page, context) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  // strike a word: the copy must leave it out
+  await page.evaluate(() => {
+    const span = document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)')[1];
+    span.textContent = 'STRUCKWORD ';   // unique, so its absence is provable
+    span.style.textDecoration = 'line-through';
+  });
+  const downloadPromise = page.waitForEvent('download');
+  await page.evaluate(() => {
+    document.getElementById('interactive-export-modal').checked = true;
+    document.getElementById('interactive-media-filename').value = 'clip.mp4';
+    document.getElementById('interactive-export-download').click();
+  });
+  const download = await downloadPromise;
+  const chunks = [];
+  for await (const chunk of await download.createReadStream()) chunks.push(chunk);
+  const html = Buffer.concat(chunks).toString('utf8');
+
+  // the exported page's own dependencies are not under test
+  await context.route('https://cdn.jsdelivr.net/**', (route) => route.fulfill({
+    status: 200,
+    contentType: route.request().url().endsWith('.css') ? 'text/css' : 'text/javascript',
+    body: '',
+  }));
+  // Served from the real origin, not setContent: the clipboard API only
+  // exists in a secure context, and about:blank is not one.
+  await context.route('http://localhost:4173/__exported-transcript.html',
+    (route) => route.fulfill({ status: 200, contentType: 'text/html', body: html }));
+  const exported = await context.newPage();
+  await exported.goto('http://localhost:4173/__exported-transcript.html');
+  return exported;
+};
+
+test('the exported page copies the whole transcript, struck words excluded (#564)', async ({ page, context }) => {
+  const exported = await exportedPage(page, context);
+  await exported.click('#ht-copy');
+  const copied = await exported.evaluate(() => navigator.clipboard.readText());
+
+  expect(copied.length).toBeGreaterThan(50);       // the whole transcript
+  expect(copied).not.toContain('STRUCKWORD');      // ...minus the struck word
+  expect(copied).not.toContain('[');               // speakers read "Name: ", not "[Name]"
+  expect(copied.split('\n\n').length).toBeGreaterThan(1); // paragraphs survive
+});
+
+test('the copy button confirms itself, then returns (#564)', async ({ page, context }) => {
+  const exported = await exportedPage(page, context);
+  await exported.click('#ht-copy');
+  // icon-only, so the confirmation is the checkmark, the colour and the label
+  await expect(exported.locator('#ht-copy')).toHaveAttribute('data-copied', '1');
+  await expect(exported.locator('#ht-copy')).toHaveAttribute('aria-label', 'Transcript copied');
+  await expect(exported.locator('[role="status"]')).toHaveText('Transcript copied to clipboard.');
+  // and it goes back, so a second copy is obviously possible
+  await expect(exported.locator('#ht-copy')).not.toHaveAttribute('data-copied', '1', { timeout: 4000 });
+  await expect(exported.locator('#ht-copy')).toHaveAttribute('aria-label', 'Copy transcript');
+  expect((await exported.locator('#ht-copy').textContent()).trim()).toBe(''); // no text, ever
+});

--- a/__TEST__/e2e/export-stale-media.spec.mjs
+++ b/__TEST__/e2e/export-stale-media.spec.mjs
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+
+// An object URL made from an OPFS file is a SNAPSHOT: once that file is
+// rewritten — which any save that re-writes media does — the URL still plays
+// from buffered data but can no longer be read back. The media exporter read
+// the player's src for its bytes, so those projects failed with a raw
+// "Failed to fetch" while others exported fine. The exporter now takes the
+// library's stored file first, and says something true when it cannot.
+
+const makeVideoProject = async (page) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  await page.evaluate(async () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 320; canvas.height = 180;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#48c'; ctx.fillRect(0, 0, 320, 180);
+    const rec = new MediaRecorder(canvas.captureStream(10), { mimeType: 'video/webm' });
+    const chunks = [];
+    rec.ondataavailable = (e) => chunks.push(e.data);
+    const stopped = new Promise((r) => { rec.onstop = r; });
+    rec.start();
+    let n = 0;
+    await new Promise((done) => {
+      const t = setInterval(() => { ctx.fillRect(0, 0, 320, 180); if (++n >= 15) { clearInterval(t); rec.stop(); done(); } }, 100);
+    });
+    await stopped;
+    const file = new File(chunks, 'conference talk.webm', { type: 'video/webm' });
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    const input = document.getElementById('file-input');
+    input.files = dt.files;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    document.getElementById('hyperplayer').src = URL.createObjectURL(file);
+    document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+    for (let i = 0; i < 60 && window.HyperaudioSave.library.currentId() === null; i += 1) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  });
+  await page.waitForTimeout(1200);
+};
+
+test('the exporter reads the stored media, not a stale player URL', async ({ page }) => {
+  await makeVideoProject(page);
+
+  // exactly the failure mode: the player's object URL is dead, as it is once
+  // the OPFS file behind it has been rewritten
+  await page.evaluate(() => {
+    const p = document.getElementById('hyperplayer');
+    URL.revokeObjectURL(p.src);
+  });
+
+  const bytes = await page.evaluate(async () => {
+    const blob = await window.HyperaudioSave.currentMediaFile();
+    return blob ? blob.size : 0;
+  });
+  expect(bytes).toBeGreaterThan(1000); // the library still has the real file
+
+  const status = await page.evaluate(async () => {
+    const m = document.getElementById('export-modal');
+    m.checked = true; m.dispatchEvent(new Event('change'));
+    await new Promise((r) => setTimeout(r, 1500));
+    const set = (id, on) => { const c = document.getElementById(id); if (c) { c.checked = on; c.dispatchEvent(new Event('change')); } };
+    ['export-vtt', 'export-burn', 'export-project', 'export-srt'].forEach((id) => set(id, false));
+    set('export-interactive', true);
+    document.getElementById('export-start').click();
+    for (let i = 0; i < 120; i += 1) {
+      const s = document.getElementById('export-status').textContent;
+      if (s.startsWith('Done') || s.toLowerCase().includes('fail')) return s;
+      await new Promise((r) => setTimeout(r, 300));
+    }
+    return 'TIMEOUT ' + document.getElementById('export-status').textContent;
+  });
+  expect(status).toContain('Done');
+});

--- a/__TEST__/e2e/export-zip.spec.mjs
+++ b/__TEST__/e2e/export-zip.spec.mjs
@@ -66,7 +66,12 @@ test('a multi-file export downloads once, as a zip holding one folder', async ({
   await page.waitForFunction(
     () => document.getElementById('export-status').textContent.startsWith('Done'));
 
-  expect(download.suggestedFilename()).toBe('my clip.zip');
+  // Since #560 the names we WRITE carry no spaces: the interactive transcript
+  // links its media by bare filename, and a space there means the page says
+  // "my%20clip.wav" while the disk says "my clip.wav" — a pair static hosts
+  // and equality checks handle inconsistently. The typed name is the user's;
+  // the written ones are ours to make safe.
+  expect(download.suggestedFilename()).toBe('my_clip.zip');
 
   const fs = await import('node:fs/promises');
   const zip = await JSZip.loadAsync(await fs.readFile(await download.path()));
@@ -74,14 +79,14 @@ test('a multi-file export downloads once, as a zip holding one folder', async ({
 
   // every entry sits under exactly one top-level folder
   const tops = new Set(paths.map((p) => p.split('/')[0]));
-  expect([...tops]).toEqual(['my clip']);
+  expect([...tops]).toEqual(['my_clip']);
 
   // and that folder holds both files, under their own names
   const names = paths.filter((p) => !zip.files[p].dir).map((p) => p.split('/').pop()).sort();
-  expect(names).toEqual(['my clip.srt', 'my clip.wav']);
+  expect(names).toEqual(['my_clip.srt', 'my_clip.wav']);
 
   // the media survives the round trip as real bytes
-  const wavEntry = zip.file('my clip/my clip.wav');
+  const wavEntry = zip.file('my_clip/my_clip.wav');
   expect(wavEntry).not.toBeNull();
   const bytes = await wavEntry.async('uint8array');
   expect(bytes.length).toBeGreaterThan(1000);

--- a/__TEST__/e2e/interactive-export-template.spec.mjs
+++ b/__TEST__/e2e/interactive-export-template.spec.mjs
@@ -97,3 +97,45 @@ test('an untitled export keeps the boilerplate title and shows no empty heading 
   expect(html).not.toContain('{heading}');
 });
 
+// #560 — the exported page links its media by bare filename, so what we WRITE
+// must be safe as a filename AND a URL path segment: no spaces to
+// percent-encode, nothing a static host will normalise or reject.
+test('a media filename with spaces is sanitised, not percent-encoded (#560)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  const downloadPromise = page.waitForEvent('download');
+  await page.evaluate(() => {
+    document.getElementById('interactive-export-modal').checked = true;
+    document.getElementById('interactive-media-filename').value = 'my media file.mp4';
+    document.getElementById('interactive-export-download').click();
+  });
+  const download = await downloadPromise;
+  const stream = await download.createReadStream();
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  const html = Buffer.concat(chunks).toString('utf8');
+
+  const videoTag = html.match(/<video[^>]*>/)[0];
+  expect(videoTag).toContain('src="my_media_file.mp4"');
+  expect(videoTag).not.toContain('%20');   // the media link needs no encoding
+  expect(html).not.toContain('my media file.mp4');
+  // (the inline caption data: URL is percent-encoded by nature — that is
+  // #561's subject, not this one)
+});
+
+test('a media URL the user typed is left exactly as entered (#560)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  const downloadPromise = page.waitForEvent('download');
+  await page.evaluate(() => {
+    document.getElementById('interactive-export-modal').checked = true;
+    document.getElementById('interactive-media-filename').value = 'https://example.com/a b/clip.mp4';
+    document.getElementById('interactive-export-download').click();
+  });
+  const download = await downloadPromise;
+  const stream = await download.createReadStream();
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  const html = Buffer.concat(chunks).toString('utf8');
+  expect(html).toContain('src="https://example.com/a b/clip.mp4"'); // theirs, untouched
+});

--- a/__TEST__/e2e/interactive-export-template.spec.mjs
+++ b/__TEST__/e2e/interactive-export-template.spec.mjs
@@ -10,9 +10,11 @@ import { test, expect } from '@playwright/test';
 // requestAnimationFrame loop with easeInOutCubic), so the tag was pure
 // legacy — a third-party request on every exported page, for nothing.
 
-const exportedHtml = async (page) => {
-  await page.goto('/index.html');
-  await page.waitForSelector('#hypertranscript [data-m]');
+const exportedHtml = async (page, navigate = true) => {
+  if (navigate) {
+    await page.goto('/index.html');
+    await page.waitForSelector('#hypertranscript [data-m]');
+  }
   const downloadPromise = page.waitForEvent('download');
   await page.evaluate(() => {
     document.getElementById('interactive-export-modal').checked = true;
@@ -46,3 +48,52 @@ test('speakers keep their class in the exported transcript (#188)', async ({ pag
   const html = await exportedHtml(page);
   expect(html).toMatch(/<span[^>]*class="speaker"[^>]*>/);
 });
+
+// #563 — an exported transcript is published and shared, so it must say what
+// it is a transcript of: in the tab, in a link unfurl, and on the page.
+const withTitle = async (page, title) => {
+  await page.evaluate(async (t) => {
+    document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+    for (let i = 0; i < 50 && window.HyperaudioSave.library.currentId() === null; i += 1) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    await window.HyperaudioSave.library.rename(window.HyperaudioSave.library.currentId(), t);
+  }, title);
+};
+
+test('the project title reaches the tab, the page and the unfurl (#563)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  await withTitle(page, 'Atmosphere Conf 26 — Teon Brooks');
+  const html = await exportedHtml(page, false);
+
+  expect(html).toContain('<title>Atmosphere Conf 26 — Teon Brooks</title>');
+  expect(html).toContain('<h1 class="ht-title">Atmosphere Conf 26 — Teon Brooks</h1>');
+  expect(html).toMatch(/<meta property="og:title" content="Atmosphere Conf 26 — Teon Brooks">/);
+  // the description is the transcript's opening words, minus speaker labels
+  const desc = html.match(/<meta name="description" content="([^"]*)">/);
+  expect(desc).not.toBeNull();
+  expect(desc[1].length).toBeGreaterThan(10);
+  expect(desc[1]).not.toContain('[Mark]');
+  // no placeholder survives into a published page
+  expect(html).not.toContain('{title}');
+  expect(html).not.toContain('{heading}');
+  expect(html).not.toContain('{description}');
+});
+
+test('a title with markup characters cannot break out of the page (#563)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  await withTitle(page, '<script>alert(1)</script> & "quoted"');
+  const html = await exportedHtml(page, false);
+  expect(html).not.toContain('<script>alert(1)</script>');
+  expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt; &amp; &quot;quoted&quot;');
+});
+
+test('an untitled export keeps the boilerplate title and shows no empty heading (#563)', async ({ page }) => {
+  const html = await exportedHtml(page); // no project, no title
+  expect(html).toContain('<title>Hyperaudio – Interactive Transcript</title>');
+  expect(html).not.toContain('<h1 class="ht-title">'); // the rule stays in CSS; the element goes
+  expect(html).not.toContain('{heading}');
+});
+

--- a/__TEST__/e2e/interactive-export-template.spec.mjs
+++ b/__TEST__/e2e/interactive-export-template.spec.mjs
@@ -36,7 +36,7 @@ test('the exported page loads no Velocity, and no cdnjs at all (#562)', async ({
 
 test('the exported page still carries the player that does the scrolling (#562)', async ({ page }) => {
   const html = await exportedHtml(page);
-  expect(html).toContain('hyperaudio-lite/js/hyperaudio-lite.js');
+  expect(html).toMatch(/hyperaudio-lite@[\d.]+\/js\/hyperaudio-lite\.js/); // pinned since #571
   expect(html).toContain('id="hypertranscript"');
   expect(html).toContain('data-m=');
 });

--- a/__TEST__/e2e/interactive-export-template.spec.mjs
+++ b/__TEST__/e2e/interactive-export-template.spec.mjs
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+// The exported interactive transcript is an archival artefact: it gets
+// published, linked and cited long after it leaves the editor. What it loads
+// at that point is a promise we make to the reader — so the template's
+// third-party dependencies are asserted here rather than trusted.
+//
+// #562: Velocity was loaded from cdnjs and never called. hyperaudio-lite has
+// scrolled natively since 2.x (scrollToParagraph → smoothScrollTo, a
+// requestAnimationFrame loop with easeInOutCubic), so the tag was pure
+// legacy — a third-party request on every exported page, for nothing.
+
+const exportedHtml = async (page) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  const downloadPromise = page.waitForEvent('download');
+  await page.evaluate(() => {
+    document.getElementById('interactive-export-modal').checked = true;
+    document.getElementById('interactive-media-filename').value = 'clip.mp4';
+    document.getElementById('interactive-export-download').click();
+  });
+  const download = await downloadPromise;
+  const stream = await download.createReadStream();
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+};
+
+test('the exported page loads no Velocity, and no cdnjs at all (#562)', async ({ page }) => {
+  const html = await exportedHtml(page);
+  expect(html).not.toContain('velocity');
+  expect(html).not.toContain('cdnjs.cloudflare.com');
+});
+
+test('the exported page still carries the player that does the scrolling (#562)', async ({ page }) => {
+  const html = await exportedHtml(page);
+  expect(html).toContain('hyperaudio-lite/js/hyperaudio-lite.js');
+  expect(html).toContain('id="hypertranscript"');
+  expect(html).toContain('data-m=');
+});
+
+// #188 (filed 2023) — the export must carry the semantic speaker class, so a
+// published transcript can style and machine-read who is speaking. The
+// canonical serializer emits it; this pins that end to end.
+test('speakers keep their class in the exported transcript (#188)', async ({ page }) => {
+  const html = await exportedHtml(page);
+  expect(html).toMatch(/<span[^>]*class="speaker"[^>]*>/);
+});

--- a/__TEST__/unit/export-names.test.mjs
+++ b/__TEST__/unit/export-names.test.mjs
@@ -1,0 +1,44 @@
+// #560 — the shared export-filename sanitiser. Pure string work, so it is
+// unit-tested directly rather than through a download.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// mirrors js/media-export.js safeExportName (kept in step by these tests)
+const safeExportName = (name, fallback) => {
+  const cleaned = String(name === undefined || name === null ? '' : name)
+    .normalize('NFC')
+    .replace(/[/\\:*?"<>|#%&{}$!'`+=@]+/g, '')
+    .replace(/\s+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^[._-]+/, '')
+    .replace(/[._-]+$/, '')
+    .trim();
+  return cleaned !== '' ? cleaned : (fallback || 'hyperaudio-export');
+};
+
+test('spaces become single underscores', () => {
+  assert.equal(safeExportName('my media file'), 'my_media_file');
+  assert.equal(safeExportName('lots    of   space'), 'lots_of_space');
+});
+
+test('characters hostile to URLs or filesystems are dropped', () => {
+  assert.equal(safeExportName('a/b\\c:d*e?f"g<h>i|j'), 'abcdefghij');
+  assert.equal(safeExportName('100% #1 & done'), '100_1_done');
+});
+
+test('nothing exports as a hidden file, or with trailing noise', () => {
+  assert.equal(safeExportName('...hidden'), 'hidden');
+  assert.equal(safeExportName('trailing...'), 'trailing');
+  assert.equal(safeExportName('-leading-dash'), 'leading-dash');
+});
+
+test('an empty or all-hostile name falls back', () => {
+  assert.equal(safeExportName(''), 'hyperaudio-export');
+  assert.equal(safeExportName('///', 'export'), 'export');
+  assert.equal(safeExportName(null), 'hyperaudio-export');
+});
+
+test('ordinary names survive unchanged', () => {
+  assert.equal(safeExportName('interview-2026-08-13'), 'interview-2026-08-13');
+  assert.equal(safeExportName('Teon.Brooks'), 'Teon.Brooks');
+});

--- a/__TEST__/unit/export-pins.test.mjs
+++ b/__TEST__/unit/export-pins.test.mjs
@@ -1,0 +1,38 @@
+// #571 — an exported interactive transcript is an archival artefact: it is
+// published, linked and cited long after it leaves the editor. Unpinned CDN
+// URLs made every such page track upstream HEAD forever, so a change in
+// hyperaudio-lite could alter or break a transcript published years earlier.
+//
+// These assertions are the guard rail: no unpinned dependency may return, and
+// the pin must match the player the editor itself vendors — otherwise the page
+// you export behaves unlike the editor that made it.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const template = readFileSync(new URL('../../hyperaudio-template.html', import.meta.url), 'utf8');
+const player = readFileSync(new URL('../../js/hyperaudio-lite.js', import.meta.url), 'utf8');
+
+test('every hyperaudio-lite dependency in the template is pinned', () => {
+  const unpinned = [...template.matchAll(/cdn\.jsdelivr\.net\/gh\/hyperaudio\/hyperaudio-lite(?!@)[^"']*/g)]
+    .map((m) => m[0]);
+  assert.deepEqual(unpinned, [], 'unpinned CDN URLs in the exported page');
+});
+
+test('the pin matches the player version the editor vendors', () => {
+  const pins = new Set([...template.matchAll(/hyperaudio-lite@([0-9][^/]*)\//g)].map((m) => m[1]));
+  assert.equal(pins.size, 1, 'the template pins more than one version: ' + [...pins].join(', '));
+  const vendored = player.match(/Version\s+([0-9.]+)/);
+  assert.ok(vendored, 'no version marker in the vendored player');
+  assert.equal([...pins][0], vendored[1],
+    'the exported page would run a different player version than the editor');
+});
+
+test('no third-party CDN other than jsDelivr is loaded', () => {
+  // Only what the page FETCHES counts: script src and stylesheet href. (SVG
+  // xmlns values are namespace identifiers, not requests, and the footer's
+  // hyperaudio.github.io is a link the reader may click, not a load.)
+  const loaded = [...template.matchAll(/(?:<script[^>]*\ssrc|<link[^>]*\shref)="https?:\/\/([a-z0-9.-]+)\//gi)]
+    .map((m) => m[1]);
+  assert.deepEqual([...new Set(loaded)], ['cdn.jsdelivr.net']);
+});

--- a/hyperaudio-template.html
+++ b/hyperaudio-template.html
@@ -3,7 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Hyperaudio – Interactive Transcript</title>
+  <title>{title}</title>
+  <meta name="description" content="{description}">
+  <meta property="og:title" content="{title}">
+  <meta property="og:description" content="{description}">
+  <meta property="og:type" content="article">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/css/hyperaudio-lite-player.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/css/share-this.css">
   <style>
@@ -11,6 +15,18 @@
       margin: 0;
       background: #f7f7f8;
       color: #1a1a1a;
+    }
+    /* The page says what it is a transcript of. Sized to sit under the
+       player's own weight rather than compete with it; an export with no
+       title omits the element entirely, so there is no empty gap. */
+    .ht-title {
+      max-width: 34rem;
+      margin: 20px auto 12px;
+      padding: 0 8px;
+      font: 600 1.25rem/1.35 system-ui, -apple-system, "Segoe UI", sans-serif;
+      color: #23252a;
+      text-align: center;
+      overflow-wrap: anywhere;
     }
     /* ------------------------------------------------------------------
        Select-to-copy. The library owns behaviour — it positions #popover,
@@ -170,6 +186,7 @@
 </head>
 <body>
   <main class="ht-wrap">
+    <h1 class="ht-title">{heading}</h1>
     <video id="hyperplayer" class="hyperaudio-player" playsinline controls src="{sourcemedia}" type="video/mp4">
       <track id="hyperplayer-vtt" label="English" kind="subtitles" srclang="en" src="{sourcevtt}">
     </video>

--- a/hyperaudio-template.html
+++ b/hyperaudio-template.html
@@ -8,8 +8,15 @@
   <meta property="og:title" content="{title}">
   <meta property="og:description" content="{description}">
   <meta property="og:type" content="article">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/css/hyperaudio-lite-player.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/css/share-this.css">
+  <!-- PINNED (#571). Unpinned, jsDelivr serves hyperaudio-lite's default
+       branch, so every exported page tracked upstream HEAD forever: a change
+       there could alter — or break — a transcript published years earlier and
+       cited with a timecode link. An export is an archival artefact and must
+       stay reproducible. The pin matches the player the editor itself vendors
+       (js/hyperaudio-lite.js, "Version 2.6.4"); bump both together, never one
+       alone — __TEST__/unit/export-pins.test.mjs fails if they drift. -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite@2.6.4/css/hyperaudio-lite-player.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite@2.6.4/css/share-this.css">
   <style>
     body {
       margin: 0;
@@ -396,10 +403,10 @@
   })();
   </script>
 
-  <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/hyperaudio-lite.js"></script>
-  <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/hyperaudio-lite-extension.js"></script>
-  <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/share-this.js"></script>
-  <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/js/share-this-clipboard.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite@2.6.4/js/hyperaudio-lite.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite@2.6.4/js/hyperaudio-lite-extension.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite@2.6.4/js/share-this.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite@2.6.4/js/share-this-clipboard.js"></script>
   <script>
   // minimizedMode is still experimental - it aims to show the current words in the title, which can be seen on the browser tab.
   let minimizedMode = false;

--- a/hyperaudio-template.html
+++ b/hyperaudio-template.html
@@ -19,6 +19,44 @@
     /* The page says what it is a transcript of. Sized to sit under the
        player's own weight rather than compete with it; an export with no
        title omits the element entirely, so there is no empty gap. */
+    /* Taking the text is the commonest thing anyone does with a transcript
+       page, and select-to-copy is a different job (it copies a quotation
+       plus a replay link). This copies the whole transcript, always. */
+    /* The editor's corner copy button, transplanted: it sits in the TRANSCRIPT
+       PANE's own top-right corner (the wrapper is the positioning context, so
+       the button never lands in the transcript markup the player walks), grey
+       until hovered, icon only. */
+    /* The wrapper must be the CARD's box, not the page column's: #hypertranscript
+       is 34rem centred inside a 40rem wrap, so a button anchored to the wrap
+       landed ~30px outside the card's right edge. */
+    .ht-transcript-wrap {
+      position: relative;
+      max-width: 34rem;
+      margin: 0 auto;
+    }
+    #ht-copy {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      z-index: 5;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 30px;
+      height: 30px;
+      padding: 0;
+      border: 0;
+      border-radius: 7px;
+      background: rgba(247, 247, 248, 0.82);
+      color: rgba(26, 26, 26, 0.5);
+      cursor: pointer;
+      -webkit-backdrop-filter: blur(3px);
+      backdrop-filter: blur(3px);
+    }
+    #ht-copy:hover { color: #1a1a1a; }
+    #ht-copy[data-copied] { color: #1f7a48; }
+    @media print { #ht-copy { display: none; } }
+
     .ht-title {
       max-width: 34rem;
       margin: 20px auto 12px;
@@ -191,8 +229,13 @@
       <track id="hyperplayer-vtt" label="English" kind="subtitles" srclang="en" src="{sourcevtt}">
     </video>
 
-    <div id="hypertranscript" class="hyperaudio-transcript">
+    <div class="ht-transcript-wrap">
+      <button id="ht-copy" type="button" aria-label="Copy transcript" title="Copy transcript">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+      </button>
+      <div id="hypertranscript" class="hyperaudio-transcript">
 {hypertranscript}
+      </div>
     </div>
 
     <!-- Select-to-copy: hyperaudio-lite's OWN copy feature, which it
@@ -243,6 +286,113 @@
         'file’s video src to its full URL.';
       player.insertAdjacentElement('afterend', note);
     });
+  })();
+  </script>
+
+  <script>
+  /* Copy transcript — the editor's own contract (#467), inherited rather than
+     reinvented: it ALWAYS copies the whole transcript (a selection-sensitive
+     button is a trap, and selection copying already has an owner here — the
+     citation popover), it writes both a plain-text and a conservative HTML
+     flavour so it pastes cleanly everywhere, and because a clipboard write is
+     invisible it flips to a checkmark and announces itself to screen readers.
+     Struck-through words are speech the author removed, so they are not
+     copied. */
+  (function () {
+    var btn = document.getElementById('ht-copy');
+    var transcript = document.getElementById('hypertranscript');
+    if (!btn || !transcript) return;
+
+    var status = document.createElement('div');
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+    status.style.cssText = 'position:absolute; width:1px; height:1px; overflow:hidden; clip:rect(0 0 0 0); white-space:nowrap;';
+    document.body.appendChild(status);
+
+    var COPY_ICON = btn.innerHTML;
+    var CHECK_ICON = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>';
+    var resetTimer = null;
+
+    function blocks() {
+      var out = [];
+      transcript.querySelectorAll('p').forEach(function (p) {
+        var speaker = '';
+        var words = [];
+        p.querySelectorAll('span[data-m]').forEach(function (span) {
+          if ((span.style.textDecoration || '').indexOf('line-through') !== -1) return;
+          var text = span.textContent;
+          if (span.classList.contains('speaker')) {
+            speaker = text.replace(/^\s*\[?/, '').replace(/\]?\s*$/, '').trim();
+            return;
+          }
+          words.push(text);
+        });
+        var line = words.join('').replace(/\s+/g, ' ').trim();
+        if (line !== '') out.push({ speaker: speaker, text: line });
+      });
+      return out;
+    }
+
+    function escapeHtml(text) {
+      return String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    function confirmCopied() {
+      btn.dataset.copied = '1';
+      btn.innerHTML = CHECK_ICON;
+      btn.setAttribute('aria-label', 'Transcript copied');
+      btn.setAttribute('title', 'Copied');
+      status.textContent = '';
+      status.textContent = 'Transcript copied to clipboard.';
+      clearTimeout(resetTimer);
+      resetTimer = setTimeout(function () {
+        delete btn.dataset.copied;
+        btn.innerHTML = COPY_ICON;
+        btn.setAttribute('aria-label', 'Copy transcript');
+        btn.setAttribute('title', 'Copy transcript');
+      }, 1500);
+    }
+
+    btn.addEventListener('click', function () {
+      var parts = blocks();
+      if (parts.length === 0) return;
+      var plain = parts.map(function (b) {
+        return (b.speaker ? b.speaker + ': ' : '') + b.text;
+      }).join('\n\n') + '\n';
+      var html = parts.map(function (b) {
+        return '<p>' + (b.speaker ? '<b>' + escapeHtml(b.speaker) + ':</b> ' : '')
+          + escapeHtml(b.text) + '</p>';
+      }).join('\n');
+
+      if (navigator.clipboard && window.ClipboardItem && navigator.clipboard.write) {
+        navigator.clipboard.write([new ClipboardItem({
+          'text/plain': new Blob([plain], { type: 'text/plain' }),
+          'text/html': new Blob([html], { type: 'text/html' }),
+        })]).then(confirmCopied, function () { fallback(plain); });
+      } else {
+        fallback(plain);
+      }
+    });
+
+    // Older engines, and any page served without a secure context: plain text
+    // through the legacy path rather than no copy button at all.
+    function fallback(plain) {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(plain).then(confirmCopied, legacy);
+        return;
+      }
+      legacy();
+      function legacy() {
+        var area = document.createElement('textarea');
+        area.value = plain;
+        area.setAttribute('readonly', '');
+        area.style.cssText = 'position:fixed; top:-1000px; left:-1000px;';
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); confirmCopied(); } catch (e) { /* nothing more to try */ }
+        area.remove();
+      }
+    }
   })();
   </script>
 

--- a/hyperaudio-template.html
+++ b/hyperaudio-template.html
@@ -6,7 +6,6 @@
   <title>Hyperaudio – Interactive Transcript</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/css/hyperaudio-lite-player.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/hyperaudio/hyperaudio-lite/css/share-this.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>
   <style>
     body {
       margin: 0;

--- a/index.html
+++ b/index.html
@@ -1047,7 +1047,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.3.0"></script>
   <script src="js/transcript-maintenance.js?v=1.3.0"></script>
-  <script src="js/editor-core.js?v=1.3.5.2"></script>
+  <script src="js/editor-core.js?v=1.3.5.3"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1090,7 +1090,7 @@ If you are creating an open source application under a license compatible with t
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
-  <script src="js/media-export.js?v=1.3.5.1"></script>
+  <script src="js/media-export.js?v=1.3.5.2"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
   <script src="js/word-vtt.js?v=1.1.6"></script>
   <!-- end of caption editor additions -->

--- a/index.html
+++ b/index.html
@@ -1047,7 +1047,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.3.0"></script>
   <script src="js/transcript-maintenance.js?v=1.3.0"></script>
-  <script src="js/editor-core.js?v=1.3.5.3"></script>
+  <script src="js/editor-core.js?v=1.3.5.7"></script>
 
 
   <import-deepgram-json></import-deepgram-json>

--- a/index.html
+++ b/index.html
@@ -1047,7 +1047,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.3.0"></script>
   <script src="js/transcript-maintenance.js?v=1.3.0"></script>
-  <script src="js/editor-core.js?v=1.3.5.1"></script>
+  <script src="js/editor-core.js?v=1.3.5.2"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1090,7 +1090,7 @@ If you are creating an open source application under a license compatible with t
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
-  <script src="js/media-export.js?v=1.1.8"></script>
+  <script src="js/media-export.js?v=1.3.5.1"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
   <script src="js/word-vtt.js?v=1.1.6"></script>
   <!-- end of caption editor additions -->

--- a/index.html
+++ b/index.html
@@ -1090,7 +1090,7 @@ If you are creating an open source application under a license compatible with t
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
-  <script src="js/media-export.js?v=1.3.5.2"></script>
+  <script src="js/media-export.js?v=1.3.5.3"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
   <script src="js/word-vtt.js?v=1.1.6"></script>
   <!-- end of caption editor additions -->
@@ -1106,7 +1106,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.3.3"></script>
+  <script src="js/hyperaudio-save.js?v=1.3.5.1"></script>
   <script src="js/hyperaudio-library.js?v=1.3.4"></script>
   <script src="js/media-first-frame.js?v=1.3.4"></script>
   <script src="js/media-posters.js?v=1.3.4"></script>

--- a/index.html
+++ b/index.html
@@ -1047,7 +1047,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.3.0"></script>
   <script src="js/transcript-maintenance.js?v=1.3.0"></script>
-  <script src="js/editor-core.js?v=1.3.1"></script>
+  <script src="js/editor-core.js?v=1.3.5.1"></script>
 
 
   <import-deepgram-json></import-deepgram-json>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.3.5 (last changed in release 1.3.5) -->
+<!--  Hyperaudio Lite Editor - Version 1.3.6 (last changed in release 1.3.6) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.3.5">
+  <meta name="version" content="1.3.6">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -1047,7 +1047,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.3.0"></script>
   <script src="js/transcript-maintenance.js?v=1.3.0"></script>
-  <script src="js/editor-core.js?v=1.3.5.7"></script>
+  <script src="js/editor-core.js?v=1.3.6"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1090,7 +1090,7 @@ If you are creating an open source application under a license compatible with t
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
-  <script src="js/media-export.js?v=1.3.5.3"></script>
+  <script src="js/media-export.js?v=1.3.6"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
   <script src="js/word-vtt.js?v=1.1.6"></script>
   <!-- end of caption editor additions -->
@@ -1106,7 +1106,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.3.5.1"></script>
+  <script src="js/hyperaudio-save.js?v=1.3.6"></script>
   <script src="js/hyperaudio-library.js?v=1.3.4"></script>
   <script src="js/media-first-frame.js?v=1.3.4"></script>
   <script src="js/media-posters.js?v=1.3.4"></script>

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -141,7 +141,7 @@
   window.document.addEventListener('hyperaudioGenerateCaptionsFromTranscript', hyperaudioGenerateCaptionsFromTranscript, false);
   let hyperaudioTemplate = "";
 
-  fetch('hyperaudio-template.html?v=1.3.5.2') // bump with the template — an unversioned fetch served stale copies from the browser cache
+  fetch('hyperaudio-template.html?v=1.3.5.6') // bump with the template — an unversioned fetch served stale copies from the browser cache
   .then(function(response) {
       // When the page is loaded convert it to text
       return response.text()

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -141,7 +141,7 @@
   window.document.addEventListener('hyperaudioGenerateCaptionsFromTranscript', hyperaudioGenerateCaptionsFromTranscript, false);
   let hyperaudioTemplate = "";
 
-  fetch('hyperaudio-template.html?v=1.3.5.1') // bump with the template — an unversioned fetch served stale copies from the browser cache
+  fetch('hyperaudio-template.html?v=1.3.5.2') // bump with the template — an unversioned fetch served stale copies from the browser cache
   .then(function(response) {
       // When the page is loaded convert it to text
       return response.text()
@@ -210,12 +210,18 @@
         const track = document.querySelector('#hyperplayer-vtt');
         // function replacements so a literal $ in the transcript/filename isn't
         // treated as a replacement pattern
-        const html = hyperaudioTemplate
-          .replace('{hypertranscript}', () => (typeof serializeTranscriptHtml === 'function'
-            ? serializeTranscriptHtml(document.querySelector('#hypertranscript'))
-            : getTranscriptData()))
+        const inner = typeof serializeTranscriptHtml === 'function'
+          ? serializeTranscriptHtml(document.querySelector('#hypertranscript'))
+          : getTranscriptData();
+        let html = hyperaudioTemplate
+          .replace('{hypertranscript}', () => inner)
           .replace('{sourcemedia}', () => mediaSrc)
           .replace('{sourcevtt}', () => (track !== null ? track.src : ''));
+        // the project's title in the tab, the unfurl and on the page (#563) —
+        // the same filler the media-export route uses, so both agree
+        if (typeof window.fillExportIdentity === 'function') {
+          html = window.fillExportIdentity(html, inner);
+        }
         const blob = new Blob([html], { type: 'text/html' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -141,7 +141,7 @@
   window.document.addEventListener('hyperaudioGenerateCaptionsFromTranscript', hyperaudioGenerateCaptionsFromTranscript, false);
   let hyperaudioTemplate = "";
 
-  fetch('hyperaudio-template.html?v=1.3.5.6') // bump with the template — an unversioned fetch served stale copies from the browser cache
+  fetch('hyperaudio-template.html?v=1.3.6') // bump with the template — an unversioned fetch served stale copies from the browser cache
   .then(function(response) {
       // When the page is loaded convert it to text
       return response.text()

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -141,7 +141,7 @@
   window.document.addEventListener('hyperaudioGenerateCaptionsFromTranscript', hyperaudioGenerateCaptionsFromTranscript, false);
   let hyperaudioTemplate = "";
 
-  fetch('hyperaudio-template.html?v=1.1.7') // bump with the template — an unversioned fetch served stale copies from the browser cache
+  fetch('hyperaudio-template.html?v=1.3.5.1') // bump with the template — an unversioned fetch served stale copies from the browser cache
   .then(function(response) {
       // When the page is loaded convert it to text
       return response.text()

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -205,8 +205,21 @@
 
     if (iaDownload !== null && iaInput !== null) {
       iaDownload.addEventListener('click', () => {
-        const mediaSrc = iaInput.value.trim();
-        if (mediaSrc === '') { iaInput.focus(); return; }
+        const typed = iaInput.value.trim();
+        if (typed === '') { iaInput.focus(); return; }
+        // A bare filename is a path segment in the exported page, so it gets
+        // the same sanitising as the files the media exporter writes (#560)
+        // — spaces and hostile characters out, no percent-encoding needed.
+        // A URL the user typed is theirs: left exactly as entered.
+        const isUrl = /^[a-z][a-z0-9+.-]*:/i.test(typed) || typed.startsWith('//');
+        const mediaSrc = (!isUrl && typeof window.safeExportName === 'function')
+          ? (() => {
+            const dot = typed.lastIndexOf('.');
+            const stem = dot > 0 ? typed.slice(0, dot) : typed;
+            const ext = dot > 0 ? typed.slice(dot) : '';
+            return window.safeExportName(stem, 'media') + ext.replace(/\s+/g, '');
+          })()
+          : typed;
         const track = document.querySelector('#hyperplayer-vtt');
         // function replacements so a literal $ in the transcript/filename isn't
         // treated as a replacement pattern

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.3.3 — last changed in release 1.3.3
+ * @version 1.3.6 — last changed in release 1.3.6
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3330,6 +3330,25 @@
     // speaker-preserving, caption-mode-aware gather the save path uses
     getTranscriptJson: () => getEditorTranscriptJson(),
     loadJSZip, // shared vendored-zip loader (the .docx export packages with it)
+    // The project's media as a FRESH File. An object URL made from an OPFS
+    // file is a snapshot: once that file is rewritten (any save that re-writes
+    // media does), the URL still plays from buffered data but can no longer be
+    // read back — which is how the media exporter met "Failed to fetch" on
+    // some projects and not others. Callers that need the BYTES ask here
+    // rather than re-reading the player's src.
+    currentMediaFile: async () => {
+      if (session.projectId !== null) {
+        try {
+          const root = await navigator.storage.getDirectory();
+          const dir = await (await root.getDirectoryHandle('work')).getDirectoryHandle(session.projectId);
+          const mediaDir = await dir.getDirectoryHandle('media');
+          for await (const [, handle] of mediaDir.entries()) {
+            if (handle.kind === 'file') return await handle.getFile();
+          }
+        } catch (e) { /* no stored media — fall through */ }
+      }
+      return session.mediaFile;
+    },
     openFromFile,
     autosaveNow: writeDraft,
     isDirty,

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -110,18 +110,39 @@
 
   // The player src may be http(s), blob: or data: (local files restored from
   // IndexedDB) — fetch handles all three; mediabunny reads the Blob.
-  const makeInput = async (mb) => {
+  // Read the media BYTES. The player's src is the obvious source but not a
+  // reliable one: an object URL made from an OPFS file is a snapshot, and
+  // once that file is rewritten (any save that re-writes media does) the URL
+  // still plays from buffered data yet fails to read back — "Failed to fetch"
+  // on some projects and not others. So the library's stored file wins when
+  // it exists, and the player's src is the fallback (URL-mode media, or no
+  // project at all). Both failing is a real error, reported for what it is.
+  const readMediaBlob = async () => {
+    const save = window.HyperaudioSave;
+    if (save && typeof save.currentMediaFile === 'function') {
+      try {
+        const file = await save.currentMediaFile();
+        if (file && file.size > 0) return file;
+      } catch (e) { /* fall through to the player's src */ }
+    }
     const src = playerSrc();
     if (!src) throw new Error('No media is loaded.');
     let response;
     try {
       response = await fetch(src);
+      if (!response.ok) throw new Error(`Could not read the media (HTTP ${response.status}).`);
+      return await response.blob();   // .blob() can fail too: a stale object URL dies here
     } catch (e) {
+      if (src.startsWith('blob:')) {
+        throw new Error('The media could not be re-read from this page. Reopen the project (or reload the media file) and try the export again.');
+      }
       // playing cross-origin media needs no CORS, but READING its bytes does
       throw new Error('This media source does not allow cross-origin reading (CORS), so it cannot be exported. Load the file locally and try again.');
     }
-    if (!response.ok) throw new Error(`Could not read the media (HTTP ${response.status}).`);
-    const blob = await response.blob();
+  };
+
+  const makeInput = async (mb) => {
+    const blob = await readMediaBlob();
     return new mb.Input({ formats: mb.ALL_FORMATS, source: new mb.BlobSource(blob) });
   };
 

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -1,7 +1,7 @@
 /**
  * media-export.js
  * (C) The Hyperaudio Project
- * @version 1.1.8 — last changed in release 1.1.8
+ * @version 1.3.6 — last changed in release 1.3.6
  * @license MIT
  *
  * Media export via mediabunny (#289, #291, #292): export the loaded media as

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -230,7 +230,7 @@
       .replace('{sourcemedia}', () => mediaSrc)
       .replace('{sourcevtt}', () => (trackSrc || ''));
     if (!trackSrc) html = html.replace(/<track[^>]*>/i, '');
-    return html;
+    return window.fillExportIdentity ? window.fillExportIdentity(html, inner) : html;
   };
 
   // Word chunks for burn-in, already mapped onto the EDITED/output timeline.
@@ -528,6 +528,54 @@
   // ---------------------------------------------------------------------------
   // Downloads
   // ---------------------------------------------------------------------------
+
+  /* --------------------------------------------------------------------------
+   * Exported-page identity (#563): the project's title in the tab, in an
+   * unfurl, and on the page itself — every export was previously anonymous
+   * boilerplate. The description is the transcript's opening words, which is
+   * what a reader (or a link preview) needs to recognise it.
+   *
+   * Shared with the plain Interactive Transcript modal in editor-core, so
+   * both routes produce the same page: one filler, two callers.
+   * ------------------------------------------------------------------------ */
+  const escapeAttr = (text) => String(text)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+  // The transcript's opening words, trimmed to a sentence-ish length.
+  const openingWords = (transcriptHtml) => {
+    const host = document.createElement('div');
+    host.innerHTML = transcriptHtml || '';
+    // speakers are labels, not speech — the description reads better without
+    host.querySelectorAll('.speaker').forEach((el) => el.remove());
+    const text = host.textContent.replace(/\s+/g, ' ').trim();
+    if (text === '') return '';
+    if (text.length <= 160) return text;
+    const cut = text.slice(0, 160);
+    const lastSpace = cut.lastIndexOf(' ');
+    return (lastSpace > 80 ? cut.slice(0, lastSpace) : cut) + '…';
+  };
+
+  const fillExportIdentity = (html, transcriptHtml) => {
+    const title = exportTitle();
+    const description = openingWords(transcriptHtml);
+    const pageTitle = title !== '' ? title : 'Hyperaudio – Interactive Transcript';
+    return html
+      .replace(/\{title\}/g, () => escapeAttr(pageTitle))
+      .replace(/\{description\}/g, () => escapeAttr(description))
+      // an untitled export drops the heading element rather than showing an
+      // empty one — no gap, no lonely rule above the player
+      .replace(/\s*<h1 class="ht-title">\{heading\}<\/h1>/,
+        () => (title !== '' ? '\n    <h1 class="ht-title">' + escapeAttr(title) + '</h1>' : ''));
+  };
+  window.fillExportIdentity = fillExportIdentity;
+
+  // The project's own title, before it is reduced to a filename.
+  const exportTitle = () => {
+    const title = (window.HyperaudioSave && typeof window.HyperaudioSave.getProjectTitle === 'function')
+      ? window.HyperaudioSave.getProjectTitle() : '';
+    return title.trim();
+  };
 
   const exportBaseName = () => {
     // the Recents list is gone (#451); the project session names exports now

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -596,10 +596,32 @@
   //
   // STORE, not deflate: the payload is already-compressed media, so compressing
   // buys nothing and costs time on large exports.
-  const zipFolderName = (name) => {
-    const cleaned = String(name).replace(/[\\/:*?"<>|]+/g, '-').replace(/^\.+/, '').trim();
-    return cleaned !== '' ? cleaned : 'hyperaudio-export';
+  /* --------------------------------------------------------------------------
+   * Export filenames (#560). The interactive transcript links its media by
+   * bare filename, so whatever we WRITE has to be safe as both a filename and
+   * a URL path segment — otherwise the page carries "media%20file.mp4" while
+   * the disk holds "media file.mp4", and static hosts, CDNs and equality
+   * checks each handle that pair differently.
+   *
+   * One helper, every call site: spaces (and runs of them) become single
+   * underscores, filesystem/URL-hostile characters go, and leading dots are
+   * dropped so nothing exports as a hidden file. The user's own media and
+   * project titles are untouched — this only names the files we produce.
+   * ------------------------------------------------------------------------ */
+  const safeExportName = (name, fallback) => {
+    const cleaned = String(name === undefined || name === null ? '' : name)
+      .normalize('NFC')
+      .replace(/[\/\\:*?"<>|#%&{}$!'`+=@]+/g, '')  // hostile in a path, a URL, or a shell
+      .replace(/\s+/g, '_')                        // no percent-encoding needed anywhere
+      .replace(/_+/g, '_')
+      .replace(/^[._-]+/, '')                      // no hidden files, no leading noise
+      .replace(/[._-]+$/, '')
+      .trim();
+    return cleaned !== '' ? cleaned : (fallback || 'hyperaudio-export');
   };
+  window.safeExportName = safeExportName;
+
+  const zipFolderName = (name) => safeExportName(name, 'hyperaudio-export');
 
   const buildOutputsZip = async (outputs, baseName, onProgress) => {
     if (!window.HyperaudioSave || typeof window.HyperaudioSave.loadJSZip !== 'function') {
@@ -974,7 +996,10 @@
       // user-chosen export name (verbatim, so the media file and the transcript's
       // <video src> always agree); light sanitise for filename safety
       const rawName = nameInput !== null ? nameInput.value.trim() : '';
-      const baseName = (rawName || exportBaseName() || 'export').replace(/[\/\\:*?"<>|]+/g, '_');
+      // Sanitised once, here: the media file, the sidecar captions, the
+      // transcript page and the archive folder all derive from this, so the
+      // bundle stays internally consistent and needs no encoding (#560).
+      const baseName = safeExportName(rawName || exportBaseName(), 'export');
 
       const player = document.getElementById('hyperplayer');
       const duration = player && !isNaN(player.duration) ? player.duration : Infinity;


### PR DESCRIPTION
The interactive transcript export, taken seriously as a publishable artefact.

- **Exported pages say what they are** (#563): the project's title reaches the tab, a heading above the player, and `og:`/description metadata — with the transcript's opening words as the description, so a shared link unfurls into something recognisable. Untitled exports keep the old boilerplate and show no empty heading; titles are escaped.
- **The transcript can be copied** (#564): an icon-only button in the transcript pane's corner, inheriting the editor's copy contract (#467) — the whole transcript, plain-text and HTML flavours, struck words excluded, with visible confirmation.
- **Exports stop tracking upstream HEAD** (#571): the page's dependencies are pinned to the player version the editor vendors, so a transcript published today still behaves the same years later. Guarded by unit tests that fail if a pin is dropped or drifts from the vendored player.
- **One sanitiser for every filename an export writes** (#560): no spaces to percent-encode, so the page's media link and the file on disk agree — on any static host. A URL you type yourself is left untouched.
- **The dead Velocity dependency is gone** (#562): never called, and the player has scrolled natively since 2.x — one less third-party request on every exported page.
- **Media export no longer fails on projects whose media was rewritten** (#573): opening a project file rewrites its media into OPFS, which voids the `File` snapshot the player's object URL was made from; the exporter now reads the library's stored file instead. A dead local URL and a genuine CORS refusal also say different, true things now.

Fixes #560. Fixes #562. Fixes #563. Fixes #564. Fixes #571. Fixes #573.

Also closed during this work: #188 (verified fixed, now pinned by a test) and #565 (the browser's own rate control suffices). #561 (inline VTT data URLs) and #574 remain open.

Suite: 89 unit + 239 e2e green (1 known Playwright-WebKit OPFS skip).
