### PR TITLE
Version 1.3.7

### DIFF
--- a/__TEST__/e2e/export-embedder-media.spec.mjs
+++ b/__TEST__/e2e/export-embedder-media.spec.mjs
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+// #574 — media served through a host application's own URL scheme (#547) is
+// fetched to embed it in a .hyperaudio file. That fetch can legitimately fail
+// (the file moved or was renamed on the host side, permissions changed, the
+// handler is not ready yet) and it was unguarded: the raw TypeError escaped
+// as "Failed to fetch" and the save was ABANDONED, while the sibling branch
+// for http(s) media has always caught, explained, and offered a link save.
+// Same class of bug as #573.
+
+test('a failing embedder-scheme fetch offers the link save instead of dying', async ({ page }) => {
+  const dialogs = [];
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+
+  await page.evaluate(() => {
+    // a host application that declares a scheme, whose handler then fails
+    window.hyperaudioLinkSchemes = ['app-media:'];
+    globalThis.hyperaudioLinkSchemes = window.hyperaudioLinkSchemes;
+    const player = document.getElementById('hyperplayer');
+    Object.defineProperty(player, 'src', { get: () => 'app-media://library/talk.mp4', configurable: true });
+    document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+  });
+  // the scheme has no handler in a plain browser, so the fetch rejects — the
+  // failure this test is about
+  await page.waitForTimeout(600);
+
+  // the designed dialog carries the explanation and the choice
+  const askedPromise = page.waitForFunction(() => {
+    const el = document.getElementById('project-dialog');
+    return el !== null && el.classList.contains('modal-open')
+      ? el.querySelector('#project-dialog-message').textContent : false;
+  }, null, { timeout: 20000 });
+
+  await page.evaluate(() => { window.HyperaudioSave.exportProject(); });
+  const asked = await (await askedPromise).jsonValue();
+
+  expect(asked).toContain('could not provide the media file');
+  expect(asked).toContain('LINK');
+  // and it is a real choice: cancelling abandons nothing silently
+  await page.click('#project-dialog-cancel');
+  await expect(page.locator('#project-dialog.modal-open')).toHaveCount(0);
+  expect(dialogs).toEqual([]); // no native alert anywhere in this path
+});

--- a/__TEST__/e2e/export-low-rate-audio.spec.mjs
+++ b/__TEST__/e2e/export-low-rate-audio.spec.mjs
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+import { ladderWav, transcriptHtml } from './helpers.mjs';
+
+// #579 — WebKit's WebCodecs AudioEncoder picks HE-AAC for MONO audio below
+// 32 kHz, and the muxed track is unreadable to AVFoundation: a silent export
+// that looks successful. Low-rate audio is therefore lifted before it reaches
+// the encoder.
+//
+// WHAT THIS SPEC CAN AND CANNOT SHOW. It runs in Chromium, which does not
+// exhibit the bug, and Playwright's WebKit is not Safari's AVFoundation
+// stack — so no CI test can prove the exported FILE has audio on Safari.
+// That verification lives in a WKWebView + AVAssetReader harness (see #579).
+// What is provable here is the transformation: audio below 32 kHz reaches the
+// encoder lifted, on every path into it, and audio at or above 32 kHz is left
+// exactly as it was.
+
+const exportAt = async (page, { sourceRate, rate = 1, format = 'm4a' }) => {
+  const wav = ladderWav(3, sourceRate); // 16-bit MONO — the failing shape
+  await page.route('**/__low.wav', (route) => route.fulfill({ body: wav, contentType: 'audio/wav' }));
+  await page.goto('/index.html');
+  await page.waitForFunction(() => typeof window.getPlayableSections === 'function');
+  await page.evaluate(async () => {
+    const blob = await (await fetch('/__low.wav')).blob();
+    document.getElementById('hyperplayer').src = URL.createObjectURL(blob);
+  });
+  await page.waitForFunction(() => {
+    const p = document.getElementById('hyperplayer');
+    return p.readyState >= 1 && p.duration > 2;
+  });
+  // three words, one struck, so the export takes the EDITED path (which
+  // re-encodes) rather than a straight copy
+  await page.evaluate((html) => { document.getElementById('hypertranscript').innerHTML = html; },
+    transcriptHtml([[0, 900], [1000, 900, 1], [2000, 900]]));
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.evaluate(async ({ fmt, speed }) => {
+    const m = document.getElementById('export-modal');
+    m.checked = true; m.dispatchEvent(new Event('change'));
+    await new Promise((r) => setTimeout(r, 1500));
+    document.getElementById('export-format').value = fmt;
+    document.getElementById('export-format').dispatchEvent(new Event('change'));
+    const set = (id, on) => { const c = document.getElementById(id); if (c) { c.checked = on; c.dispatchEvent(new Event('change')); } };
+    ['export-vtt', 'export-srt', 'export-burn', 'export-project', 'export-retime'].forEach((id) => set(id, false));
+    if (speed !== 1) {
+      // the speed only applies when its row is enabled — setting the number
+      // alone leaves exportRate() at 1 (which made this test vacuous once)
+      const adjust = document.getElementById('export-adjust');
+      adjust.checked = true;
+      adjust.dispatchEvent(new Event('change'));
+      const speedInput = document.getElementById('export-speed');
+      speedInput.value = String(speed);
+      speedInput.dispatchEvent(new Event('input'));
+      speedInput.dispatchEvent(new Event('change'));
+    }
+    document.getElementById('export-start').click();
+  }, { fmt: format, speed: rate });
+  const download = await downloadPromise;
+  await page.waitForFunction(
+    () => document.getElementById('export-status').textContent.startsWith('Done'), null, { timeout: 120000 });
+
+  const chunks = [];
+  for await (const chunk of await download.createReadStream()) chunks.push(chunk);
+  return audioSampleRate(Buffer.concat(chunks));
+};
+
+// The rate the muxed file actually declares, read from the MP4 audio sample
+// entry. (decodeAudioData is no good here: it resamples to the AudioContext's
+// own rate, so it reports the browser's device rate rather than the file's.)
+// Layout after the 'mp4a' fourcc: reserved[6] + data_ref[2] + version/rev/
+// vendor[8] + channels[2] + samplesize[2] + pre_defined[2] + reserved[2],
+// then samplerate as 16.16 fixed point.
+function audioSampleRate(bytes) {
+  const at = bytes.indexOf('mp4a', 0, 'ascii');
+  const mv = bytes.indexOf('mvhd', 0, 'ascii');
+  // mvhd v0: version+flags[4], creation[4], modification[4], timescale[4], duration[4]
+  const duration = mv === -1 ? null
+    : bytes.readUInt32BE(mv + 20) / bytes.readUInt32BE(mv + 16);
+  if (at === -1) return { sampleRate: null, duration, size: bytes.length };
+  // the integer half of the 16.16 field (a >> 16 here sign-extends: 0xac44... reads negative)
+  return { sampleRate: bytes.readUInt16BE(at + 28), duration, size: bytes.length };
+}
+
+test('16 kHz mono audio is lifted before it reaches the encoder (#579)', async ({ page }) => {
+  const out = await exportAt(page, { sourceRate: 16000 });
+  expect(out.sampleRate).toBeGreaterThanOrEqual(32000); // clear of WebKit's HE-AAC cliff
+  expect(out.sampleRate).toBe(48000);                   // 16000 divides 48000 exactly
+  expect(out.size).toBeGreaterThan(2000);               // and it still has audio in it
+});
+
+test('22.05 kHz mono lifts to a rate it divides exactly (#579)', async ({ page }) => {
+  const out = await exportAt(page, { sourceRate: 22050 });
+  expect(out.sampleRate).toBe(44100);
+});
+
+test('the speed-change path lifts too — the stretcher is not a hole (#579)', async ({ page }) => {
+  const out = await exportAt(page, { sourceRate: 16000, rate: 1.5 });
+  // First prove the STRETCHER actually ran: at 1.5x the ~1.9s of kept audio
+  // must come out around 1.3s. Without this the test can pass while never
+  // exercising the path it exists for.
+  expect(out.duration).toBeGreaterThan(0.9);
+  expect(out.duration).toBeLessThan(1.6);
+  expect(out.sampleRate).toBeGreaterThanOrEqual(32000);
+});
+
+test('44.1 kHz audio is passed through untouched (#579)', async ({ page }) => {
+  const out = await exportAt(page, { sourceRate: 44100 });
+  expect(out.sampleRate).toBe(44100); // no needless resample on the common path
+});

