### PR TITLE
Version 1.3.12

### DIFF
--- a/__TEST__/e2e/first-frame-posters.spec.mjs
+++ b/__TEST__/e2e/first-frame-posters.spec.mjs
@@ -1,0 +1,63 @@
+// #575 is a WebKit-only bug, invisible to the rest of the suite: removing the
+// player's poster (and epsilon-seeking) moved the element into a display mode
+// WebKit never leaves, so every project opened after a video one painted
+// NOTHING — while the DOM said all was well, poster attribute present and
+// resolving. Nothing observable from JS distinguishes the two states, so this
+// screenshots the element and asks whether any picture is there.
+//
+// Launches WebKit itself: the suite's default project is Chromium, where this
+// bug does not reproduce at all.
+import { test, expect, webkit } from '@playwright/test';
+import { pngLuma } from './png-luma.mjs';
+
+const FIXTURE = 'http://localhost:4173/__TEST__/e2e/fixtures/first-frame-posters.html';
+
+test('WebKit: a project opened after a video still paints its poster (#575)', async () => {
+  let browser;
+  try {
+    browser = await webkit.launch();
+  } catch (e) {
+    test.skip(true, 'WebKit build not installed: ' + e.message);
+    return;
+  }
+  try {
+    const page = await (await browser.newContext()).newPage();
+    await page.goto(FIXTURE);
+    await page.evaluate(() => window.ready); // the fixture drives both elements
+
+    const alone = pngLuma(await page.locator('#first').screenshot());
+    const afterVideo = pngLuma(await page.locator('#hyperplayer').screenshot());
+
+    // the control: audio on its own has always painted its poster
+    expect(alone.distinctLuma).toBeGreaterThan(20);
+
+    // the bug: one distinct luminance value across the whole box — the
+    // element painting nothing, the page background showing through
+    expect(
+      afterVideo.distinctLuma,
+      'audio after a video painted a uniform box: the WebKit display-mode trap',
+    ).toBeGreaterThan(20);
+
+    // and both elements agree, as their identical DOM state says they should
+    expect(Math.abs(afterVideo.distinctLuma - alone.distinctLuma)).toBeLessThan(60);
+  } finally {
+    await browser.close();
+  }
+});
+
+test('the poster is never removed, in any engine (#575)', async ({ page }) => {
+  // The mechanism behind the WebKit symptom, guarded everywhere: once the
+  // element has been posterless it cannot be recovered, so the fix is that it
+  // never is.
+  await page.goto(FIXTURE);
+  await page.evaluate(() => {
+    window.__posterGone = false;
+    const el = document.getElementById('hyperplayer');
+    new MutationObserver(() => {
+      if (el.getAttribute('poster') === null) window.__posterGone = true;
+    }).observe(el, { attributes: true, attributeFilter: ['poster'] });
+  });
+  await page.evaluate(() => window.ready);
+  expect(await page.evaluate(() => window.__posterGone)).toBe(false);
+  expect(await page.getAttribute('#hyperplayer', 'poster')).not.toBe(null);
+});

