### PR TITLE
Version 1.3.11

### DIFF
--- a/__TEST__/e2e/search-cramped.spec.mjs
+++ b/__TEST__/e2e/search-cramped.spec.mjs
@@ -30,6 +30,18 @@ test('the search is gone in BOTH cramped bands, not just the reported one (#592)
   }
 });
 
+test('the cut-off sits where it was chosen, in both bands (#592)', async ({ page }) => {
+  // 1070px is the deliberate boundary: an 83px box with ~37px for text. One
+  // notch narrower and it goes, rather than creeping toward the 48px floor.
+  for (const [width, shown] of [[1070, true], [1060, false], [670, true], [660, false]]) {
+    await page.setViewportSize({ width, height: 800 });
+    // poll rather than sleep: the navbar's width animates, so a fixed wait
+    // reads a size that is still on its way somewhere
+    await expect.poll(() => searchVisible(page), { message: `search at ${width}px` })
+      .toBe(shown);
+  }
+});
+
 test('the search stays where it is usable (#592)', async ({ page }) => {
   for (const width of [1400, 1200, 1120, 900, 800]) {
     await page.setViewportSize({ width, height: 800 });

--- a/__TEST__/e2e/search-cramped.spec.mjs
+++ b/__TEST__/e2e/search-cramped.spec.mjs
@@ -58,3 +58,21 @@ test('an active search is cleared on the way out, leaving no orphan highlights (
     .toBe(0);
   expect(await page.inputValue('#search-box')).toBe('');
 });
+
+test('hiding the search leaves Save/Export/New still right-aligned (#594)', async ({ page }) => {
+  // .navbar-center was the only flex: 1 1 auto item, so hiding it took the
+  // growing with it and left both fixed sides bunched at the left — the
+  // right-hand buttons trailing a gap where the search used to be.
+  for (const width of [1400, 1050, 1000, 960, 900, 620, 600]) {
+    await page.setViewportSize({ width, height: 800 });
+    await page.waitForTimeout(250);
+    const gap = await page.evaluate(() => {
+      const nav = document.querySelector('.main-panel .navbar');
+      const end = document.querySelector('.navbar-end');
+      return nav.getBoundingClientRect().right - end.getBoundingClientRect().right;
+    });
+    // the navbar's own right padding, and nothing more, whether or not the
+    // search is showing at this width
+    expect(gap, `right-hand gap at ${width}px`).toBeLessThan(12);
+  }
+});

--- a/css/hyperaudio-lite-editor.css
+++ b/css/hyperaudio-lite-editor.css
@@ -109,6 +109,13 @@ input[type="number"] {
 body.search-cramped .navbar-center {
   display: none;
 }
+/* ...and the right-hand group still has to sit on the right. .navbar-center
+   was the only flex: 1 1 auto item, so removing it left both fixed sides
+   bunched at the left with the free space trailing behind Save/Export/New.
+   The auto margin takes over the growing the hidden item used to do. */
+body.search-cramped .navbar-end {
+  margin-left: auto;
+}
 
 /* Fixed-width side panel so its grey background fills to the transcript edge,
    with an equal 16px gutter on both sides (matches left:400px on

--- a/index.html
+++ b/index.html
@@ -1096,7 +1096,7 @@ If you are creating an open source application under a license compatible with t
   <!-- end of caption editor additions -->
 
   <!-- responsive small-screen UI toggles (#349) -->
-  <script src="js/responsive.js?v=1.3.10"></script>
+  <script src="js/responsive.js?v=1.3.11"></script>
 
   <!-- keyboard operability for modal label-buttons (#402) -->
   <script src="js/a11y.js?v=0.8.3"></script>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.3.10 (last changed in release 1.3.10) -->
+<!--  Hyperaudio Lite Editor - Version 1.3.11 (last changed in release 1.3.11) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.3.10">
+  <meta name="version" content="1.3.11">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ If you are creating an open source application under a license compatible with t
        }
      } catch (e) { /* private mode: no hint, no hide */ }
    </script>
-   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.10">
+   <link rel="stylesheet" href="css/hyperaudio-lite-editor.css?v=1.3.11">
    <!-- DaisyUI / Tailwind - must be loaded last -->
    <link rel="stylesheet" href="css/tailwind-min.css">
 </head>

--- a/js/responsive.js
+++ b/js/responsive.js
@@ -69,7 +69,12 @@
    * Below MIN_SEARCH_ROOM the box drops under ~100px and stops being typable.
    * The 580px CSS rule stays as the no-JS floor.
    * ------------------------------------------------------------------------ */
-  const MIN_SEARCH_ROOM = 150;
+  // 128px of room is the chosen cut-off: the search stays down to ~1070px
+  // wide, where the box is 83px with about 37px for text — tight, but you can
+  // type and read a short term in it. Below that it goes rather than shrink
+  // toward the 48px floor, where it was focusable and useless. In the band
+  // under the 948px layout change the same number lands at ~670px.
+  const MIN_SEARCH_ROOM = 128;
   const navbarEl = document.querySelector('.main-panel .navbar');
   const navStart = document.querySelector('.navbar-start');
   const navEnd = document.querySelector('.navbar-end');

--- a/js/responsive.js
+++ b/js/responsive.js
@@ -1,7 +1,7 @@
 /**
  * responsive.js
  * (C) The Hyperaudio Project
- * @version 1.3.10 — last changed in release 1.3.10
+ * @version 1.3.11 — last changed in release 1.3.11
  * @license MIT
  *
  * Small-screen UI toggles for the responsive layout (#349):


### PR DESCRIPTION
Two changes, both following on from 1.3.10's search fix.

**#594 — Save/Export/New keep their right alignment when the search is hidden.** A regression from #592: `.navbar-center` was the only `flex: 1 1 auto` item in the navbar, so hiding it removed the growing and left both fixed sides bunched at the left — a 109px gap at 1050px against the 8px of padding that is all there should be. An auto margin on `.navbar-end` takes over the job the hidden item was doing.

**#592 tuning — the search now stays down to ~1070px.** The original 150px cut-off took it away below about 1090px while the box was still 133px wide and perfectly usable. 128px of navbar room puts the boundary at ~1070px, where the box is 83px with about 37px for text; below that it still goes rather than shrink toward the 48px floor. The same number lands the lower band at ~670px, so the two stay proportionate. The boundary is pinned by a test now, so it cannot drift silently.

Fixes #594

Gate: 101 unit, 260 e2e passed, 1 skipped (known WebKit OPFS skip).