--- a/__TEST__/e2e/export-zip.spec.mjs
+++ b/__TEST__/e2e/export-zip.spec.mjs
@@ -180,3 +180,28 @@ test('the interactive transcript links a sidecar .vtt, never an inline data URL'
   expect(html).toContain('src="talk.vtt"');       // linked by plain filename
   expect(html).not.toContain('data:text/vtt');    // never inlined
 });
+
+// The .vtt rides along with an interactive transcript (#561) — but NOT when
+// captions are burned into the picture, since then the page carries no
+// <track> at all. The note has to say so only when it is true: a blanket
+// claim is wrong exactly when someone burns captions, which is how the
+// missing <track> looked like a bug in the first place.
+test('the "included with the interactive transcript" note tracks reality', async ({ page }) => {
+  await openExportModal(page);
+  const note = page.locator('#export-vtt-note');
+  const set = (id, on) => page.evaluate(({ i, v }) => {
+    const c = document.getElementById(i);
+    if (c) { c.checked = v; c.dispatchEvent(new Event('change')); }
+  }, { i: id, v: on });
+
+  await set('export-retime', false);
+  await expect(note).toBeHidden();          // no interactive transcript, no claim
+
+  await set('export-retime', true);
+  await expect(note).toBeVisible();         // the .vtt does ride along
+
+  // (The burn case — note retracts because no sidecar is written — is covered
+  // by the code comment rather than a test: asserting it needs a video source,
+  // which is minutes of suite time for a line of label text.)
+});
+

--- a/__TEST__/e2e/export-zip.spec.mjs
+++ b/__TEST__/e2e/export-zip.spec.mjs
@@ -145,3 +145,38 @@ test('the zip offer appears once a second file is selected', async ({ page }) =>
   });
   await expect(page.locator('#export-name-note')).toContainText('keep the downloads together');
 });
+
+// #561 — the interactive transcript links its captions as a SIDECAR file
+// rather than embedding them as a data: URL. The page was never
+// self-contained (its media sits beside it), and files are the only shape
+// that extends to a <track> per language for translations.
+test('the interactive transcript links a sidecar .vtt, never an inline data URL', async ({ page }) => {
+  await openExportModal(page);
+  await page.evaluate(() => {
+    const set = (id, on) => {
+      const c = document.getElementById(id);
+      if (c) { c.checked = on; c.dispatchEvent(new Event('change')); }
+    };
+    // captions NOT ticked: the interactive transcript must still get its file
+    ['export-vtt', 'export-srt', 'export-burn', 'export-project'].forEach((id) => set(id, false));
+    set('export-retime', true);
+    set('export-zip', true);
+    document.getElementById('export-name').value = 'talk';
+  });
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.click('#export-start');
+  const download = await downloadPromise;
+  await page.waitForFunction(
+    () => document.getElementById('export-status').textContent.startsWith('Done'));
+
+  const fs = await import('node:fs/promises');
+  const zip = await JSZip.loadAsync(await fs.readFile(await download.path()));
+  const names = Object.keys(zip.files).filter((p) => !zip.files[p].dir).map((p) => p.split('/').pop()).sort();
+  expect(names).toContain('talk.vtt');            // the sidecar rides along
+  expect(names).toContain('talk-transcript.html');
+
+  const html = await zip.file('talk/talk-transcript.html').async('string');
+  expect(html).toContain('src="talk.vtt"');       // linked by plain filename
+  expect(html).not.toContain('data:text/vtt');    // never inlined
+});

--- a/__TEST__/e2e/gap-edges.spec.mjs
+++ b/__TEST__/e2e/gap-edges.spec.mjs
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+import { ladderWav, transcriptHtml } from './helpers.mjs';
+
+// #577 — gap skipping must consider the two gaps most likely to be long: the
+// silence before anyone speaks and the dead air after the last word. Both were
+// invisible to it: regions were only built BETWEEN kept words, and the trailing
+// region existed only when struck words followed the last one.
+
+const load = async (page, seconds, words) => {
+  const wav = ladderWav(seconds);
+  await page.route('**/__ladder.wav', (route) => route.fulfill({ body: wav, contentType: 'audio/wav' }));
+  await page.goto('/index.html');
+  await page.waitForFunction(() => typeof window.getPlayableSections === 'function');
+  await page.evaluate(async () => {
+    const blob = await (await fetch('/__ladder.wav')).blob();
+    document.getElementById('hyperplayer').src = URL.createObjectURL(blob);
+  });
+  await page.waitForFunction((s) => {
+    const p = document.getElementById('hyperplayer');
+    return p.readyState >= 1 && p.duration > s - 1;
+  }, seconds);
+  await page.evaluate((html) => { document.getElementById('hypertranscript').innerHTML = html; }, transcriptHtml(words));
+};
+
+const sectionsWithGaps = (page, on) => page.evaluate((enabled) => {
+  document.getElementById('remove-gaps-enabled').checked = enabled;
+  document.getElementById('remove-gaps-enabled').dispatchEvent(new Event('change', { bubbles: true }));
+  return window.getPlayableSections();
+}, on);
+
+test('the silence before the first word is skipped (#577)', async ({ page }) => {
+  // speech occupies 4s–7s of a 10s file: 4s of lead-in, 3s of tail
+  await load(page, 10, [[4000, 1000, 0], [5000, 1000, 0], [6000, 1000, 0]]);
+
+  const off = await sectionsWithGaps(page, false);
+  expect(off[0].start).toBe(0); // unchanged when gap skipping is off
+
+  const on = await sectionsWithGaps(page, true);
+  // playback now starts at the first word (less the edge buffer), not at 0
+  expect(on[0].start).toBeGreaterThan(3.5);
+  expect(on[0].start).toBeLessThanOrEqual(4);
+});
+
+test('the dead air after the last word is skipped (#577)', async ({ page }) => {
+  await load(page, 10, [[4000, 1000, 0], [5000, 1000, 0], [6000, 1000, 0]]);
+  const on = await sectionsWithGaps(page, true);
+  const last = on[on.length - 1];
+  // ...and ends at the last word, not at the media's end
+  expect(last.end).toBeLessThan(8);
+  expect(last.end).toBeGreaterThanOrEqual(7);
+});
+
+test('a short lead-in is left alone, like any sub-threshold gap (#577)', async ({ page }) => {
+  // 0.3s before the first word: under the 0.5s default threshold
+  await load(page, 6, [[300, 1000, 0], [1300, 1000, 0]]);
+  const on = await sectionsWithGaps(page, true);
+  expect(on[0].start).toBe(0);
+});
+
+test('struck words in the lead-in are not cut twice (#577)', async ({ page }) => {
+  // a struck word inside the lead-in region, then speech
+  await load(page, 10, [[1000, 500, 1], [4000, 1000, 0], [5000, 1000, 0]]);
+  const on = await sectionsWithGaps(page, true);
+  // one continuous kept span from the first kept word onward — no slivers of
+  // the lead-in surviving between overlapping cuts
+  const kept = on.filter((s) => s.end - s.start > 0.01);
+  expect(kept.length).toBe(1);
+  expect(kept[0].start).toBeGreaterThan(3.5);
+});
+
+// PLAYBACK, not just export (#577). The two are separate mechanisms: export
+// consumes getPlayableSections, while playback jumps via checkStrikeThrus —
+// which only ever examined the bands BETWEEN kept sections, so the lead-in
+// played in full even once the sections themselves were right.
+const playheadAfter = async (page, at) => page.evaluate(async (t) => {
+  const p = document.getElementById('hyperplayer');
+  p.currentTime = t;
+  p.dispatchEvent(new Event('timeupdate'));
+  await new Promise((r) => setTimeout(r, 120));
+  return p.currentTime;
+}, at);
+
+test('playback skips the lead-in instead of playing it (#577)', async ({ page }) => {
+  await load(page, 10, [[4000, 1000, 0], [5000, 1000, 0], [6000, 1000, 0]]);
+  await sectionsWithGaps(page, true);
+
+  expect(await playheadAfter(page, 0)).toBeGreaterThan(2);   // jumped forward
+  expect(await playheadAfter(page, 0)).toBeLessThan(4.5);    // ...to the speech
+});
+
+test('playback lets the media end rather than run out the dead air (#577)', async ({ page }) => {
+  await load(page, 10, [[4000, 1000, 0], [5000, 1000, 0], [6000, 1000, 0]]);
+  await sectionsWithGaps(page, true);
+
+  const after = await playheadAfter(page, 7.5); // past the last word
+  expect(after).toBeGreaterThan(9.5);           // taken to the end
+});
+
+test('with gap skipping OFF the playhead is left alone (#577)', async ({ page }) => {
+  await load(page, 10, [[4000, 1000, 0], [5000, 1000, 0], [6000, 1000, 0]]);
+  await sectionsWithGaps(page, false);
+  expect(await playheadAfter(page, 0)).toBeLessThan(0.5);
+  expect(await playheadAfter(page, 7.5)).toBeLessThan(8);
+});

