### PR TITLE
Version 1.3.10

### DIFF
--- a/__TEST__/e2e/search-cramped.spec.mjs
+++ b/__TEST__/e2e/search-cramped.spec.mjs
@@ -1,0 +1,60 @@
+// #592: the search input bottoms out at 48px — its own padding plus the clear
+// button — and then stays there, a visible focusable stub with ~2px of room
+// for text. It happens in two bands, either side of the 948px layout change,
+// so what decides it is the room the navbar has, not the viewport width.
+import { test, expect } from '@playwright/test';
+
+const searchVisible = (page) => page.evaluate(() => {
+  const centre = document.querySelector('.navbar-center');
+  return getComputedStyle(centre).display !== 'none';
+});
+
+// room for text inside the box: its width less its own padding
+const textRoom = (page) => page.evaluate(() => {
+  const box = document.getElementById('search-box');
+  const cs = getComputedStyle(box);
+  return box.getBoundingClientRect().width
+    - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+});
+
+test('the search is gone in BOTH cramped bands, not just the reported one (#592)', async ({ page }) => {
+  for (const width of [1000, 960, 620, 600]) {
+    await page.setViewportSize({ width, height: 800 });
+    await page.waitForTimeout(200);
+    expect(await searchVisible(page), `search should be hidden at ${width}px`).toBe(false);
+  }
+});
+
+test('the search stays where it is usable (#592)', async ({ page }) => {
+  for (const width of [1400, 1200, 1120, 900, 800]) {
+    await page.setViewportSize({ width, height: 800 });
+    await page.waitForTimeout(200);
+    expect(await searchVisible(page), `search should be visible at ${width}px`).toBe(true);
+    // and visible means typable, not a stub
+    expect(await textRoom(page), `usable text room at ${width}px`).toBeGreaterThan(80);
+  }
+});
+
+test('an active search is cleared on the way out, leaving no orphan highlights (#592)', async ({ page }) => {
+  await page.setViewportSize({ width: 1400, height: 800 });
+  await page.waitForTimeout(200);
+  // pressSequentially, not fill: the vendored search runs off keyup
+  await page.locator('#search-box').pressSequentially('the', { delay: 40 });
+  await page.waitForTimeout(500);
+  expect(await page.locator('#hypertranscript mark.search-mark').count())
+    .toBeGreaterThan(0);
+
+  await page.setViewportSize({ width: 1000, height: 800 });
+  await page.waitForTimeout(400);
+
+  expect(await searchVisible(page)).toBe(false);
+  // the query went with it — no highlighted matches stranded with no control
+  expect(await page.locator('#hypertranscript mark.search-mark').count())
+    .toBe(0);
+  expect(await page.inputValue('#search-box')).toBe('');
+});

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -102,6 +102,14 @@ input[type="number"] {
   margin-right: 4px;
 }
 
