### PR TITLE
Version 1.3.8

### DIFF
--- a/__TEST__/e2e/project-save.spec.mjs
+++ b/__TEST__/e2e/project-save.spec.mjs
@@ -1705,3 +1705,72 @@ test('a project switch does not leave a stray caret above the transcript', async
   expect(result.hostStillFocused).toBe(false);
   expect(result.selectionOnHost).toBe(false);
 });
+
+// #587 — switching back to a project restores your place: scroll (anchored to
+// the first visible word, not pixels) and the paused playhead. An UNKNOWN
+// project opens at its top — previously replaceChildren kept the scroll
+// container's offset, so the incoming project inherited the outgoing one's
+// scroll position. Session-only: nothing persists.
+test('a project switch restores scroll and playhead; unknown projects start at the top (#587)', async ({ page }, testInfo) => {
+  const dialogs = [];
+  // a long transcript, so there is somewhere to scroll to
+  await openFixture(page, testInfo, dialogs, (project) => {
+    // word0 keeps the fixture's expected first word: openFixture asserts it
+    const words = [{ text: 'Benvenuti ', start: 0, end: 0.4 }];
+    for (let i = 1; i < 600; i += 1) {
+      words.push({ text: 'word' + i + ' ', start: i * 0.5, end: i * 0.5 + 0.4 });
+    }
+    project.transcript.words = words;
+    project.transcript.paragraphs = [{ speaker: '', start: 0, end: 300 }];
+  });
+  await awaitLibraryEntry(page);
+  const longId = await page.evaluate(() => window.HyperaudioSave.library.currentId());
+
+  // a second, short project to switch to
+  await page.evaluate(async (id) => { await window.HyperaudioSave.library.duplicate(id); }, longId);
+  const shortId = await page.evaluate(async (a) => {
+    const list = await window.HyperaudioSave.library.list();
+    return list.find((e) => e.id !== a).id;
+  }, longId);
+
+  // scroll deep into the long project and note the first visible word
+  const anchorM = await page.evaluate(() => {
+    const holder = document.querySelector('.transcript-holder');
+    holder.scrollTop = holder.scrollHeight / 2;
+    const top = holder.getBoundingClientRect().top;
+    const words = document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)');
+    for (const s of words) {
+      if (s.getBoundingClientRect().bottom >= top) return s.getAttribute('data-m');
+    }
+    return null;
+  });
+  expect(anchorM).not.toBeNull();
+
+  // park the playhead mid-media before leaving
+  await page.evaluate(() => {
+    const player = document.getElementById('hyperplayer');
+    if (player.readyState >= 1) player.currentTime = 3;
+  });
+
+  // switching to the OTHER copy must open at ITS top, not inherit the offset
+  await page.evaluate((id) => window.HyperaudioSave.library.open(id), shortId);
+  await page.waitForFunction((id) => window.HyperaudioSave.library.currentId() === id, shortId);
+  expect(await page.evaluate(() => document.querySelector('.transcript-holder').scrollTop)).toBe(0);
+
+  // ...and switching BACK restores the anchored word to the visible top
+  await page.evaluate((id) => window.HyperaudioSave.library.open(id), longId);
+  await page.waitForFunction((id) => window.HyperaudioSave.library.currentId() === id, longId);
+  const restored = await page.evaluate(() => {
+    const holder = document.querySelector('.transcript-holder');
+    const top = holder.getBoundingClientRect().top;
+    const words = document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)');
+    for (const s of words) {
+      if (s.getBoundingClientRect().bottom >= top) {
+        return { m: s.getAttribute('data-m'), scrollTop: holder.scrollTop };
+      }
+    }
+    return null;
+  });
+  expect(restored.scrollTop).toBeGreaterThan(0);
+  expect(Math.abs(Number(restored.m) - Number(anchorM))).toBeLessThanOrEqual(1000); // within ~2 words
+});