--- a/__TEST__/e2e/interactive-modal-vtt.spec.mjs
+++ b/__TEST__/e2e/interactive-modal-vtt.spec.mjs
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import JSZip from 'jszip';
+
+// #581 — the FILE → Interactive Transcript modal must never inline captions.
+// It passed the live track's src straight into the page, and that src is a
+// data:text/vtt URL: a percent-encoded copy of the whole caption track inside
+// the HTML, and a shape no <track srclang> per language can extend to.
+// The page and its .vtt now travel together in one archive, because two
+// downloads would let the browser rename the second and silently break the
+// page's reference to it.
+
+const runModalExport = async (page) => {
+  const downloadPromise = page.waitForEvent('download');
+  await page.evaluate(() => {
+    document.getElementById('interactive-export-modal').checked = true;
+    document.getElementById('interactive-media-filename').value = 'clip.mp4';
+    document.getElementById('interactive-export-download').click();
+  });
+  const download = await downloadPromise;
+  const chunks = [];
+  for await (const chunk of await download.createReadStream()) chunks.push(chunk);
+  return { name: download.suggestedFilename(), bytes: Buffer.concat(chunks) };
+};
+
+test('captions leave as a file, and the page links them by name (#581)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  // the demo boots with captions on the live track
+  await page.waitForFunction(() => {
+    const t = document.getElementById('hyperplayer-vtt');
+    return t !== null && (t.src || '').startsWith('data:');
+  });
+
+  const out = await runModalExport(page);
+  expect(out.name).toMatch(/\.zip$/);
+
+  const zip = await JSZip.loadAsync(out.bytes);
+  const names = Object.keys(zip.files).filter((p) => !zip.files[p].dir).map((p) => p.split('/').pop());
+  const html = await zip.file(Object.keys(zip.files).find((p) => p.endsWith('.html'))).async('string');
+  const vttName = names.find((n) => n.endsWith('.vtt'));
+
+  expect(vttName).toBeTruthy();
+  expect(html).not.toContain('data:text/vtt');       // never inlined
+  expect(html).toContain(`src="${vttName}"`);        // linked by plain filename
+  const vtt = await zip.file(Object.keys(zip.files).find((p) => p.endsWith('.vtt'))).async('string');
+  expect(vtt).toContain('WEBVTT');                   // and it is a real track
+});
+
+test('with no captions it stays a single HTML file, with no empty track (#581)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  await page.evaluate(() => {
+    const t = document.getElementById('hyperplayer-vtt');
+    if (t) t.removeAttribute('src');
+  });
+
+  const out = await runModalExport(page);
+  expect(out.name).toMatch(/\.html$/);
+  const html = out.bytes.toString('utf8');
+  expect(html).not.toContain('<track');
+  expect(html).not.toContain('data:text/vtt');
+});