+/* No room to type, so no search (#592). responsive.js measures what the
+   navbar has left after its two fixed sides and sets this; the box would
+   otherwise sit at its 48px floor with ~2px of text room, visible and
+   focusable and useless. The 580px rule below is the no-JS floor. */
+body.search-cramped .navbar-center {
+  display: none;
+}
+
 /* Fixed-width side panel so its grey background fills to the transcript edge,
    with an equal 16px gutter on both sides (matches left:400px on
    .transcript-holder). Items fill the 368px content width, so the video and the

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.3.9 (last changed in release 1.3.9) -->
+<!--  Hyperaudio Lite Editor - Version 1.3.10 (last changed in release 1.3.10) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.3.9">
+  <meta name="version" content="1.3.10">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.9">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.10">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>
@@ -1096,7 +1096,7 @@ If you are creating an open source application under a license compatible with t
   <!-- end of caption editor additions -->
 
   <!-- responsive small-screen UI toggles (#349) -->
-  <script src="js/responsive.js?v=1.3.7"></script>
+  <script src="js/responsive.js?v=1.3.10"></script>
 
   <!-- keyboard operability for modal label-buttons (#402) -->
   <script src="js/a11y.js?v=0.8.3"></script>

--- a/js/responsive.js
+++ b/js/responsive.js
@@ -1,7 +1,7 @@
 /**
  * responsive.js
  * (C) The Hyperaudio Project
- * @version 1.3.7 — last changed in release 1.3.7
+ * @version 1.3.10 — last changed in release 1.3.10
  * @license MIT
  *
  * Small-screen UI toggles for the responsive layout (#349):
@@ -10,7 +10,8 @@
  * sets body.video-collapsed — see toggleAudioOnly in editor-main.js, #375.)
  *
  * Layout itself is CSS (css/hyperaudio-lite-editor.css, @media max-width:948px);
- * this only flips classes on <body>. No editor logic is touched.
+ * this only flips classes on <body>. No editor logic is touched, beyond
+ * clearing a search the user can no longer see (#592).
  */
 
 (function () {
@@ -53,6 +54,50 @@
   }
   // webfonts and late-injected toolbar buttons can settle after first paint
   window.addEventListener('load', syncCardTop);
+
+  /* --- Hide the search when there is no room to type in it (#592) -----------
+   * The input bottoms out at 48px — its own padding plus the clear button —
+   * and then simply stays there: at 1000px wide it is a visible, focusable
+   * stub with about 2px of room for text. There are two such bands, either
+   * side of the 948px layout change, which is why a breakpoint per band would
+   * be guesswork. What decides it is the room the navbar actually has, and
+   * that is measurable.
+   *
+   * navbar-start and navbar-end are both flex: 0 0 auto, so they hold their
+   * width whether the search is shown or hidden — the measurement cannot
+   * chase its own result, which a min-width on the search itself would.
+   * Below MIN_SEARCH_ROOM the box drops under ~100px and stops being typable.
+   * The 580px CSS rule stays as the no-JS floor.
+   * ------------------------------------------------------------------------ */
+  const MIN_SEARCH_ROOM = 150;
+  const navbarEl = document.querySelector('.main-panel .navbar');
+  const navStart = document.querySelector('.navbar-start');
+  const navEnd = document.querySelector('.navbar-end');
+
+  const syncSearchRoom = () => {
+    if (navbarEl === null || navStart === null || navEnd === null) return;
+    const room = navbarEl.getBoundingClientRect().width
+      - navStart.getBoundingClientRect().width
+      - navEnd.getBoundingClientRect().width;
+    const cramped = room < MIN_SEARCH_ROOM;
+    if (cramped === body.classList.contains('search-cramped')) return;
+    body.classList.toggle('search-cramped', cramped);
+    // Going away with a query still live would strand highlighted matches in
+    // the transcript with nothing on screen to clear them, so the existing
+    // clear control is used rather than a second way to reset the search.
+    if (cramped) {
+      const clear = document.getElementById('search-clear');
+      const box = document.getElementById('search-box');
+      if (clear !== null && box !== null && box.value !== '') clear.click();
+    }
+  };
+
+  syncSearchRoom();
+  window.addEventListener('resize', syncSearchRoom);
+  window.addEventListener('load', syncSearchRoom);
+  if (navbarEl !== null && typeof ResizeObserver === 'function') {
+    new ResizeObserver(syncSearchRoom).observe(navbarEl);
+  }
 
   // --- Recents drawer --------------------------------------------------------
   // Keep #sidebar-toggle's aria-pressed tracking the drawer while in the


### PR DESCRIPTION
One fix.

**#592 — the search box gets out of the way instead of shrinking to a stub.** The input bottoms out at 48px (its own padding plus the clear button) and then stays there, leaving about 2px of room for text at 1000px wide: visible, focusable, unusable.

It happens in two bands either side of the 948px layout change — 949–1050px, and 581–650px, the latter just above the breakpoint where `.navbar-center` was already hidden outright. A breakpoint aimed at the reported band would have left the other one untouched, and collapsing the side panel changes the navbar's room anyway, so the same viewport width can be roomy or cramped depending on state.

`responsive.js` now measures `navbar − navbar-start − navbar-end` and hides the search below 150px of room. Both sides are `flex: 0 0 auto`, so the measurement holds steady whether the search is shown or hidden and cannot chase its own result. The 580px CSS rule stays as the no-JS floor. An active query is cleared on the way out, so highlighted matches can't strand in the transcript with no control to clear them.

Fixes #592

Gate: 101 unit, 258 e2e passed, 1 skipped (known WebKit OPFS skip).