--- a/__TEST__/unit/word-alignment.test.mjs
+++ b/__TEST__/unit/word-alignment.test.mjs
@@ -1,0 +1,118 @@
+// #425 — the alignment rework, informed by ts-aligner v0.2.2. These pin the
+// four behaviours the issue names: normalized matching, distributed
+// insert-run timing, bounded large-input alignment, and the language-agnostic
+// speaker rules the rework brought with it.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const wa = require('../../js/word-alignment.js');
+
+const timingsFor = (words, start = 0, dur = 0.5) =>
+  words.map((_, i) => ({ start: start + i * dur, end: start + (i + 1) * dur }));
+
+test('punctuation and case differences are matches, not substitutions (#425)', () => {
+  const src = ['Hello,', 'world.', '“Quoted”', '(aside)'];
+  const tgt = ['hello', 'world', 'quoted', 'aside'];
+  const alignment = wa.alignWords(src, tgt);
+  assert.deepEqual(alignment.map((a) => a.type), ['match', 'match', 'match', 'match']);
+});
+
+test('interior apostrophes and hyphens keep word identity', () => {
+  assert.equal(wa.normalizeWord("Don't"), "don't");
+  assert.equal(wa.normalizeWord('co-op,'), 'co-op');
+});
+
+test('an exact match is never substituted through (substitution costs 2)', () => {
+  // naive cost-1 DP may substitute across "b"; the anchored alignment must
+  // keep "b" matched and pay insert+delete around it instead
+  const alignment = wa.alignWords(['x', 'b'], ['b', 'y']);
+  const matched = alignment.find((a) => a.type === 'match');
+  assert.ok(matched, 'the exact match "b" must survive as a match');
+});
+
+test('insert-run timings distribute across the anchor gap, monotonic and flush (#425)', () => {
+  // machine: A B with a 2s silence between them; corrected inserts two words
+  const src = ['alpha', 'omega'];
+  const timings = [{ start: 0, end: 1 }, { start: 3, end: 4 }];
+  const tgt = ['alpha', 'new', 'words', 'omega'];
+  const alignment = wa.alignWords(src, tgt);
+  const out = wa.generateAlignedJSON(alignment, src, tgt, timings, tgt.join(' '));
+  const w = out.words;
+  assert.equal(w.length, 4);
+  // strictly inside the gap, flush to both anchors, no overlaps, monotonic
+  assert.equal(w[1].start, 1);
+  assert.equal(w[3].start, 3);
+  assert.ok(Math.abs(w[2].end - 3) < 1e-9, 'run ends flush with the next anchor');
+  for (let i = 1; i < w.length; i++) {
+    assert.ok(w[i].start >= w[i - 1].end - 1e-9, 'no overlap');
+  }
+  assert.ok(w[1].end > w[1].start && w[2].end > w[2].start, 'no zero durations in an open gap');
+});
+
+test('a longer word takes a larger share of the gap (syllable weighting)', () => {
+  const src = ['a', 'z'];
+  const timings = [{ start: 0, end: 1 }, { start: 4, end: 5 }];
+  const tgt = ['a', 'hi', 'undeniable', 'z']; // 1 vowel group vs 5
+  const out = wa.generateAlignedJSON(wa.alignWords(src, tgt), src, tgt, timings, tgt.join(' '));
+  const short = out.words[1], long = out.words[2];
+  assert.ok((long.end - long.start) > (short.end - short.start) * 2,
+    'the multi-syllable word takes the visibly larger share');
+});
+
+test('inserted words before the first anchor back-fill toward it, clamped at zero', () => {
+  const src = ['omega'];
+  const timings = [{ start: 0.3, end: 1 }];
+  const tgt = ['brand', 'new', 'omega'];
+  const out = wa.generateAlignedJSON(wa.alignWords(src, tgt), src, tgt, timings, tgt.join(' '));
+  const w = out.words;
+  assert.ok(w[0].start >= 0);
+  assert.ok(Math.abs(w[1].end - 0.3) < 1e-9, 'run ends where the first anchor begins');
+  assert.ok(w[1].start >= w[0].end - 1e-9);
+});
+
+test('inserted words after the last anchor run on at nominal pace', () => {
+  const src = ['alpha'];
+  const timings = [{ start: 0, end: 1 }];
+  const tgt = ['alpha', 'trailing', 'words'];
+  const out = wa.generateAlignedJSON(wa.alignWords(src, tgt), src, tgt, timings, tgt.join(' '));
+  const w = out.words;
+  assert.equal(w[1].start, 1);
+  assert.ok(w[2].end > w[2].start && w[1].end > w[1].start);
+  assert.ok(w[2].start >= w[1].end - 1e-9);
+});
+
+test('banded alignment agrees with the full table on a drifted transcript (#425)', () => {
+  // 400 words with scattered edits: substitutions, an insertion run, deletions
+  const src = Array.from({ length: 400 }, (_, i) => 'word' + i);
+  const tgt = src.slice();
+  tgt[50] = 'changed';
+  tgt.splice(200, 0, 'extra', 'inserted', 'words');
+  tgt.splice(300, 4);
+  const standard = wa.alignWordsStandard(src, tgt);
+  const banded = wa.alignWordsBanded(src, tgt, 40);
+  assert.deepEqual(banded, standard);
+});
+
+test('the greedy fallback terminates and stays sane on disjoint inputs', () => {
+  const alignment = wa.alignWordsGreedy(['a', 'b', 'c'], ['x', 'y', 'z', 'w']);
+  assert.equal(alignment.filter((a) => a.targetIdx !== null).length, 4);
+  assert.equal(alignment.filter((a) => a.sourceIdx !== null).length, 3);
+});
+
+test('speaker detection is language-agnostic (#425)', () => {
+  // the old rules required a capital [A-Z0-9] after the label — every
+  // non-Latin transcript was rejected outright
+  assert.equal(wa.isValidSpeakerPattern('[María] él dijo algo').isValid, true);
+  assert.equal(wa.isValidSpeakerPattern('[田中] こんにちは').isValid, true);
+  assert.equal(wa.isValidSpeakerPattern('Алиса: привет').isValid, true);
+  assert.equal(wa.isValidSpeakerPattern('[Bob] Hello').speaker, 'Bob');
+});
+
+test('sentences with colons are not speakers', () => {
+  assert.equal(wa.isValidSpeakerPattern('The meeting at 3:30 was long').isValid, false);
+  assert.equal(wa.isValidSpeakerPattern('This sentence, with a comma, has a colon: here').isValid, false);
+  const seven = wa.isValidSpeakerPattern('one two three four five six seven: text');
+  assert.equal(seven.isValid, false);
+});

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.3.7 (last changed in release 1.3.7) -->
+<!--  Hyperaudio Lite Editor - Version 1.3.8 (last changed in release 1.3.8) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.3.7">
+  <meta name="version" content="1.3.8">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
@@ -48,7 +48,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcribe-prefs.js?v=0.8.2"></script>
   <script src="js/hyperaudio-lite-editor-whisper.js?v=1.3.3"></script>
   <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=1.3.3"></script>
-  <script src="js/word-alignment.js?v=1.3.7.1"></script>
+  <script src="js/word-alignment.js?v=1.3.8"></script>
   <script src="js/html-json-converter.js?v=1.1.9"></script>
   <script src="js/transcript-to-ionosphere.js?v=1.1.1"></script>
   <script src="js/paragraph-timecodes.js?v=1.2.0"></script>