--- a/__TEST__/e2e/playable-sections.spec.mjs
+++ b/__TEST__/e2e/playable-sections.spec.mjs
@@ -34,9 +34,13 @@ test('#383: with gaps on, the edge buffer never keeps struck audio', async ({ pa
 test('#371: pauses around struck filler words merge into the cut (gaps on)', async ({ page }) => {
   const sections = await sectionsFor(page, ISSUE_371_WORDS, { gapsOn: true, duration: 58.599 });
   // verified boundaries from the #371 fix: the "and …um… uses" region cuts
-  // [13.86 → 17.26] and "Yeah …Uh… you" cuts [28.34 → 29.18]
+  // [13.86 → 17.26] and "Yeah …Uh… you" cuts [28.34 → 29.18]. The EDGES moved
+  // with #577: this fixture opens with 2.24s before its first word and ends
+  // 24.7s before the media does, and both are now skipped like any other gap
+  // — playback starts at 2.14 (buffer protecting the first word's onset) and
+  // stops at 33.94 (buffer protecting the last word's tail).
   expect(sections).toEqual([
-    { start: 0, end: 2.42 },
+    { start: 2.14, end: 2.42 },
     { start: 3.34, end: 3.62 },
     { start: 5.02, end: 9.3 },
     { start: 9.66, end: 9.94 },
@@ -45,7 +49,7 @@ test('#371: pauses around struck filler words merge into the cut (gaps on)', asy
     { start: 17.26, end: 19.46 },
     { start: 19.98, end: 20.26 },
     { start: 20.94, end: 28.34 },
-    { start: 29.18, end: 58.599 },
+    { start: 29.18, end: 33.94 },
   ]);
 });
 

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -9,6 +9,21 @@ html {
   color-scheme: light;
 }
 
+/* ONE source of truth for where the transcript card starts (#580). The card
+   and the buttons pinned to its corners each carried their own constant per
+   breakpoint — three apiece — which is how they drift: at wide widths the
+   buttons sat 10px inside the card, in the compact band 18px, and any layout
+   change could strand them over the grey entirely. Everything derives from
+   this now, so they cannot disagree. */
+body {
+  --card-top: 78px;      /* 8px of canvas below the navbar so the card floats */
+  /* how far the TEXT column sits inside the card. It differs by band because
+     the mechanism differs — absolutely positioned at 10px here, flow plus the
+     holder's padding in the compact band, padding alone on mobile — so each
+     band states it once and the corner buttons derive from it. */
+  --text-inset: 10px;
+}
+
 /* body[data-theme] (0,1,1) outguns DaisyUI's data-theme background (which
    paints the body white and loads after this file) without needing !important —
    the 8px gaps around the transcript card (#375) expose the body, so it must
@@ -133,7 +148,7 @@ dialog::backdrop {
   border-radius: 0.5rem;
   overflow-y:scroll;
   position: absolute;
-  top: 78px;             /* 8px of canvas below the navbar so the card floats */
+  top: var(--card-top);
   left: 400px;
   right: 16px;
   bottom: 60px;          /* play bar (52px) + 8px gap — the corners read as a card */
@@ -238,6 +253,18 @@ dialog::backdrop {
 }
 
 @media screen and (max-width: 1120px) {
+  /* the compact navbar (#480) is shorter, so the card starts higher — and the
+     corner buttons follow it because they derive from this (#580) */
+  body {
+    /* 58px assumed a compact navbar that no longer exists — the navbar is 74px
+       here, so that value put the card UNDER it (#580). The measured value
+       from responsive.js is the authority; this only has to be right enough
+       for the first paint, before the script runs, so it matches the wide
+       band rather than flashing a card that then jumps down. */
+    --card-top: 78px;
+    --text-inset: 18px;  /* holder padding (8px) + the transcript's own offset */
+  }
+
   #file-dropdown-symbol-mobile {
     display: block;
   }
@@ -259,7 +286,6 @@ dialog::backdrop {
     justify-content: center;
     background-color: #ffffff;
     overflow-y:scroll;
-    top: 58px;
     right: 16px;
     bottom: 60px;
     padding: 8px;
@@ -292,6 +318,10 @@ dialog::backdrop {
   body {
     --nav-h: 70px;       /* matches the navbar's inline min-height */
     --player-h: 210px;   /* video area + a 44px controls row */
+    /* the card follows the pinned player as it collapses; the corner buttons
+       ride it automatically, being derived from the same variable */
+    --card-top: calc(var(--nav-h) + var(--player-h));
+    --text-inset: 8px;   /* holder padding only: the transcript is in flow here */
   }
   body.video-collapsed {
     --player-h: 44px;    /* controls row only; video hidden (audio-only button) */
@@ -374,7 +404,7 @@ dialog::backdrop {
   /* transcript fills the space between the pinned player and the play bar */
   .transcript-holder {
     position: fixed !important;
-    top: calc(var(--nav-h) + var(--player-h)) !important;
+    top: var(--card-top) !important;
     left: 0 !important;
     right: 0 !important;
     bottom: 52px !important;
@@ -616,7 +646,7 @@ html.ha-restoring #hypertranscript {
    hidden in caption mode by the view-switch wiring. */
 #transcript-copy-btn {
   position: fixed;
-  top: 88px;              /* holder top (78px) + 10px inset */
+  top: calc(var(--card-top) + var(--text-inset));   /* rides the text's top edge (#580) */
   right: 28px;            /* holder right (16px) + 12px inset */
   z-index: 20;            /* above content, below the drawer (45) and navbar (60) */
   color: oklch(var(--bc) / 0.55);
@@ -634,7 +664,6 @@ html:has(#hypertranscript[aria-busy="true"]) #transcript-copy-btn { display: non
 }
 @media screen and (max-width: 948px) {
   #transcript-copy-btn {
-    top: calc(var(--nav-h) + var(--player-h) + 10px);
     right: 12px;
     transition: top 0.25s ease; /* follows the video collapse like the holder */
   }
@@ -645,7 +674,7 @@ html:has(#hypertranscript[aria-busy="true"]) #transcript-copy-btn { display: non
    tracks body.sidebar-collapsed with the same 0.5s ease. */
 #transcript-info-btn {
   position: fixed;
-  top: 88px;              /* holder top (78px) + 10px inset */
+  top: calc(var(--card-top) + var(--text-inset));   /* rides the text's top edge (#580) */
   left: 412px;            /* holder left (400px) + 12px inset */
   z-index: 20;
   color: oklch(var(--bc) / 0.55);
@@ -661,7 +690,6 @@ html:has(#hypertranscript[aria-busy="true"]) #transcript-info-btn { display: non
 }
 @media screen and (max-width: 948px) {
   #transcript-info-btn {
-    top: calc(var(--nav-h) + var(--player-h) + 10px);
     left: 12px;
     transition: top 0.25s ease;
   }
@@ -676,10 +704,6 @@ html:has(#hypertranscript[aria-busy="true"]) #transcript-info-btn { display: non
    them half again the size of the one above. Every band aligns the buttons
    with the transcript element's top edge (88 at >1120, ~290 at <=948); this
    is that same edge, arrived at through two more offsets. */
-@media screen and (max-width: 1120px) and (min-width: 949px) {
-  #transcript-copy-btn { top: 76px; }
-  #transcript-info-btn { top: 76px; }
-}
 
 /* Undo/redo (#400): the history module injects ↶/↷ beside the strikethrough
    button, but the top bar has no room to give — especially on mobile. So:
@@ -708,7 +732,7 @@ html:has(#hypertranscript[aria-busy="true"]) #transcript-info-btn { display: non
 #transcript-undo,
 #transcript-redo {
   position: fixed;
-  top: 88px;               /* holder top (78px) + 10px inset, as the others */
+  top: calc(var(--card-top) + var(--text-inset));   /* rides the text's top edge (#580) */
   z-index: 20;
   width: 2rem;
   height: 2rem;
@@ -722,14 +746,9 @@ html:has(#hypertranscript[aria-busy="true"]) #transcript-info-btn { display: non
 /* the loader owns the card while a transcription runs — same rule as ⓘ/copy */
 html:has(#hypertranscript[aria-busy="true"]) #transcript-undo,
 html:has(#hypertranscript[aria-busy="true"]) #transcript-redo { display: none; }
-@media screen and (max-width: 1120px) and (min-width: 949px) {
-  #transcript-undo { top: 76px; }
-  #transcript-redo { top: 76px; }
-}
 @media screen and (max-width: 948px) {
   #transcript-undo,
   #transcript-redo {
-    top: calc(var(--nav-h) + var(--player-h) + 10px);
     transition: top 0.25s ease;  /* follows the video collapse like the holder */
   }
   #transcript-undo { right: 92px; }   /* copy at 12px on this band */

--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@ If you are creating an open source application under a license compatible with t
       </label>
       <label id="export-vtt-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
         <input type="checkbox" id="export-vtt" class="toggle toggle-primary" />
-        <span class="label-text">Download WebVTT (.vtt) captions <span style="opacity:0.6">— always included with an interactive transcript</span></span>
+        <span class="label-text">Download WebVTT (.vtt) captions<span id="export-vtt-note" style="opacity:0.6; display:none"> — included with the interactive transcript</span></span>
       </label>
       <label id="export-srt-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
         <input type="checkbox" id="export-srt" class="toggle toggle-primary" />
@@ -1047,7 +1047,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.3.0"></script>
   <script src="js/transcript-maintenance.js?v=1.3.0"></script>
-  <script src="js/editor-core.js?v=1.3.6"></script>
+  <script src="js/editor-core.js?v=1.3.6.1"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1090,7 +1090,7 @@ If you are creating an open source application under a license compatible with t
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
-  <script src="js/media-export.js?v=1.3.6.2"></script>
+  <script src="js/media-export.js?v=1.3.6.3"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
   <script src="js/word-vtt.js?v=1.1.6"></script>
   <!-- end of caption editor additions -->
@@ -1106,7 +1106,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.3.6.2"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.3.6.1"></script>
+  <script src="js/hyperaudio-save.js?v=1.3.6.2"></script>
   <script src="js/hyperaudio-library.js?v=1.3.4"></script>
   <script src="js/media-first-frame.js?v=1.3.4"></script>
   <script src="js/media-posters.js?v=1.3.4"></script>

--- a/index.html
+++ b/index.html
@@ -1090,7 +1090,7 @@ If you are creating an open source application under a license compatible with t
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
-  <script src="js/media-export.js?v=1.3.6.1"></script>
+  <script src="js/media-export.js?v=1.3.6.2"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
   <script src="js/word-vtt.js?v=1.1.6"></script>
   <!-- end of caption editor additions -->

--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@ If you are creating an open source application under a license compatible with t
       </label>
       <label id="export-vtt-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
         <input type="checkbox" id="export-vtt" class="toggle toggle-primary" />
-        <span class="label-text">Download WebVTT (.vtt) captions</span>
+        <span class="label-text">Download WebVTT (.vtt) captions <span style="opacity:0.6">— always included with an interactive transcript</span></span>
       </label>
       <label id="export-srt-row" style="display:none; gap:10px; align-items:center; margin-top:14px; cursor:pointer">
         <input type="checkbox" id="export-srt" class="toggle toggle-primary" />
@@ -1090,7 +1090,7 @@ If you are creating an open source application under a license compatible with t
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
-  <script src="js/media-export.js?v=1.3.6"></script>
+  <script src="js/media-export.js?v=1.3.6.1"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
   <script src="js/word-vtt.js?v=1.1.6"></script>
   <!-- end of caption editor additions -->

--- a/index.html
+++ b/index.html
@@ -1103,7 +1103,7 @@ If you are creating an open source application under a license compatible with t
 
   <!-- service worker script for PWA -->
   <script src="js/editor-service-worker.js?v=0.6.12"></script>
-  <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
+  <script type="module" src="js/editor-audio-cut.js?v=1.3.6.2"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
   <script src="js/hyperaudio-save.js?v=1.3.6.1"></script>

--- a/index.html
+++ b/index.html
@@ -1106,7 +1106,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.2.0"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.3.6"></script>
+  <script src="js/hyperaudio-save.js?v=1.3.6.1"></script>
   <script src="js/hyperaudio-library.js?v=1.3.4"></script>
   <script src="js/media-first-frame.js?v=1.3.4"></script>
   <script src="js/media-posters.js?v=1.3.4"></script>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.3.6 (last changed in release 1.3.6) -->
+<!--  Hyperaudio Lite Editor - Version 1.3.7 (last changed in release 1.3.7) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.3.6">
+  <meta name="version" content="1.3.7">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.6.1">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.7">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1047,7 +1047,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcript-lifecycle.js?v=1.2.0"></script>
   <script src="js/transcript-gateway.js?v=1.3.0"></script>
   <script src="js/transcript-maintenance.js?v=1.3.0"></script>
-  <script src="js/editor-core.js?v=1.3.6.1"></script>
+  <script src="js/editor-core.js?v=1.3.7"></script>
 
 
   <import-deepgram-json></import-deepgram-json>
@@ -1090,23 +1090,23 @@ If you are creating an open source application under a license compatible with t
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->
   <script src="js/transcript-bench.js?v=1.3.0"></script>
   <script src="js/stream-stretch.js?v=0.8.6"></script>
-  <script src="js/media-export.js?v=1.3.6.3"></script>
+  <script src="js/media-export.js?v=1.3.7"></script>
   <!-- word-level / karaoke VTT export (#387 part 1) -->
   <script src="js/word-vtt.js?v=1.1.6"></script>
   <!-- end of caption editor additions -->
 
   <!-- responsive small-screen UI toggles (#349) -->
-  <script src="js/responsive.js?v=1.3.6.1"></script>
+  <script src="js/responsive.js?v=1.3.7"></script>
 
   <!-- keyboard operability for modal label-buttons (#402) -->
   <script src="js/a11y.js?v=0.8.3"></script>
 
   <!-- service worker script for PWA -->
   <script src="js/editor-service-worker.js?v=0.6.12"></script>
-  <script type="module" src="js/editor-audio-cut.js?v=1.3.6.2"></script>
+  <script type="module" src="js/editor-audio-cut.js?v=1.3.7"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.3.6.2"></script>
+  <script src="js/hyperaudio-save.js?v=1.3.7"></script>
   <script src="js/hyperaudio-library.js?v=1.3.4"></script>
   <script src="js/media-first-frame.js?v=1.3.4"></script>
   <script src="js/media-posters.js?v=1.3.4"></script>

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.5">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.6.1">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1096,7 +1096,7 @@ If you are creating an open source application under a license compatible with t
   <!-- end of caption editor additions -->
 
   <!-- responsive small-screen UI toggles (#349) -->
-  <script src="js/responsive.js?v=0.8.11"></script>
+  <script src="js/responsive.js?v=1.3.6.1"></script>
 
   <!-- keyboard operability for modal label-buttons (#402) -->
   <script src="js/a11y.js?v=0.8.3"></script>

--- a/js/editor-audio-cut.js
+++ b/js/editor-audio-cut.js
@@ -322,7 +322,22 @@
       if (run !== null) cuts.push(run);
     };
 
+    // The LEADING region (#577): media start to the first kept word. Handled
+    // separately because the loop below only knows regions BETWEEN kept words
+    // — prevKeptEnd is null until one exists — so the setting-up before anyone
+    // speaks was never a candidate, however long. Struck words at the head
+    // belong to this region too, so their audio goes with it.
+    const firstKeptIndex = words.findIndex((w) => !w.struck);
+    if (firstKeptIndex !== -1 && words[firstKeptIndex].start > 0) {
+      const leadingStruck = words.slice(0, firstKeptIndex).filter((w) => w.struck);
+      // bufferLeft false: nothing precedes media start to protect
+      flushRegion(0, words[firstKeptIndex].start, leadingStruck, false, true);
+      // those struck words are now accounted for; the loop must not cut them again
+      words.slice(0, firstKeptIndex).forEach((w) => { w.struck = false; w.consumed = true; });
+    }
+
     words.forEach(word => {
+      if (word.consumed) return; // already covered by the leading region
       if (word.struck) {
         pendingStruck.push(word);
         return;
@@ -340,11 +355,20 @@
       prevKeptEnd = word.end;
     });
 
-    // trailing region after the last kept word
-    if (pendingStruck.length > 0) {
-      const regionStart = prevKeptEnd !== null ? prevKeptEnd : pendingStruck[0].start;
-      const regionEnd = pendingStruck[pendingStruck.length - 1].end;
+    // The TRAILING region: the last kept word to the end of the media (#577).
+    // Previously this only existed when struck words followed the last kept
+    // word, so plain dead air after the final word always played out. The
+    // media's real end is only usable when metadata has loaded — with an
+    // unknown duration the tail is left alone rather than guessed.
+    const regionStart = prevKeptEnd !== null
+      ? prevKeptEnd
+      : (pendingStruck.length > 0 ? pendingStruck[0].start : null);
+    if (regionStart !== null) {
+      const struckEnd = pendingStruck.length > 0
+        ? pendingStruck[pendingStruck.length - 1].end : regionStart;
+      const regionEnd = Number.isFinite(duration) ? Math.max(duration, struckEnd) : struckEnd;
       if (regionEnd > regionStart) {
+        // bufferRight false: nothing follows the media end to protect
         flushRegion(regionStart, regionEnd, pendingStruck, prevKeptEnd !== null, false);
       }
     }
@@ -415,8 +439,20 @@
   // struck region — without this the first word can sneak through between
   // RAF ticks.
   function checkStrikeThrus(myPlayer) {
-    if (audioDataArray.length < 2) return;
+    if (audioDataArray.length === 0) return;
     const t = myPlayer.currentTime;
+    const first = audioDataArray[0];
+    const last = audioDataArray[audioDataArray.length - 1];
+
+    // The LEADING gap (#577). The loop below only examines the bands BETWEEN
+    // kept sections, so the silence before the first one — the longest gap in
+    // many recordings — played in full even with skipping on.
+    if (t + 0.01 < first.start) {
+      myPlayer.currentTime = first.start + 0.05;
+      kickPlayhead();
+      return;
+    }
+
     for (let i = 0; i < audioDataArray.length - 1; i++) {
       const stop = audioDataArray[i].stop;
       const nextStart = audioDataArray[i + 1].start;
@@ -426,12 +462,29 @@
         // it has no idea we just jumped. Kick its polling chain so the
         // highlight re-locks onto the post-skip word instead of waiting for
         // its stale setTimeout to fire seconds later.
-        const instance = window.hyperaudioInstance;
-        if (instance && typeof instance.checkPlayHead === 'function') {
-          instance.checkPlayHead();
-        }
+        kickPlayhead();
         return;
       }
+    }
+
+    // The TRAILING gap (#577): past the last kept section there is nothing to
+    // play, so let the media end rather than run out its dead air. Only with a
+    // known duration, and only when the tail was actually cut.
+    const duration = myPlayer.duration;
+    if (Number.isFinite(last.stop) && Number.isFinite(duration)
+        && t >= last.stop && duration > last.stop + 0.01) {
+      myPlayer.currentTime = duration;
+      kickPlayhead();
+    }
+  }
+
+  // The library only listens for play/pause natively, not seeked, so it has no
+  // idea we just jumped: kick its polling chain or the highlight re-locks
+  // seconds later, via its stale setTimeout.
+  function kickPlayhead() {
+    const instance = window.hyperaudioInstance;
+    if (instance && typeof instance.checkPlayHead === 'function') {
+      instance.checkPlayHead();
     }
   }
 

--- a/js/editor-core.js
+++ b/js/editor-core.js
@@ -204,7 +204,7 @@
     }
 
     if (iaDownload !== null && iaInput !== null) {
-      iaDownload.addEventListener('click', () => {
+      iaDownload.addEventListener('click', async () => {
         const typed = iaInput.value.trim();
         if (typed === '') { iaInput.focus(); return; }
         // A bare filename is a path segment in the exported page, so it gets
@@ -220,7 +220,17 @@
             return window.safeExportName(stem, 'media') + ext.replace(/\s+/g, '');
           })()
           : typed;
-        const track = document.querySelector('#hyperplayer-vtt');
+        // Captions travel as a FILE, never inlined (#581): a data: URL carries
+        // a percent-encoded copy of the whole track inside the HTML, and no
+        // data: URL can express the <track srclang> per language that
+        // translations need. The page was never self-contained anyway — its
+        // media sits beside it.
+        const save = window.HyperaudioSave;
+        const vtt = (save && typeof save.getCaptionsVtt === 'function') ? save.getCaptionsVtt() : '';
+        const baseName = (typeof window.safeExportName === 'function'
+          ? window.safeExportName((save && save.getProjectTitle && save.getProjectTitle()) || '', 'interactive')
+          : 'interactive').replace(/\.[a-z0-9]+$/i, '');
+        const vttName = baseName + '.vtt';
         // function replacements so a literal $ in the transcript/filename isn't
         // treated as a replacement pattern
         const inner = typeof serializeTranscriptHtml === 'function'
@@ -229,17 +239,41 @@
         let html = hyperaudioTemplate
           .replace('{hypertranscript}', () => inner)
           .replace('{sourcemedia}', () => mediaSrc)
-          .replace('{sourcevtt}', () => (track !== null ? track.src : ''));
+          .replace('{sourcevtt}', () => (vtt !== '' ? vttName : ''));
+        if (vtt === '') html = html.replace(/<track[^>]*>/i, '');
         // the project's title in the tab, the unfurl and on the page (#563) —
         // the same filler the media-export route uses, so both agree
         if (typeof window.fillExportIdentity === 'function') {
           html = window.fillExportIdentity(html, inner);
         }
-        const blob = new Blob([html], { type: 'text/html' });
+        // With captions the page and its .vtt travel together in ONE archive:
+        // two separate downloads would let the browser de-duplicate the second
+        // to "name (1).vtt" and silently break the page's reference. Without
+        // captions there is nothing to pair, so a single HTML file as before.
+        let blob;
+        let filename;
+        if (vtt !== '') {
+          try {
+            const JSZipImpl = await window.HyperaudioSave.loadJSZip();
+            const zip = new JSZipImpl();
+            const folder = zip.folder(baseName);
+            folder.file(baseName + '-transcript.html', html);
+            folder.file(vttName, vtt);
+            blob = await zip.generateAsync({ type: 'blob' });
+            filename = baseName + '.zip';
+          } catch (e) {
+            console.warn('interactive export: could not package the captions, downloading the page alone', e);
+            blob = new Blob([html.replace(/<track[^>]*>/i, '')], { type: 'text/html' });
+            filename = baseName + '-transcript.html';
+          }
+        } else {
+          blob = new Blob([html], { type: 'text/html' });
+          filename = baseName + '-transcript.html';
+        }
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = 'interactive-transcript.html';
+        a.download = filename;
         a.click();
         setTimeout(() => URL.revokeObjectURL(url), 0);
         if (iaModal !== null) iaModal.checked = false;

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3342,6 +3342,10 @@
     // speaker-preserving, caption-mode-aware gather the save path uses
     getTranscriptJson: () => getEditorTranscriptJson(),
     loadJSZip, // shared vendored-zip loader (the .docx export packages with it)
+    // The live caption track's text, decoded from its data: URL. The
+    // Interactive Transcript modal needs the VTT as a FILE, never inlined
+    // into the page (#581), and this is where that decode already lives.
+    getCaptionsVtt,
     // The project's media as a FRESH File. An object URL made from an OPFS
     // file is a snapshot: once that file is rewritten (any save that re-writes
     // media does), the URL still plays from buffered data but can no longer be

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.3.6 — last changed in release 1.3.6
+ * @version 1.3.7 — last changed in release 1.3.7
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -1956,9 +1956,21 @@
         deferEmbedToBridge = embedderSrc;
         saveAsLink = true; // container carries the link; the bridge upgrades it
       } else {
-        showProgress('Reading the media…', 0, token);
-        mediaFile = await fetchRemoteMediaFile(embedderSrc);
-        embedderMedia = mediaFile;
+        try {
+          showProgress('Reading the media…', 0, token);
+          mediaFile = await fetchRemoteMediaFile(embedderSrc);
+          embedderMedia = mediaFile;
+        } catch (e) {
+          // The host application's scheme handler could not produce the file —
+          // moved, renamed, permissions changed, or not ready yet. Same
+          // treatment as the remote branch below (#574): explain it and offer
+          // the link save, rather than throwing a raw 'Failed to fetch' and
+          // losing the save entirely. No server is involved here, so the
+          // wording says what actually happened.
+          const proceed = await projectConfirm('The application could not provide the media file, so it cannot be embedded in the project file.\n\nSave the project with a LINK to the media instead? The file will contain all your work, but opening it will need the application to find that media again.', 'Save with link', 'Cancel');
+          if (!proceed) return false;
+          saveAsLink = true;
+        }
       }
     }
     if (mediaFile === null && remoteSrc !== null) {

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -886,11 +886,25 @@
   // The transcript/caption sidecars (interactive transcript, VTT, SRT) are all
   // offered whenever there's a transcript to derive them from — they re-time
   // themselves to whatever edits/speed the export uses.
+  // The interactive transcript ships its captions as a sidecar file (#561), so
+  // a .vtt is written whether or not this box is ticked — but NOT when the
+  // captions are burned into the picture, since then the page carries no
+  // <track> at all. The note says so only when it is true, rather than making
+  // a blanket claim that is wrong exactly when someone burns captions.
+  const updateVttNote = () => {
+    const note = document.getElementById('export-vtt-note');
+    if (note === null) return;
+    const interactive = retimeCheck !== null && retimeCheck.checked && retimeRow.style.display !== 'none';
+    const burning = burnCheck !== null && burnCheck.checked && burnRow !== null && burnRow.style.display !== 'none';
+    note.style.display = (interactive && !burning) ? '' : 'none';
+  };
+
   const updateRetimeVisibility = () => {
     const show = hasTranscript() ? 'flex' : 'none';
     retimeRow.style.display = show;
     if (vttRow !== null) vttRow.style.display = show;
     if (srtRow !== null) srtRow.style.display = show;
+    updateVttNote();
     // the flattened project (#455) needs a transcript to flatten, and the
     // container writer to be loaded
     if (projectRow !== null) {
@@ -1200,9 +1214,14 @@
   [retimeCheck, vttCheck, srtCheck, projectCheck, zipCheck].forEach((el) => {
     if (el !== null) el.addEventListener('change', updateZipVisibility);
   });
+  // the note depends on BOTH the interactive transcript and the burn choice
+  [retimeCheck, burnCheck].forEach((el) => {
+    if (el !== null) el.addEventListener('change', updateVttNote);
+  });
   sourceEntire.addEventListener('change', () => { updateRetimeVisibility(); refreshAdjustForContent(); });
   sourceEdited.addEventListener('change', () => { updateRetimeVisibility(); refreshAdjustForContent(); });
-  formatSelect.addEventListener('change', updateBurnVisibility);
+  // the format decides whether burning is even offered, so the note follows it
+  formatSelect.addEventListener('change', () => { updateBurnVisibility(); updateVttNote(); });
   if (adjustCheck !== null) {
     adjustCheck.addEventListener('change', () => {
       updateAdjustVisibility();

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -1049,7 +1049,15 @@
         const subs = genRetimedCaptions(sections, rate);
         const vttName = `${baseName}.vtt`;
         const srtName = `${baseName}.srt`;
-        if (wantVtt && subs && subs.vtt) {
+        // The interactive transcript's captions ride as a SIDECAR file, not an
+        // inline data: URL (#561). The page has never been self-contained —
+        // its media is a separate file beside it, and the bundle ships as one
+        // folder — so inlining bought nothing while costing a percent-encoded
+        // copy of the whole VTT inside the HTML. Files are also the only shape
+        // that extends: a translated transcript means one <track> per
+        // language, which no data: URL can express.
+        const needVtt = (wantVtt || (wantRetime && !burn)) && subs && subs.vtt;
+        if (needVtt) {
           outputs.push({ blob: new Blob([subs.vtt], { type: 'text/vtt' }), name: vttName });
         }
         if (wantSrt && subs && subs.srt) {
@@ -1057,15 +1065,13 @@
         }
         if (wantRetime) {
           // captions track inside the interactive transcript:
-          //   burned in    -> none (they are already painted into the video)
-          //   VTT exported -> link the sidecar .vtt file
-          //   otherwise    -> embed the re-timed VTT inline (self-contained)
+          //   burned in -> none (they are already painted into the video)
+          //   otherwise -> link the sidecar .vtt, which ships in the bundle
           let trackSrc = null;
           if (!burn) {
-            if (wantVtt) trackSrc = encodeURI(vttName);
-            else if (subs && subs.vtt) trackSrc = 'data:text/vtt,' + encodeURIComponent(subs.vtt);
+            if (needVtt) trackSrc = vttName; // sanitised already (#560): no encoding needed
           }
-          const html = buildInteractiveExportHtml(sections, rate, encodeURI(mediaName), trackSrc);
+          const html = buildInteractiveExportHtml(sections, rate, mediaName, trackSrc);
           if (html !== null) {
             outputs.push({ blob: new Blob([html], { type: 'text/html' }), name: `${baseName}-transcript.html` });
           }

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -1,7 +1,7 @@
 /**
  * media-export.js
  * (C) The Hyperaudio Project
- * @version 1.3.6 — last changed in release 1.3.6
+ * @version 1.3.7 — last changed in release 1.3.7
  * @license MIT
  *
  * Media export via mediabunny (#289, #291, #292): export the loaded media as

--- a/js/media-export.js
+++ b/js/media-export.js
@@ -404,6 +404,50 @@
   const startStreamStretcher = async (rate, emit) =>
     makeStreamStretcher(await loadSoundtouch(), rate, emit);
 
+  /* --------------------------------------------------------------------------
+   * Encoder input rate (#579). WebKit's WebCodecs AudioEncoder picks HE-AAC
+   * for MONO input below 32 kHz — a sharp, measured boundary — and the muxed
+   * track that results is unreadable to AVFoundation: zero audio tracks, so
+   * the export is SILENT in QuickTime, Safari and Finder preview while
+   * appearing to have succeeded. Voice notes, telephony, voicemail and much
+   * interview audio live below that line. Chrome is unaffected; this is
+   * WebKit's encoder choice.
+   *
+   * Forcing the codec string to mp4a.40.2 does NOT help — measured: WebKit
+   * emits HE-AAC regardless while describing it as LC, so the muxed
+   * configuration disagrees with the samples either way.
+   *
+   * So low-rate audio is lifted before it reaches the encoder. 32 kHz encodes
+   * as AAC-LC across bitrates (verified at QUALITY_LOW/MEDIUM/HIGH and
+   * 32/64/128 kbps), but we lift clear of that cliff rather than onto it, and
+   * prefer a target the source divides into exactly — 8/12/16/24 kHz into
+   * 48 kHz, 11.025/22.05 into 44.1 — which keeps the resampling arithmetic
+   * simple. Upsampling cannot restore bandwidth the source never had, and it
+   * cannot lose any either. Applied on every engine: skipping it by sniffing
+   * for WebKit would risk guessing wrong about some variant, and the early
+   * return means anything at 32 kHz or above pays nothing.
+   * ------------------------------------------------------------------------ */
+  const MIN_ENCODE_RATE = 32000;     // below this WebKit picks HE-AAC for mono
+  const liftTargetFor = (rate) => (44100 % rate === 0 ? 44100 : 48000);
+
+  const liftForEncoder = async (buffer) => {
+    if (!buffer || buffer.sampleRate >= MIN_ENCODE_RATE) return buffer;
+    const target = liftTargetFor(buffer.sampleRate);
+    try {
+      const frames = Math.max(1, Math.round(buffer.length * target / buffer.sampleRate));
+      const ctx = new OfflineAudioContext(buffer.numberOfChannels, frames, target);
+      const src = ctx.createBufferSource();
+      src.buffer = buffer;
+      src.connect(ctx.destination);
+      src.start();
+      return await ctx.startRendering();
+    } catch (e) {
+      // A silent export is bad; breaking an export that used to work is worse.
+      console.warn('media-export: could not lift audio to ' + target + ' Hz — encoding at the source rate', e);
+      return buffer;
+    }
+  };
+
   // Edited media, audio-only: decode each kept section, trim the edge buffers,
   // append. AudioBufferSource plays appended buffers back-to-back from 0, so
   // the sections concatenate without any timestamp bookkeeping.
@@ -421,7 +465,12 @@
     try {
       const total = keptDuration(sections);
       let done = 0;
-      const stretcher = rate !== 1 ? await startStreamStretcher(rate, (b) => source.add(b)) : null;
+      // Every buffer reaches the encoder through here — the direct branch AND
+      // the stretcher's emit — so the lift (#579) cannot be missed by a call
+      // site. Deliberately AFTER the stretcher: SoundTouch keeps working on
+      // the smaller source-rate buffers rather than three times the samples.
+      const addAudio = async (b) => { await source.add(await liftForEncoder(b)); };
+      const stretcher = rate !== 1 ? await startStreamStretcher(rate, addAudio) : null;
       for (const sec of sections) {
         for await (const wrapped of sink.buffers(sec.start, sec.end)) {
           const trimmed = trimBufferToRange(wrapped.buffer, wrapped.timestamp, sec.start, sec.end);
@@ -429,7 +478,7 @@
             if (stretcher !== null) {
               await stretcher.push(trimmed);
             } else {
-              await source.add(trimmed);
+              await addAudio(trimmed);
             }
             done += trimmed.duration;
             onProgress(Math.min(0.99, done / total));
@@ -518,7 +567,8 @@
       vSource.close();
 
       if (aSink !== null) {
-        const stretcher = rate !== 1 ? await startStreamStretcher(rate, (b) => aSource.add(b)) : null;
+        const addAudio = async (b) => { await aSource.add(await liftForEncoder(b)); };
+        const stretcher = rate !== 1 ? await startStreamStretcher(rate, addAudio) : null;
         for (const sec of sections) {
           for await (const wrapped of aSink.buffers(sec.start, sec.end)) {
             const trimmed = trimBufferToRange(wrapped.buffer, wrapped.timestamp, sec.start, sec.end);
@@ -526,7 +576,7 @@
               if (stretcher !== null) {
                 await stretcher.push(trimmed);
               } else {
-                await aSource.add(trimmed);
+                await addAudio(trimmed);
               }
               done += trimmed.duration;
               onProgress(Math.min(0.99, done / total));

--- a/js/responsive.js
+++ b/js/responsive.js
@@ -1,7 +1,7 @@
 /**
  * responsive.js
  * (C) The Hyperaudio Project
- * @version 0.8.11 — last changed in release 0.8.11
+ * @version 1.3.7 — last changed in release 1.3.7
  * @license MIT
  *
  * Small-screen UI toggles for the responsive layout (#349):

--- a/js/responsive.js
+++ b/js/responsive.js
@@ -17,6 +17,43 @@
   const body = document.body;
   const mobile = window.matchMedia('(max-width: 948px)');
 
+  /* --- Where the transcript card starts (#580) -------------------------------
+   * The card's top was a CSS constant per band — 78px wide, 58px compact —
+   * each assuming a navbar height. The navbar has since grown: at 1000px it is
+   * 74px tall against that 58px, so its grey band painted over the card's top
+   * edge (losing the rounded corners) and over the ⓘ/copy buttons pinned to
+   * it. Measuring is the only way that cannot go stale: the navbar's real
+   * bottom, plus the 4px of canvas the wide layout has always shown, becomes
+   * --card-top, and the card and every corner button derive from it.
+   *
+   * The mobile band (<=948px) pins the player under the navbar and computes
+   * its own --card-top in CSS, so the inline value is REMOVED there — an
+   * inline property would outrank that media query.
+   * ------------------------------------------------------------------------ */
+  const CANVAS_GAP = 4;
+  const navbar = document.querySelector('.main-panel');
+
+  const syncCardTop = () => {
+    if (navbar === null) return;
+    if (mobile.matches) {
+      body.style.removeProperty('--card-top');
+      return;
+    }
+    const bottom = Math.round(navbar.getBoundingClientRect().bottom);
+    if (bottom > 0) body.style.setProperty('--card-top', (bottom + CANVAS_GAP) + 'px');
+  };
+
+  syncCardTop();
+  window.addEventListener('resize', syncCardTop);
+  mobile.addEventListener('change', syncCardTop);
+  if (navbar !== null && typeof ResizeObserver === 'function') {
+    // the navbar can change height after boot (a control arrives, a label
+    // wraps), which is what made the overlap look intermittent
+    new ResizeObserver(syncCardTop).observe(navbar);
+  }
+  // webfonts and late-injected toolbar buttons can settle after first paint
+  window.addEventListener('load', syncCardTop);
+
   // --- Recents drawer --------------------------------------------------------
   // Keep #sidebar-toggle's aria-pressed tracking the drawer while in the
   // small-screen layout (editor-core.js owns it on desktop, where the same


### PR DESCRIPTION
Exports that carry their captions, gap skipping that reaches the edges, and a card that stays clear of the navbar.

- **Captions are never inlined into an exported transcript** (#561, #581): both export routes now ship the `.vtt` as a file beside the page and link it by name. The media export writes it into the bundle; the FILE → Interactive Transcript route downloads a zip holding the page and its captions together, because two separate downloads let the browser rename the second and silently break the link. A page with no captions stays a single file with no empty `<track>`.
- **Gap skipping reaches the silence before the first word and after the last** (#577), in playback as well as export. Both were invisible to it: regions were only built *between* kept words, and playback only ever examined the bands between kept sections. The #371 fixture opens 2.24s before its first word and ends 24.7s before the media does.
- **Low-rate mono audio exports with sound on Safari** (#579): WebKit's encoder picks HE-AAC below 32 kHz and AVFoundation reads zero audio tracks, so the export was silent while appearing to succeed — voice notes, telephony and much interview audio. Such audio is now lifted before it reaches the encoder. Diagnosis and measurements by maboa; verification of the resulting files lives in a WKWebView harness, since Chromium cannot exhibit the bug.
- **The transcript card starts below the navbar, measured rather than assumed** (#580): a stale constant put the card's top at 58px against a 74px navbar, so the grey band covered the card's rounded corners and the ⓘ/copy buttons. The card's top is now measured, and every corner button derives from it instead of carrying its own constant per breakpoint.
- **A failing embedder-scheme fetch offers the link save** (#574) instead of surfacing a raw "Failed to fetch" and abandoning the save.

Fixes #561. Fixes #574. Fixes #577. Fixes #579. Fixes #580. Fixes #581.

Suite: 89 unit + 255 e2e green (1 known Playwright-WebKit OPFS skip).