--- a/__TEST__/e2e/fixtures/first-frame-posters.html
+++ b/__TEST__/e2e/fixtures/first-frame-posters.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<meta charset="utf-8">
+<!-- Fixture for #575, the shape the bug report used: the real module driving
+     two elements, one that only ever plays audio and one that plays a video
+     first. Both end in identical DOM state; before the fix only the first
+     painted anything in WebKit. Deliberately standalone — no OPFS, which
+     Playwright's WebKit does not provide, and none of the app around it. -->
+<style>
+  body { background: #d9d9d9; margin: 0; font: 12px sans-serif; }
+  video { width: 320px; display: block; background: transparent; }
+  .cell { display: inline-block; margin: 8px; }
+</style>
+<div class="cell"><b>A: audio alone</b><video id="hyperplayer" playsinline muted poster="../../../images/poster.png"></video></div>
+<div class="cell"><b>B: video, then the same audio</b><video id="second" playsinline muted poster="../../../images/poster.png"></video></div>
+<script src="../../../js/media-first-frame.js"></script>
+<script>
+  document.getElementById('hyperplayer').id = 'first';
+  document.getElementById('second').id = 'hyperplayer';
+</script>
+<script src="../../../js/media-first-frame.js"></script>
+<script>
+window.ready = (async () => {
+  const mkVideo = () => new Promise((resolve) => {
+    const c = document.createElement('canvas'); c.width = 320; c.height = 180;
+    const x = c.getContext('2d');
+    const rec = new MediaRecorder(c.captureStream(10), { mimeType: 'video/mp4' });
+    const ch = []; rec.ondataavailable = e => ch.push(e.data);
+    rec.onstop = () => resolve(URL.createObjectURL(new Blob(ch, { type: 'video/mp4' })));
+    rec.start();
+    let f = 0;
+    const t = setInterval(() => { x.fillStyle = f % 2 ? '#c33' : '#3c3'; x.fillRect(0,0,320,180);
+      if (++f >= 10) { clearInterval(t); rec.stop(); } }, 60);
+  });
+  const mkAudio = () => {
+    const sr = 8000, n = sr, buf = new ArrayBuffer(44 + n * 2), dv = new DataView(buf);
+    const w = (o, s) => { for (let i = 0; i < s.length; i++) dv.setUint8(o + i, s.charCodeAt(i)); };
+    w(0,'RIFF'); dv.setUint32(4, 36 + n*2, true); w(8,'WAVEfmt ');
+    dv.setUint32(16,16,true); dv.setUint16(20,1,true); dv.setUint16(22,1,true);
+    dv.setUint32(24,sr,true); dv.setUint32(28,sr*2,true); dv.setUint16(32,2,true);
+    dv.setUint16(34,16,true); w(36,'data'); dv.setUint32(40,n*2,true);
+    for (let i = 0; i < n; i++) dv.setInt16(44 + i*2, Math.sin(i/20)*3000, true);
+    return URL.createObjectURL(new Blob([buf], { type: 'audio/wav' }));
+  };
+  const wait = (ms) => new Promise(r => setTimeout(r, ms));
+  const videoUrl = await mkVideo();
+  const audioUrl = mkAudio();
+  const a = document.getElementById('first');
+  const b = document.getElementById('hyperplayer');
+
+  a.src = audioUrl;                    // A: only ever audio
+  b.src = videoUrl;                    // B: a video first...
+  await wait(2500);
+  b.src = audioUrl;                    // ...then the same audio
+  await wait(2500);
+  return true;
+})();
+</script>

--- a/__TEST__/e2e/media-first-frame.spec.mjs
+++ b/__TEST__/e2e/media-first-frame.spec.mjs
@@ -1,11 +1,15 @@
 import { test, expect } from '@playwright/test';
 import { ladderWav } from './helpers.mjs';
 
-// #556 — first-frame display for video media. Video drops the generic demo
-// poster and takes an epsilon seek so the real first frame paints; audio
-// keeps the poster; the aspect-ratio pin follows the medium. The video
-// fixture is synthesized in-page (canvas.captureStream + MediaRecorder), so
-// no binary fixture is checked in.
+// #556 — first-frame display for video media, as amended by #575. The
+// original shape (drop the poster, epsilon-seek so the decoder paints frame
+// one) turned out to strand WebKit in a display mode it never leaves, so the
+// poster is now never removed and the picture comes from the project's stored
+// capture instead. What survives from #556 is the intent: a video project
+// shows its own first frame rather than the demo artwork, audio keeps the
+// artwork, and the aspect-ratio pin follows the medium. The video fixture is
+// synthesized in-page (canvas.captureStream + MediaRecorder), so no binary
+// fixture is checked in.
 const makeWebm = () => new Promise((resolve) => {
   const canvas = document.createElement('canvas');
   canvas.width = 320; canvas.height = 240;
@@ -24,7 +28,7 @@ const makeWebm = () => new Promise((resolve) => {
   }, 100);
 });
 
-test('video media drops the poster, paints frame one, and pins its aspect (#556)', async ({ page }) => {
+test('video media pins its aspect and keeps a poster throughout (#556/#575)', async ({ page }) => {
   await page.goto('/index.html');
   await page.waitForSelector('#hypertranscript [data-m]');
   // the demo is audio: the generic poster must be present at boot
@@ -34,26 +38,29 @@ test('video media drops the poster, paints frame one, and pins its aspect (#556)
     document.getElementById('hyperplayer').src = url;
   })`);
   const player = page.locator('#hyperplayer');
-  await expect(player).not.toHaveAttribute('poster', /.*/, { timeout: 10000 }); // poster dropped
+  await expect(player).toHaveAttribute('style', /aspect-ratio/, { timeout: 10000 });
   const state = await page.evaluate(() => {
     const p = document.getElementById('hyperplayer');
-    return { aspect: p.style.aspectRatio, time: p.currentTime, paused: p.paused };
+    return { aspect: p.style.aspectRatio, poster: p.getAttribute('poster'), paused: p.paused };
   });
   expect(state.aspect).toBe('320 / 240');
-  expect(state.time).toBeGreaterThan(0);   // the epsilon nudge decoded frame one
-  expect(state.time).toBeLessThan(0.1);    // ...and stayed at the start
+  // #575: never posterless, and never seeked. Loose media like this has no
+  // project behind it and so no stored capture — what matters is that the
+  // element keeps SOMETHING, because a video element that has gone bare
+  // cannot be given a poster again in WebKit.
+  expect(state.poster).not.toBe(null);
   expect(state.paused).toBe(true);
 });
 
 test('audio media keeps the poster and clears the aspect pin (#556)', async ({ page }, testInfo) => {
   await page.goto('/index.html');
   await page.waitForSelector('#hypertranscript [data-m]');
-  // video first, so the poster is gone and the pin is set...
+  // video first, so the pin is set (the poster stays, per #575)...
   await page.evaluate(`(${makeWebm.toString()})().then((url) => {
     document.getElementById('hyperplayer').src = url;
   })`);
   const player = page.locator('#hyperplayer');
-  await expect(player).not.toHaveAttribute('poster', /.*/, { timeout: 10000 });
+  await expect(player).toHaveAttribute('style', /aspect-ratio/, { timeout: 10000 });
 
   // ...then audio: the generic poster returns and the pin releases
   const wavPath = testInfo.outputPath('tone.wav');
@@ -64,6 +71,13 @@ test('audio media keeps the poster and clears the aspect pin (#556)', async ({ p
     const url = URL.createObjectURL(new Blob([bytes], { type: 'audio/wav' }));
     document.getElementById('hyperplayer').src = url;
   }, buf.toString('base64'));
-  await expect(player).toHaveAttribute('poster', /poster/, { timeout: 10000 });
-  expect(await page.evaluate(() => document.getElementById('hyperplayer').style.aspectRatio)).toBe('');
+  // Wait on the PIN, not the poster: since #575 the poster is never removed,
+  // so /poster/ still matches the artwork left over from boot and would pass
+  // before the audio has loaded anything. The pin releasing is the signal
+  // that this medium has been recognised as audio.
+  await expect.poll(
+    () => page.evaluate(() => document.getElementById('hyperplayer').style.aspectRatio),
+    { timeout: 10000 },
+  ).toBe('');
+  await expect(player).toHaveAttribute('poster', /poster/);
 });

--- a/__TEST__/e2e/media-posters.spec.mjs
+++ b/__TEST__/e2e/media-posters.spec.mjs
@@ -99,3 +99,49 @@ test('the hover popout shows the stored poster, or the wave glyph without one (#
   await page.hover('#file-picker .recents-row .file-item');
   await expect(page.locator('#recents-popout img.recents-popout-poster')).toBeVisible({ timeout: 5000 });
 });
+
+// #575's other half, which the standalone fixture cannot show: in the app the
+// player must end up wearing THIS project's stored capture, not the frozen
+// frame of the one before it and not the intro artwork. Chromium, because the
+// app needs OPFS and Playwright's WebKit has none.
+test('the player wears the project\'s own capture after a switch (#575)', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+
+  const make = async (name) => {
+    await page.evaluate(async (name) => {
+      const blob = await window.__makeWebmForTest();
+      const file = new File([blob], name + '.webm', { type: 'video/webm' });
+      const dt = new DataTransfer(); dt.items.add(file);
+      const input = document.getElementById('file-input');
+      input.files = dt.files;
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      document.getElementById('hyperplayer').src = URL.createObjectURL(file);
+      document.dispatchEvent(new CustomEvent('hyperaudioInit'));
+      const lib = window.HyperaudioSave.library;
+      const deadline = Date.now() + 15000;
+      while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 100));
+        const id = lib.currentId();
+        if (id !== null && (await lib.list()).some((e) => e.id === id)) break;
+      }
+      await window.HyperaudioSave.saveProject();
+    }, name);
+    await page.waitForTimeout(1200);
+  };
+
+  await page.addScriptTag({ content: `window.__makeWebmForTest = ${makeWebmBlob.toString()};` });
+  await make('First');
+  await make('Second');
+  const ids = await page.evaluate(async () =>
+    (await window.HyperaudioSave.library.list()).map((e) => e.id));
+
+  await page.evaluate((id) => window.HyperaudioSave.library.open(id), ids[ids.length - 1]);
+
+  // it settles on a stored capture: a blob URL, not the previous project's
+  // frozen data: URL and not the markup's poster
+  await expect.poll(async () => {
+    const poster = await page.getAttribute('#hyperplayer', 'poster');
+    return poster === null ? 'none' : poster.split(':')[0];
+  }, { timeout: 15000 }).toBe('blob');
+});

--- a/__TEST__/e2e/picture-in-picture.spec.mjs
+++ b/__TEST__/e2e/picture-in-picture.spec.mjs
@@ -1,0 +1,92 @@
+// #600 — Safari does nothing on the PiP button because we only ever called the
+// standard API. WebKit reports document.pictureInPictureEnabled === true and
+// offers requestPictureInPicture(), then refuses the call with
+// NotSupportedError; its working API is webkitSetPresentationMode.
+//
+// Entering real PiP in Safari cannot be automated here, so this pins the
+// DECISION: given the presentation-mode API, we use it and do not fall back to
+// a call that engine rejects. The standard path is guarded too, so preferring
+// WebKit's API costs Chromium nothing.
+import { test, expect } from '@playwright/test';
+
+const makeWebm = () => new Promise((resolve) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 320; canvas.height = 180;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = '#a63'; ctx.fillRect(0, 0, 320, 180);
+  const rec = new MediaRecorder(canvas.captureStream(10), { mimeType: 'video/webm' });
+  const chunks = [];
+  rec.ondataavailable = (e) => chunks.push(e.data);
+  rec.onstop = () => resolve(URL.createObjectURL(new Blob(chunks, { type: 'video/webm' })));
+  rec.start();
+  let f = 0;
+  const t = setInterval(() => { ctx.fillRect(0, 0, 320, 180); if (++f >= 8) { clearInterval(t); rec.stop(); } }, 60);
+});
+
+async function loadVideo(page) {
+  await page.evaluate(`(${makeWebm.toString()})().then((url) => {
+    const v = document.getElementById('hyperplayer');
+    v.src = url;
+    return new Promise((r) => v.addEventListener('loadedmetadata', r, { once: true }));
+  })`);
+  await page.waitForTimeout(400);
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+});
+
+test('the presentation-mode API is preferred where it exists (#600)', async ({ page }) => {
+  await loadVideo(page);
+  // Stand in for WebKit: the same two methods Safari exposes, recording what
+  // they are asked to do. requestPictureInPicture is watched too — reaching it
+  // would be the bug, since that is the call WebKit rejects.
+  await page.evaluate(() => {
+    const v = document.getElementById('hyperplayer');
+    window.__calls = [];
+    v.webkitPresentationMode = 'inline';
+    v.webkitSupportsPresentationMode = (mode) => mode === 'picture-in-picture';
+    v.webkitSetPresentationMode = (mode) => {
+      window.__calls.push('webkit:' + mode);
+      v.webkitPresentationMode = mode;
+    };
+    const original = v.requestPictureInPicture;
+    v.requestPictureInPicture = function () {
+      window.__calls.push('standard');
+      return original.apply(this, arguments);
+    };
+  });
+
+  await page.click('#pip-btn');
+  expect(await page.evaluate(() => window.__calls)).toEqual(['webkit:picture-in-picture']);
+
+  // and it toggles back out rather than only ever going in
+  await page.click('#pip-btn');
+  expect(await page.evaluate(() => window.__calls)).toEqual(['webkit:picture-in-picture', 'webkit:inline']);
+});
+
+test('engines without it still use the standard API (#600)', async ({ page }) => {
+  await loadVideo(page);
+  await page.click('#pip-btn');
+  await expect.poll(() => page.evaluate(() => document.pictureInPictureElement !== null))
+    .toBe(true);
+});
+
+test('the button is shown when only the presentation-mode API exists (#600)', async ({ page }) => {
+  // The old gate hid the button whenever document.pictureInPictureEnabled was
+  // false, which would hide it in an engine that offers only WebKit's API.
+  // On the PROTOTYPE, not the element: the module gates the button as soon as
+  // the player exists, so a stub that waits for the element is a race — and
+  // one that failed only sometimes, which is worse than failing.
+  await page.addInitScript(() => {
+    Object.defineProperty(document, 'pictureInPictureEnabled', { get: () => false });
+    HTMLVideoElement.prototype.webkitSupportsPresentationMode = function (m) {
+      return m === 'picture-in-picture';
+    };
+    HTMLVideoElement.prototype.webkitSetPresentationMode = function () {};
+  });
+  await page.goto('/index.html');
+  await page.waitForSelector('#hypertranscript [data-m]');
+  await expect(page.locator('#pip-btn')).toBeVisible();
+});

--- a/__TEST__/e2e/player-box-stability.spec.mjs
+++ b/__TEST__/e2e/player-box-stability.spec.mjs
@@ -64,8 +64,11 @@ test('switching projects keeps the media box sized and unbranded (#590)', async 
     let brandedPoster = false;
     const watch = new MutationObserver(() => {
       if (player.style.aspectRatio === '') pinCleared = true;
+      // "branded" means the markup's poster — the intro audio's artwork.
+      // A stored capture is a blob: URL and is exactly what SHOULD be here
+      // (#575), so test for the artwork itself rather than for "not data:".
       const poster = player.getAttribute('poster');
-      if (poster !== null && !poster.startsWith('data:')) brandedPoster = true;
+      if (poster !== null && poster.includes('images/poster.png')) brandedPoster = true;
     });
     watch.observe(player, { attributes: true, attributeFilter: ['style', 'poster', 'src'] });
     await window.HyperaudioSave.library.open(id);
@@ -85,7 +88,8 @@ test('switching projects keeps the media box sized and unbranded (#590)', async 
   expect(seen.pinCleared).toBe(false);
 
   // and the hyperaudio wordmark never went up: the outgoing frame covered the
-  // gap, and video ends with no poster at all once it is painting
+  // gap, then this project's own capture replaced it. Never posterless —
+  // that is the WebKit trap #575 documents.
   expect(seen.brandedPoster).toBe(false);
-  expect(seen.posterAfter).toBe(null);
+  expect(seen.posterAfter).not.toBe(null);
 });

--- a/__TEST__/e2e/png-luma.mjs
+++ b/__TEST__/e2e/png-luma.mjs
@@ -1,0 +1,52 @@
+// Minimal PNG reader, for asking whether a screenshot has any picture in it
+// at all. Used by the WebKit poster test (#575), where the failure mode is a
+// perfectly uniform box — the element painting nothing and the page showing
+// through — which no DOM assertion can tell from a poster that IS painting.
+import zlib from 'node:zlib';
+export function pngLuma(buf) {
+  let pos = 8, w = 0, h = 0, bitDepth = 0, colorType = 0;
+  const idat = [];
+  while (pos < buf.length) {
+    const len = buf.readUInt32BE(pos);
+    const type = buf.toString('ascii', pos + 4, pos + 8);
+    const data = buf.subarray(pos + 8, pos + 8 + len);
+    if (type === 'IHDR') {
+      w = data.readUInt32BE(0); h = data.readUInt32BE(4);
+      bitDepth = data[8]; colorType = data[9];
+    } else if (type === 'IDAT') idat.push(data);
+    else if (type === 'IEND') break;
+    pos += 12 + len;
+  }
+  if (bitDepth !== 8) throw new Error('unexpected bit depth ' + bitDepth);
+  const channels = { 0: 1, 2: 3, 4: 2, 6: 4 }[colorType];
+  const raw = zlib.inflateSync(Buffer.concat(idat));
+  const stride = w * channels;
+  const out = Buffer.alloc(h * stride);
+  let rp = 0;
+  for (let y = 0; y < h; y++) {
+    const filter = raw[rp++];
+    const line = raw.subarray(rp, rp + stride); rp += stride;
+    const cur = out.subarray(y * stride, (y + 1) * stride);
+    const prev = y > 0 ? out.subarray((y - 1) * stride, y * stride) : Buffer.alloc(stride);
+    for (let x = 0; x < stride; x++) {
+      const a = x >= channels ? cur[x - channels] : 0;
+      const bb = prev[x];
+      const c = (x >= channels && y > 0) ? prev[x - channels] : 0;
+      let v = line[x];
+      if (filter === 1) v += a; else if (filter === 2) v += bb;
+      else if (filter === 3) v += (a + bb) >> 1;
+      else if (filter === 4) {
+        const pp = a + bb - c, pa = Math.abs(pp - a), pb = Math.abs(pp - bb), pc = Math.abs(pp - c);
+        v += (pa <= pb && pa <= pc) ? a : (pb <= pc ? bb : c);
+      }
+      cur[x] = v & 0xff;
+    }
+  }
+  const seen = new Set();
+  let min = 255, max = 0;
+  for (let i = 0; i < out.length; i += channels) {
+    const lum = channels >= 3 ? Math.round(0.299 * out[i] + 0.587 * out[i+1] + 0.114 * out[i+2]) : out[i];
+    seen.add(lum); if (lum < min) min = lum; if (lum > max) max = lum;
+  }
+  return { w, h, distinctLuma: seen.size, min, max, spread: max - min };
+}

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.3.11 (last changed in release 1.3.11) -->
+<!--  Hyperaudio Lite Editor - Version 1.3.12 (last changed in release 1.3.12) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.3.11">
+  <meta name="version" content="1.3.12">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">

--- a/index.html
+++ b/index.html
@@ -1084,7 +1084,7 @@ If you are creating an open source application under a license compatible with t
     }
 
   </style>
-  <script src="js/editor-main.js?v=1.3.1"></script>
+  <script src="js/editor-main.js?v=1.3.12"></script>
   <script src="js/find-replace.js?v=1.3.5"></script>
   <script src="js/transcript-history.js?v=1.3.1"></script>
   <!-- device limits benchmark — inert without ?bench=1 in the URL -->

--- a/index.html
+++ b/index.html
@@ -1108,7 +1108,7 @@ If you are creating an open source application under a license compatible with t
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
   <script src="js/hyperaudio-save.js?v=1.3.9"></script>
   <script src="js/hyperaudio-library.js?v=1.3.9"></script>
-  <script src="js/media-first-frame.js?v=1.3.9"></script>
+  <script src="js/media-first-frame.js?v=1.3.12"></script>
   <script src="js/media-posters.js?v=1.3.9"></script>
   <!-- transcript document exports: TXT / Markdown (#467) -->
   <script src="js/transcript-doc-export.js?v=1.1.1"></script>

--- a/js/editor-main.js
+++ b/js/editor-main.js
@@ -205,10 +205,32 @@
     // Picture-in-picture: pops the video into a floating window so it stays
     // visible while scrolling the transcript. Only meaningful for media with a
     // video track, so the button disables itself for audio-only sources.
+    //
+    // Two APIs, and WebKit is the reason (#600). It answers
+    // document.pictureInPictureEnabled with true and offers
+    // requestPictureInPicture(), then rejects the call with NotSupportedError
+    // — "The video element does not support the Picture-in-Picture mode." Its
+    // working API is the presentation-mode one, so that is tried FIRST
+    // wherever it exists rather than kept as a fallback: a browser that
+    // implements it means it.
+    const webkitPip = (video) =>
+      typeof video.webkitSetPresentationMode === 'function'
+      && typeof video.webkitSupportsPresentationMode === 'function';
+
     function togglePictureInPicture() {
       const video = document.querySelector('#hyperplayer');
       if (video === null) {
         return;
+      }
+      if (webkitPip(video)) {
+        try {
+          video.webkitSetPresentationMode(
+            video.webkitPresentationMode === 'picture-in-picture' ? 'inline' : 'picture-in-picture',
+          );
+          return;
+        } catch (e) {
+          console.warn('Picture-in-picture failed:', e); // fall through to the standard call
+        }
       }
       const action = document.pictureInPictureElement
         ? document.exitPictureInPicture()
@@ -378,7 +400,10 @@
       if (btn === null || video === null) {
         return;
       }
-      if (!document.pictureInPictureEnabled || video.disablePictureInPicture) {
+      // Hide only when NEITHER API is on offer; WebKit has the presentation-mode
+      // one whatever document.pictureInPictureEnabled says (#600).
+      const standardPip = document.pictureInPictureEnabled && !video.disablePictureInPicture;
+      if (!standardPip && !webkitPip(video)) {
         btn.style.display = 'none';   // unsupported – don't show a dead button
         return;
       }

--- a/js/media-first-frame.js
+++ b/js/media-first-frame.js
@@ -1,7 +1,7 @@
 /**
  * media-first-frame.js
  * (C) The Hyperaudio Project
- * @version 1.3.9 — last changed in release 1.3.9
+ * @version 1.3.12 — last changed in release 1.3.12
  * @license MIT
  *
  * First-frame display for video media (#556). A <video> shows its poster —
@@ -25,6 +25,20 @@
  * medium IS gets settled when its metadata says so, not guessed at
  * loadstart.
  *
+ * The poster is NEVER removed (#575). Removing it and epsilon-seeking did
+ * paint frame 1, but it also moved the element's display mode to "video", and
+ * WebKit has no path back: every project opened afterwards painted nothing —
+ * a blank box, with the poster attribute present and resolving. Restoring the
+ * attribute does not restore the mode, and neither does load(); only a fresh
+ * element recovers. Blink is unaffected, so it never showed up in Chrome.
+ *
+ * What is shown instead is the project's own stored capture, which
+ * media-posters.js (#523) already makes for the Recents thumbnail: the same
+ * picture the seek was chasing, without the element ever going posterless.
+ * Going through MediaPosters.urlFor also honours window.hyperaudioMediaPoster,
+ * the embedder seam #567 asks for. Each load carries a token so a capture that
+ * arrives late cannot repaint the project that replaced it.
+ *
  * Self-contained and removable: no other module depends on this file.
  */
 (function firstFrameForVideo() {
@@ -32,7 +46,9 @@
     const player = document.getElementById('hyperplayer');
     if (player === null) { setTimeout(wire, 500); return; }
     const defaultPoster = player.getAttribute('poster');
-    let nudged = false;
+    // Bumped on every load; an async poster lookup that finishes after the
+    // next one has started must stand down rather than repaint it.
+    let loadToken = 0;
 
     // The frame on screen, as a data URL — the stand-in while the next medium
     // loads. Null for audio (nothing to draw) and for cross-origin media,
@@ -56,19 +72,55 @@
       // poster for the length of the gap. With nothing to freeze — a cold
       // start, or audio, where the poster IS the display — whatever is
       // already showing is left alone, which is the same continuity.
-      nudged = false;
+      loadToken += 1;
       const frozen = freezeFrame();
       if (frozen !== null) player.setAttribute('poster', frozen);
     });
 
+    const currentProjectId = () => {
+      const lib = window.HyperaudioSave && window.HyperaudioSave.library;
+      return lib && typeof lib.currentId === 'function' ? lib.currentId() : null;
+    };
+
+    // The project's own stored frame-1 capture, waiting for it to be made if
+    // this is the first visit. ensureProjectPoster is the same serialized,
+    // capture-once chain the Recents thumbnails use, so asking again here
+    // costs a read when one already exists.
+    async function applyStoredPoster(token) {
+      const posters = window.MediaPosters;
+      const id = currentProjectId();
+      if (!posters || typeof posters.urlFor !== 'function' || id === null) return false;
+      try {
+        let url = await posters.urlFor(id);
+        if (!url && typeof posters.ensureProjectPoster === 'function') {
+          await posters.ensureProjectPoster(id);
+          if (token !== loadToken) return false;
+          url = await posters.urlFor(id);
+        }
+        if (token !== loadToken || !url) return false;
+        player.setAttribute('poster', url);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    }
+
     function reveal() {
       if (player.videoWidth <= 0) return; // audio, or dimensions not known yet
       player.style.aspectRatio = player.videoWidth + ' / ' + player.videoHeight;
-      if (player.getAttribute('poster') !== null) player.removeAttribute('poster');
-      if (!nudged && player.paused && player.currentTime === 0) {
-        nudged = true;
-        try { player.currentTime = 0.0001; } catch (e) { /* decoder not ready — harmless */ }
-      }
+      // NO removeAttribute, and no epsilon seek: both drove the element into
+      // the display mode WebKit will not leave (#575). The stand-in frame
+      // showing right now belongs to the PREVIOUS project, so it is replaced
+      // by this one's capture; failing that, the markup's poster is a better
+      // answer than another project's picture.
+      const token = loadToken;
+      applyStoredPoster(token).then((applied) => {
+        if (applied || token !== loadToken) return;
+        const showing = player.getAttribute('poster');
+        if (defaultPoster !== null && showing !== null && showing.startsWith('data:')) {
+          player.setAttribute('poster', defaultPoster);
+        }
+      });
     }
     ['loadedmetadata', 'loadeddata', 'resize', 'canplay'].forEach((ev) => {
       player.addEventListener(ev, reveal);


### PR DESCRIPTION
Three Safari fixes, all confirmed by hand in Safari rather than only in headless WebKit.

**#575 — a project opened after a video one painted nothing.** Removing the player's poster and epsilon-seeking to paint frame one moved the element into a display mode WebKit never leaves; every project opened afterwards showed a blank box, while the DOM insisted all was well. The poster is never removed now, and the picture comes from the project's own stored capture — which `media-posters.js` has made since #523 for the Recents thumbnail, and which is the same frame the seek was chasing. Blink was unaffected, so nothing in the suite could have caught it; there is a WebKit spec now that screenshots the element and asks whether any picture is there.

**#600 — picture-in-picture did nothing in Safari.** WebKit reports `pictureInPictureEnabled === true` and offers `requestPictureInPicture()`, then rejects the call with `NotSupportedError`. Its working API is `webkitSetPresentationMode`, which we never called. That is now tried first wherever it exists, and the button hides only when neither API is on offer.

**#567 — the embedder poster seam** is answered by the #575 work: the player's poster comes from `MediaPosters.urlFor()`, which consults `window.hyperaudioMediaPoster` first and lets it win.

Fixes #575
Fixes #600

Gate: 101 unit, 266 e2e passed, 1 skipped (known WebKit OPFS skip).