@@ -1106,7 +1106,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.3.7"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.3.7.1"></script>
+  <script src="js/hyperaudio-save.js?v=1.3.8"></script>
   <script src="js/hyperaudio-library.js?v=1.3.4"></script>
   <script src="js/media-first-frame.js?v=1.3.4"></script>
   <script src="js/media-posters.js?v=1.3.4"></script>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ If you are creating an open source application under a license compatible with t
   <script src="js/transcribe-prefs.js?v=0.8.2"></script>
   <script src="js/hyperaudio-lite-editor-whisper.js?v=1.3.3"></script>
   <script src="js/hyperaudio-lite-editor-parakeet-local.js?v=1.3.3"></script>
-  <script src="js/word-alignment.js"></script>
+  <script src="js/word-alignment.js?v=1.3.7.1"></script>
   <script src="js/html-json-converter.js?v=1.1.9"></script>
   <script src="js/transcript-to-ionosphere.js?v=1.1.1"></script>
   <script src="js/paragraph-timecodes.js?v=1.2.0"></script>

--- a/index.html
+++ b/index.html
@@ -1106,7 +1106,7 @@ If you are creating an open source application under a license compatible with t
   <script type="module" src="js/editor-audio-cut.js?v=1.3.7"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
-  <script src="js/hyperaudio-save.js?v=1.3.7"></script>
+  <script src="js/hyperaudio-save.js?v=1.3.7.1"></script>
   <script src="js/hyperaudio-library.js?v=1.3.4"></script>
   <script src="js/media-first-frame.js?v=1.3.4"></script>
   <script src="js/media-posters.js?v=1.3.4"></script>

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -1108,6 +1108,74 @@
 
   // Replay a loaded project into the editor. Mirrors what the legacy
   // renderTranscript() does for Recents, but builds the DOM safely from JSON.
+  /* --------------------------------------------------------------------------
+   * Session resume (#587): switching back to a project restores your place —
+   * the scroll position and the paused playhead. In-memory only: a reload
+   * starts clean, and durable resume is a separate decision (it would touch
+   * the library format). The caret is deliberately NOT restored: it is input
+   * routing, not context — restoring it restores focus, and a focused
+   * transcript captures the next keystroke. (Document editors, Google Docs
+   * included, restore nothing; this is already more restorative than that.)
+   *
+   * Scroll anchors to the first visible word's data-m rather than a pixel
+   * offset — pixels break when the viewport, the font, or the text changes.
+   * ------------------------------------------------------------------------ */
+  const resumePositions = new Map(); // project id → { wordM, playhead }
+
+  function scrollContainerEl() {
+    // the holder scrolls on every band; the transcript itself never does
+    return document.querySelector('.transcript-holder');
+  }
+
+  function captureResumePosition() {
+    if (session.projectId === null) return;
+    const holder = scrollContainerEl();
+    const player = document.getElementById('hyperplayer');
+    let wordM = null;
+    if (holder !== null) {
+      const holderTop = holder.getBoundingClientRect().top;
+      const words = document.querySelectorAll('#hypertranscript span[data-m]:not(.speaker)');
+      for (const span of words) {
+        if (span.getBoundingClientRect().bottom >= holderTop) {
+          wordM = span.getAttribute('data-m');
+          break;
+        }
+      }
+    }
+    resumePositions.set(session.projectId, {
+      wordM,
+      playhead: player !== null && Number.isFinite(player.currentTime) ? player.currentTime : 0,
+    });
+  }
+
+  function restoreResumePosition(id) {
+    const pos = resumePositions.get(id);
+    const holder = scrollContainerEl();
+    if (holder !== null) {
+      if (pos && pos.wordM !== null) {
+        const span = document.querySelector(
+          '#hypertranscript span[data-m="' + CSS.escape(pos.wordM) + '"]');
+        if (span !== null) {
+          span.scrollIntoView({ block: 'start' });
+        } else {
+          holder.scrollTop = 0; // the anchor word was edited away — the top
+        }
+      } else {
+        // unknown project (or nothing captured): its beginning, not the
+        // previous project's offset — replaceChildren keeps scrollTop, which
+        // was the leak this feature grew out of
+        holder.scrollTop = 0;
+      }
+    }
+    const player = document.getElementById('hyperplayer');
+    if (player === null || !pos || !(pos.playhead > 0)) return;
+    // the new media's metadata may not be in yet; the seek waits for it, and
+    // playback stays PAUSED — restoring your place is not resuming playback
+    const seek = () => { try { player.currentTime = pos.playhead; } catch (e) { /* not seekable */ } };
+    if (player.readyState >= 1) seek();
+    else player.addEventListener('loadedmetadata', seek, { once: true });
+  }
+
   function apply(loaded) {
     suppressCapture = true;
     try {
@@ -2604,6 +2672,7 @@
       if (t === null || t.getAttribute('aria-busy') !== 'true') return true;
     }
     leaveTranscriptionView();
+    captureResumePosition(); // where you are in the OUTGOING project (#587)
     const files = await readProjectFiles(id);
     if (files === null) return false;
     await flushPendingDraft();
@@ -2614,6 +2683,7 @@
     } finally {
       suppressCapture = false;
     }
+    restoreResumePosition(id); // your place in the INCOMING one (#587)
     await acquireProjectLock(id);
     const lib = await readLibrary();
     const entry = lib.projects.find((p) => p.id === id);

--- a/js/hyperaudio-save.js
+++ b/js/hyperaudio-save.js
@@ -3,7 +3,7 @@
  * .hyperaudio PROJECT SAVE — format, container, OPFS working copy, UI
  * ============================================================================
  *
- * @version 1.3.7 — last changed in release 1.3.7
+ * @version 1.3.8 — last changed in release 1.3.8
  *
  * Implements the .hyperaudio format v1.2 (normative spec:
  * docs/hyperaudio-format.md — originated in issue #403). 1.1 added media.kind

--- a/js/word-alignment.js
+++ b/js/word-alignment.js
@@ -1,6 +1,11 @@
 /**
  * ============================================================================
  * TRANSCRIPT ALIGNMENT ALGORITHM
+ * @version 1.3.8 — reworked for #425
+ *
+ * Portions derived from ts-aligner (https://github.com/theirstory/ts-aligner),
+ * Apache License 2.0, © TheirStory contributors; modified. The banded
+ * alignment and greedy fallback in particular originate there (v0.2.2).
  * ============================================================================
  * 
  * PURPOSE:
@@ -104,9 +109,13 @@
  *   stripPunctuation("okay.") → "okay"
  */
 function stripPunctuation(word) {
-  // Remove one or more trailing punctuation characters: .,!?;:'"
-  // The + means "one or more", $ means "at the end of string"
-  return word.replace(/[.,!?;:'"]+$/, '');
+  // Strip punctuation from BOTH edges, including the typographic characters
+  // real transcripts carry (curly quotes, ellipses, dashes, brackets). Interior
+  // characters stay, so "don't" and "co-op" keep their identity — only the
+  // word's edges are dressing. (#425: the old version stripped ASCII trailing
+  // punctuation only, so “quoted” words and (parenthesised) ones never
+  // matched their plain forms.)
+  return word.replace(/^[\s.,!?;:'"“”‘’()\[\]«»…—–-]+|[\s.,!?;:'"“”‘’()\[\]«»…—–-]+$/g, '');
 }
 
 /**
@@ -272,56 +281,40 @@ function extractWordsFromPlainText(plainText) {
  *   "hello: world" → {isValid: false} (lowercase speaker name)
  */
 function isValidSpeakerPattern(text) {
-  // Try bracketed pattern first: [Name] optional(:) optional(whitespace) rest
-  const bracketedMatch = text.match(/^\[([^\]]+)\]\s*:?\s*(.*)$/);
-  
+  // Bracketed pattern: [anything] optional(:) then content. Brackets are an
+  // explicit statement of intent, so the label and the following text can be
+  // ANY script — the old rule required the content to start with [A-Z0-9],
+  // which rejected every non-Latin transcript outright (#425).
+  const bracketedMatch = text.match(/^\[([^\]]+)\]\s*:?\s*(.+)$/);
   if (bracketedMatch) {
-    const potentialSpeaker = bracketedMatch[1];
-    const remainingText = bracketedMatch[2];
-    
-    // If there's remaining text, check if it starts with capital letter
-    if (remainingText.length > 0) {
-      const firstChar = remainingText.charAt(0);
-      
-      // Must start with uppercase letter or digit
-      if (firstChar === firstChar.toUpperCase() && /[A-Z0-9]/.test(firstChar)) {
-        return {
-          isValid: true,
-          speaker: potentialSpeaker,
-          remainingText: remainingText
-        };
-      } else {
-        // Lowercase first character - not a valid speaker pattern
-        return { isValid: false, speaker: null, remainingText: text };
-      }
-    } else {
-      // Empty remaining text - not valid (need actual content)
-      return { isValid: false, speaker: null, remainingText: text };
-    }
+    return {
+      isValid: true,
+      speaker: bracketedMatch[1].trim(),
+      remainingText: bracketedMatch[2]
+    };
   }
-  
-  // Try unbracketed pattern: Name(s) followed by : and then capitalized word
-  // Pattern matches text before colon that can include letters, spaces, periods, and dashes
-  // This allows: "Q:", "A:", "Dr. Johnson:", "Smith-Jones:", "Mary Jane Watson:", etc.
-  const unbracketedMatch = text.match(/^([A-Z][A-Za-z.\-\s]*?):\s*(.+)$/);
-  
+
+  // Unbracketed pattern: label followed by ':' and content. No case rules
+  // (they were Latin-only too); instead the label is bounded — at most six
+  // words and sixty characters, no sentence punctuation — so a sentence that
+  // merely CONTAINS a colon is not mistaken for a speaker.
+  // Whitespace after the colon is REQUIRED here: without it, times of day
+  // ("at 3:30") parse as a speaker called "at 3". "Alice:hello" with no space
+  // loses out, but clock times are far commoner in transcripts than unspaced
+  // labels.
+  const unbracketedMatch = text.match(/^([^:\n]{1,60}?):\s+(.+)$/);
   if (unbracketedMatch) {
-    const potentialSpeaker = unbracketedMatch[1].trim();
-    const remainingText = unbracketedMatch[2];
-    
-    // Check if remaining text starts with capital letter
-    const firstChar = remainingText.charAt(0);
-    
-    if (firstChar === firstChar.toUpperCase() && /[A-Z0-9]/.test(firstChar)) {
+    const label = unbracketedMatch[1].trim();
+    const wordCount = label.split(/\s+/).filter(Boolean).length;
+    if (label.length > 0 && wordCount <= 6 && !/[.!?]{2,}|[,;]/.test(label)) {
       return {
         isValid: true,
-        speaker: potentialSpeaker,
-        remainingText: remainingText
+        speaker: label,
+        remainingText: unbracketedMatch[2]
       };
     }
   }
-  
-  // No valid pattern found
+
   return { isValid: false, speaker: null, remainingText: text };
 }
 
@@ -481,88 +474,223 @@ function detectParagraphs(plainText) {
  *   ]
  */
 function alignWords(sourceWords, targetWords) {
-  const m = sourceWords.length;  // Number of words in machine transcript
-  const n = targetWords.length;  // Number of words in corrected transcript
-  
-  // ===== PHASE 1: BUILD DP TABLE =====
-  // Create a 2D table to store minimum edit distances
-  // dp[i][j] = minimum number of operations to align sourceWords[0..i-1] with targetWords[0..j-1]
-  const dp = Array(m + 1).fill(null).map(() => Array(n + 1).fill(0));
-  
-  // Initialize base cases:
-  // dp[i][0] = i: To align i source words with 0 target words, delete all i words
-  for (let i = 0; i <= m; i++) dp[i][0] = i;
-  
-  // dp[0][j] = j: To align 0 source words with j target words, insert all j words
-  for (let j = 0; j <= n; j++) dp[0][j] = j;
-  
-  // Fill the DP table using dynamic programming
-  // For each cell, compute the minimum cost of three possible operations
+  const m = sourceWords.length;
+  const n = targetWords.length;
+
+  // Full-table DP is exact but O(m*n): at 10M cells (Uint32Array, ~40MB) we
+  // switch to banded alignment. The band bound matters because this runs in
+  // the EDITOR'S tab, alongside the media and the transcript DOM — ts-aligner
+  // (whose v0.2.2 this rework is informed by) uses a 4000-word band sized for
+  // a dedicated bulk tool, which costs ~2GB; a corrected transcript tracks
+  // its machine original closely by nature, so a 1000-word cumulative-drift
+  // band is generous here at a tenth of the memory.
+  const FULL_TABLE_CELL_LIMIT = 10000000;
+  const BANDWIDTH = 1000;
+
+  if (m * n <= FULL_TABLE_CELL_LIMIT) {
+    return alignWordsStandard(sourceWords, targetWords);
+  }
+  return alignWordsBanded(sourceWords, targetWords, BANDWIDTH);
+}
+
+/**
+ * Exact DP over the full table, as a flat Uint32Array (4 bytes/cell, no
+ * per-row array objects).
+ *
+ * Words are compared NORMALIZED (#425): "recording." must match "recording",
+ * or every punctuation difference counts as a substitution and drags the
+ * whole alignment sideways. Normalization is precomputed once per word — in
+ * the inner loop it would run m*n times.
+ *
+ * Substitution costs 2 (a delete plus an insert) while insert and delete cost
+ * 1 each, so the algorithm prefers to keep exact matches anchored rather than
+ * substitute through one and hand its timing to the wrong word.
+ */
+function alignWordsStandard(sourceWords, targetWords) {
+  const m = sourceWords.length;
+  const n = targetWords.length;
+  const src = sourceWords.map(normalizeWord);
+  const tgt = targetWords.map(normalizeWord);
+
+  const width = n + 1;
+  const dp = new Uint32Array((m + 1) * width);
+  for (let i = 0; i <= m; i++) dp[i * width] = i;
+  for (let j = 0; j <= n; j++) dp[j] = j;
+
   for (let i = 1; i <= m; i++) {
+    const row = i * width;
+    const prev = row - width;
     for (let j = 1; j <= n; j++) {
-      // Check if current words match (case-insensitive comparison)
-      if (sourceWords[i-1].toLowerCase() === targetWords[j-1].toLowerCase()) {
-        // Words match! No operation needed, inherit cost from diagonal
-        dp[i][j] = dp[i-1][j-1];
+      if (src[i - 1] === tgt[j - 1]) {
+        dp[row + j] = dp[prev + j - 1];
       } else {
-        // Words don't match. Choose the minimum cost operation:
-        dp[i][j] = Math.min(
-          dp[i-1][j-1] + 1,  // SUBSTITUTE: Replace source word with target word (cost: 1)
-          dp[i-1][j] + 1,    // DELETE: Remove source word (cost: 1)
-          dp[i][j-1] + 1     // INSERT: Add target word (cost: 1)
+        dp[row + j] = Math.min(
+          dp[prev + j - 1] + 2,  // substitute
+          dp[prev + j] + 1,      // delete
+          dp[row + j - 1] + 1    // insert
         );
       }
     }
   }
-  
-  // ===== PHASE 2: BACKTRACK TO FIND ALIGNMENT =====
-  // Now that we have the minimum edit distance, trace back through the table
-  // to find which specific operations were used
+
+  // Backtrack from the corner, reading the same costs the fill used.
   const alignment = [];
-  let i = m;  // Start at bottom-right corner (end of source words)
-  let j = n;  // Start at bottom-right corner (end of target words)
-  
-  // Work backwards from dp[m][n] to dp[0][0]
+  let i = m, j = n;
   while (i > 0 || j > 0) {
     if (i === 0) {
-      // No more source words left, all remaining target words are insertions
-      alignment.push({ type: 'insert', sourceIdx: null, targetIdx: j-1 });
+      alignment.push({ type: 'insert', sourceIdx: null, targetIdx: j - 1 });
       j--;
     } else if (j === 0) {
-      // No more target words left, all remaining source words are deletions
-      alignment.push({ type: 'delete', sourceIdx: i-1, targetIdx: null });
+      alignment.push({ type: 'delete', sourceIdx: i - 1, targetIdx: null });
       i--;
+    } else if (src[i - 1] === tgt[j - 1]) {
+      alignment.push({ type: 'match', sourceIdx: i - 1, targetIdx: j - 1 });
+      i--; j--;
     } else {
-      // Both sequences still have words, determine which operation was used
-      const current = dp[i][j];
-      
-      // Check if words match (this gives us the operation for free)
-      if (sourceWords[i-1].toLowerCase() === targetWords[j-1].toLowerCase()) {
-        alignment.push({ type: 'match', sourceIdx: i-1, targetIdx: j-1 });
+      const here = dp[i * width + j];
+      if (here === dp[(i - 1) * width + j - 1] + 2) {
+        alignment.push({ type: 'substitute', sourceIdx: i - 1, targetIdx: j - 1 });
+        i--; j--;
+      } else if (here === dp[(i - 1) * width + j] + 1) {
+        alignment.push({ type: 'delete', sourceIdx: i - 1, targetIdx: null });
         i--;
-        j--;
-      } 
-      // Check if the current cost came from a substitution (diagonal)
-      else if (current === dp[i-1][j-1] + 1) {
-        alignment.push({ type: 'substitute', sourceIdx: i-1, targetIdx: j-1 });
-        i--;
-        j--;
-      } 
-      // Check if the current cost came from a deletion (move up)
-      else if (current === dp[i-1][j] + 1) {
-        alignment.push({ type: 'delete', sourceIdx: i-1, targetIdx: null });
-        i--;
-      } 
-      // Otherwise, it must have come from an insertion (move left)
-      else {
-        alignment.push({ type: 'insert', sourceIdx: null, targetIdx: j-1 });
+      } else {
+        alignment.push({ type: 'insert', sourceIdx: null, targetIdx: j - 1 });
         j--;
       }
     }
   }
-  
-  // Reverse the alignment array because we built it backwards
   alignment.reverse();
+  return alignment;
+}
+
+/**
+ * Banded alignment for inputs too large for the full table: only cells within
+ * `bandwidth` of the (scaled) diagonal are computed, on the observation that a
+ * corrected transcript never wanders far from its machine original. Memory is
+ * O(m * bandwidth) at 5 bytes per cell (Uint32 cost + Uint8 backtrack).
+ * If the corner proves unreachable — drift beyond the band — the greedy
+ * fallback still produces a usable alignment rather than nothing.
+ */
+function alignWordsBanded(sourceWords, targetWords, bandwidth) {
+  const m = sourceWords.length;
+  const n = targetWords.length;
+  if (m === 0) return targetWords.map((_, j) => ({ type: 'insert', sourceIdx: null, targetIdx: j }));
+  if (n === 0) return sourceWords.map((_, i) => ({ type: 'delete', sourceIdx: i, targetIdx: null }));
+
+  const src = sourceWords.map(normalizeWord);
+  const tgt = targetWords.map(normalizeWord);
+
+  // the band must at least cover the sequences' length difference
+  const effectiveBandwidth = Math.max(bandwidth, Math.abs(m - n) + 50);
+  const bandWidth = 2 * effectiveBandwidth + 1;
+
+  const INF = 0xFFFFFFFF;
+  const NONE = 0, MATCH = 1, SUB = 2, DEL = 3, INS = 4;
+  const costs = new Uint32Array((m + 1) * bandWidth).fill(INF);
+  const backs = new Uint8Array((m + 1) * bandWidth);
+
+  const diagOf = (i) => Math.round(i * n / m);
+  const idxOf = (i, j) => {
+    const offset = j - diagOf(i) + effectiveBandwidth;
+    if (offset < 0 || offset >= bandWidth) return -1;
+    return i * bandWidth + offset;
+  };
+  const costAt = (i, j) => {
+    if (i < 0 || j < 0 || j > n) return INF;
+    const k = idxOf(i, j);
+    return k < 0 ? INF : costs[k];
+  };
+
+  for (let j = 0; j <= n; j++) {
+    const k = idxOf(0, j);
+    if (k >= 0) { costs[k] = j; backs[k] = j > 0 ? INS : NONE; }
+  }
+
+  for (let i = 1; i <= m; i++) {
+    const diag = diagOf(i);
+    const minJ = Math.max(0, diag - effectiveBandwidth);
+    const maxJ = Math.min(n, diag + effectiveBandwidth);
+    for (let j = minJ; j <= maxJ; j++) {
+      const k = idxOf(i, j);
+      if (k < 0) continue;
+      if (j === 0) {
+        costs[k] = i;
+        backs[k] = DEL;
+        continue;
+      }
+      const isMatch = src[i - 1] === tgt[j - 1];
+      let best = costAt(i - 1, j - 1) + (isMatch ? 0 : 2);
+      let back = isMatch ? MATCH : SUB;
+      const del = costAt(i - 1, j) + 1;
+      if (del < best) { best = del; back = DEL; }
+      const ins = costAt(i, j - 1) + 1;
+      if (ins < best) { best = ins; back = INS; }
+      costs[k] = best;
+      backs[k] = back;
+    }
+  }
+
+  const endIdx = idxOf(m, n);
+  if (endIdx < 0 || costs[endIdx] === INF) {
+    console.warn('word-alignment: drift exceeded the band — using greedy fallback');
+    return alignWordsGreedy(src, tgt);
+  }
+
+  const alignment = [];
+  let i = m, j = n;
+  while (i > 0 || j > 0) {
+    if (i === 0) { alignment.push({ type: 'insert', sourceIdx: null, targetIdx: j - 1 }); j--; continue; }
+    if (j === 0) { alignment.push({ type: 'delete', sourceIdx: i - 1, targetIdx: null }); i--; continue; }
+    switch (backs[idxOf(i, j)]) {
+      case MATCH: alignment.push({ type: 'match', sourceIdx: i - 1, targetIdx: j - 1 }); i--; j--; break;
+      case SUB: alignment.push({ type: 'substitute', sourceIdx: i - 1, targetIdx: j - 1 }); i--; j--; break;
+      case DEL: alignment.push({ type: 'delete', sourceIdx: i - 1, targetIdx: null }); i--; break;
+      case INS: alignment.push({ type: 'insert', sourceIdx: null, targetIdx: j - 1 }); j--; break;
+      default: i--; j--; // unreachable given a valid fill; never loop forever
+    }
+  }
+  alignment.reverse();
+  return alignment;
+}
+
+/**
+ * Greedy fallback when even the band cannot reach the corner: walk both
+ * sequences, looking ahead a window for the next agreement. Not optimal, but
+ * always terminates with a usable alignment. Receives NORMALIZED words.
+ */
+function alignWordsGreedy(src, tgt) {
+  const alignment = [];
+  const m = src.length;
+  const n = tgt.length;
+  const LOOKAHEAD = 50;
+
+  let i = 0, j = 0;
+  while (i < m && j < n) {
+    if (src[i] === tgt[j]) {
+      alignment.push({ type: 'match', sourceIdx: i, targetIdx: j });
+      i++; j++;
+      continue;
+    }
+    let foundInTarget = -1;
+    for (let k = j + 1; k < Math.min(j + LOOKAHEAD, n); k++) {
+      if (src[i] === tgt[k]) { foundInTarget = k; break; }
+    }
+    let foundInSource = -1;
+    for (let k = i + 1; k < Math.min(i + LOOKAHEAD, m); k++) {
+      if (src[k] === tgt[j]) { foundInSource = k; break; }
+    }
+    if (foundInTarget >= 0 && (foundInSource < 0 || foundInTarget - j <= foundInSource - i)) {
+      while (j < foundInTarget) { alignment.push({ type: 'insert', sourceIdx: null, targetIdx: j }); j++; }
+    } else if (foundInSource >= 0) {
+      while (i < foundInSource) { alignment.push({ type: 'delete', sourceIdx: i, targetIdx: null }); i++; }
+    } else {
+      alignment.push({ type: 'substitute', sourceIdx: i, targetIdx: j });
+      i++; j++;
+    }
+  }
+  while (i < m) { alignment.push({ type: 'delete', sourceIdx: i, targetIdx: null }); i++; }
+  while (j < n) { alignment.push({ type: 'insert', sourceIdx: null, targetIdx: j }); j++; }
   return alignment;
 }
 
@@ -605,71 +733,92 @@ function alignWords(sourceWords, targetWords) {
 function generateAlignedJSON(alignment, sourceWords, targetWords, timings, plainText) {
   // ===== PHASE 1: BUILD OUTPUT ARRAY WITH WORDS AND TIMINGS =====
   
-  // Array to store final words with their timing information
-  // Each element: {word, start, end, targetIdx}
+  // Words that matched (or substituted) take their machine timing directly
+  // and act as ANCHORS. Inserted words are collected into runs and their
+  // timing DISTRIBUTED across the gap between the surrounding anchors (#425)
+  // — the old behaviour gave every inserted word the next anchor's timing
+  // verbatim, so a run of insertions collapsed onto identical timestamps:
+  // zero-duration words, overlapping cues, and highlighting that jumped.
+  //
+  // The distribution is weighted by syllable estimate — contiguous vowel
+  // groups, the same heuristic the editor's word-split feature uses — so a
+  // long word takes a proportionally longer span of the silence.
   const outputWords = [];
-  
-  // Track the most recent timing for interpolation purposes
+
+  const syllableWeight = (word) => {
+    const groups = String(word).toLowerCase().match(/[aeiouyàáâäåèéêëìíîïòóôöùúûüæø]+/g);
+    return groups && groups.length > 0 ? groups.length : 1;
+  };
+
+  // Nominal per-word duration for runs with an open end (before the first
+  // anchor, after the last, or a transcript with no anchors at all).
+  const NOMINAL_WORD_SECONDS = 0.25;
+
+  const distributeRun = (words, startTime, endTime) => {
+    const span = Math.max(0, endTime - startTime);
+    const weights = words.map((w) => syllableWeight(w.word));
+    const totalWeight = weights.reduce((a, b) => a + b, 0);
+    let cursor = startTime;
+    words.forEach((w, k) => {
+      // the last word absorbs the rounding remainder, keeping the run flush
+      const share = k === words.length - 1
+        ? (startTime + span) - cursor
+        : span * (weights[k] / totalWeight);
+      w.start = cursor;
+      w.end = cursor + share;
+      cursor = w.end;
+    });
+  };
+
+  let pendingRun = [];
   let lastTiming = null;
-  
-  // Process each alignment operation to build the output
-  alignment.forEach((align, idx) => {
-    
-    // CASE 1: MATCH or SUBSTITUTE
-    // The target word corresponds to a source word, so we can use its timing directly
+
+  const flushRun = (nextTiming) => {
+    if (pendingRun.length === 0) return;
+    if (lastTiming !== null && nextTiming !== null) {
+      // between two anchors: share out the silence between them
+      distributeRun(pendingRun, lastTiming.end, Math.max(lastTiming.end, nextTiming.start));
+    } else if (nextTiming !== null) {
+      // before the first anchor: back-fill toward it, clamped at zero
+      const total = Math.min(nextTiming.start, pendingRun.length * NOMINAL_WORD_SECONDS);
+      distributeRun(pendingRun, Math.max(0, nextTiming.start - total), nextTiming.start);
+    } else if (lastTiming !== null) {
+      // after the last anchor: run on at nominal pace
+      distributeRun(pendingRun, lastTiming.end,
+        lastTiming.end + pendingRun.length * NOMINAL_WORD_SECONDS);
+    } else {
+      // no anchors anywhere: a transcript with no matches at all
+      distributeRun(pendingRun, 0, pendingRun.length * NOMINAL_WORD_SECONDS);
+    }
+    pendingRun = [];
+  };
+
+  alignment.forEach((align) => {
     if (align.type === 'match' || align.type === 'substitute') {
       const timing = timings[align.sourceIdx];
+      flushRun(timing);
       outputWords.push({
-        word: targetWords[align.targetIdx],   // Use corrected word text
-        start: timing.start,                  // Use machine timing (seconds)
-        end: timing.end,                      // Use machine timing (seconds)
-        targetIdx: align.targetIdx            // Track position in target array
+        word: targetWords[align.targetIdx],
+        start: timing.start,
+        end: timing.end,
+        targetIdx: align.targetIdx
       });
-      lastTiming = timing;  // Remember this for interpolating inserted words
-    } 
-    
-    // CASE 2: INSERT
-    // This word was added in the corrected transcript, so it has no direct timing.
-    // We need to estimate/interpolate the timing from nearby words.
-    else if (align.type === 'insert') {
-      // Look ahead in the alignment to find the next word with timing
-      let nextTiming = null;
-      for (let i = idx + 1; i < alignment.length; i++) {
-        if (alignment[i].type === 'match' || alignment[i].type === 'substitute') {
-          nextTiming = timings[alignment[i].sourceIdx];
-          break;  // Found it, stop searching
-        }
-      }
-      
-      // Use the next timing if found, otherwise fall back to the last timing
-      // This means inserted words will "borrow" timing from adjacent words
-      const timing = nextTiming || lastTiming;
-      
-      if (timing) {
-        outputWords.push({
-          word: targetWords[align.targetIdx],
-          start: timing.start,    // Borrow start time from nearby word
-          end: timing.end,        // Borrow end time from nearby word
-          targetIdx: align.targetIdx
-        });
-      } else {
-        // FALLBACK: If no timing available at all (rare edge case)
-        // Use dummy timing values so the output is still valid
-        outputWords.push({
-          word: targetWords[align.targetIdx],
-          start: 0,     // Start at beginning
-          end: 0.1,     // 100ms duration
-          targetIdx: align.targetIdx
-        });
-      }
+      lastTiming = timing;
+    } else if (align.type === 'insert') {
+      const placeholder = {
+        word: targetWords[align.targetIdx],
+        start: 0,
+        end: 0,
+        targetIdx: align.targetIdx
+      };
+      outputWords.push(placeholder); // position holds; times filled at flush
+      pendingRun.push(placeholder);
     }
-    
-    // CASE 3: DELETE
-    // Word existed in machine transcript but not in corrected transcript
-    // We simply skip it - it won't appear in the output at all
-    // (No code needed here, just explanation)
+    // 'delete': the machine word has no counterpart in the corrected text —
+    // it simply does not appear in the output
   });
-  
+  flushRun(null);
+
   // ===== PHASE 2: DETECT PARAGRAPH STRUCTURE =====
   // Analyze the plain text to find paragraph boundaries and speaker labels
   const paragraphMap = detectParagraphs(plainText);
@@ -789,15 +938,6 @@ function alignTranscripts(machineTranscript, correctedText) {
     correctedText
   );
 
-  console.log("original timings");
-  console.log(sourceWords);
-  console.log("machine transcript");
-  console.log(machineTranscript)
-  console.log("timings");
-  console.log(timings);
-  console.log("aligned timings");
-  console.log(alignedJSON);
-  
   return alignedJSON;
 }
 
@@ -816,6 +956,9 @@ if (typeof module !== 'undefined' && module.exports) {
     extractWordsFromPlainText,
     detectParagraphs,
     alignWords,
+    alignWordsStandard,
+    alignWordsBanded,
+    alignWordsGreedy,
     generateAlignedJSON,
     // Export helpers
     stripPunctuation,


### PR DESCRIPTION
Alignment reworked, and your place kept when you switch projects.

- **The alignment algorithm is substantially better** (#425). Words are compared *normalised*, so "recording." matches "recording" rather than counting as a substitution and dragging the whole alignment sideways; an exact match is never substituted through and handed the wrong timing; and inserted words no longer collapse onto a neighbour's timestamp — a run of them is distributed across the silence between the surrounding anchored words, weighted by syllable estimate, monotonic and non-overlapping. Long transcripts are bounded by a banded alignment with a greedy fallback instead of an unbounded O(m×n) table. Speaker detection is language-agnostic: the old rules required a capital `[A-Z0-9]` after the label, which rejected every non-Latin transcript outright.

  Portions derived from [ts-aligner](https://github.com/theirstory/ts-aligner) (Apache-2.0, © TheirStory contributors), modified — the banded alignment and greedy fallback in particular; the file header carries the attribution.

- **Switching back to a project restores your place** (#587): the transcript's scroll position and the paused playhead. Previously the playhead reset to zero while the scroll offset *leaked from the project you left*. Session-only — a reload starts clean — and the caret is deliberately not restored, since restoring it restores focus and a focused transcript would capture your next keystroke.

Fixes #425. Fixes #587.

Suite: 100 unit + 256 e2e green (1 known Playwright-WebKit OPFS skip). Eleven of the unit tests are new, covering the alignment rework.
