### PR TITLE
Version 1.3.13

### DIFF
--- a/__TEST__/e2e/external-projects.spec.mjs
+++ b/__TEST__/e2e/external-projects.spec.mjs
@@ -87,19 +87,24 @@ test('a slow host does not delay the panel (#604)', async ({ page }) => {
   // Measured before the rewrite: a 1200ms host delayed the active-row
   // highlight by 1216ms after a switch, leaving the list pointing at the
   // project you had just left.
+  // The gap between the host's delay and the assertion window has to be wide
+  // enough to survive a loaded machine: at 1200ms vs 900ms this failed in a
+  // full gate run where other specs were launching browsers. The point is that
+  // the panel does not WAIT, not that it renders within any particular
+  // millisecond, so give the host a delay nothing could mistake for prompt.
   await withHost(page, () => {
     window.hyperaudioExternalProjects = () => new Promise((r) => setTimeout(() => r([
       { id: 'ext:slow', title: 'a slow host row', modified: 9_000_000_000_000 },
-    ]), 1200));
+    ]), 6000));
   });
   await page.goto('/index.html');
   await page.waitForSelector('#hypertranscript [data-m]');
 
   // the editor's own row is there long before the host answers
-  await expect.poll(() => panel(page), { timeout: 900 })
+  await expect.poll(() => panel(page), { timeout: 3000 })
     .toEqual([{ name: 'How to use the Editor', external: false }]);
   // and the host's arrives afterwards, without anything having blocked
-  await expect.poll(() => panel(page), { timeout: 5000 }).toEqual([
+  await expect.poll(() => panel(page), { timeout: 12000 }).toEqual([
     { name: 'a slow host row', external: true },
     { name: 'How to use the Editor', external: false },
   ]);

--- a/__TEST__/e2e/strike-selection.spec.mjs
+++ b/__TEST__/e2e/strike-selection.spec.mjs
@@ -1,0 +1,84 @@
+// #613 — striking a word also struck the word before it, in Safari only.
+//
+// intersectsNode() is true for a span the range merely touches, and the two
+// engines anchor a drag differently when it starts on a word's first letter:
+//
+//   WebKit    selected "charlie"  anchored in text("bravo ")@6   <- previous span
+//   Chromium  selected "charlie"  anchored in text("charlie ")@0
+//
+// So in WebKit the previous span held the range's start boundary while
+// contributing no characters, and the leading-space trim could not see it —
+// the selected string starts cleanly at the word.
+//
+// Launches WebKit itself: the suite's default project is Chromium, where this
+// does not reproduce at all.
+import { test, expect, webkit, chromium } from '@playwright/test';
+
+const MARKUP = '<article><section><p>'
+  + '<span data-m="0" data-d="400">alpha </span>'
+  + '<span data-m="400" data-d="400">bravo </span>'
+  + '<span data-m="800" data-d="400">charlie </span>'
+  + '<span data-m="1200" data-d="400">delta </span>'
+  + '</p></section></article>';
+
+const WORD = '#hypertranscript span[data-m]:nth-of-type(3)'; // "charlie"
+
+async function strikeVia(page, how) {
+  await page.evaluate((m) => {
+    document.getElementById('hypertranscript').innerHTML = m;
+    window.getSelection().removeAllRanges();
+  }, MARKUP);
+  const box = await page.locator(WORD).boundingBox();
+  const midY = box.y + box.height / 2;
+  if (how === 'dblclick') {
+    await page.dblclick(WORD);
+  } else if (how === 'ltr') {
+    await page.mouse.move(box.x + 1, midY);            // ON the first letter
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width - 3, midY, { steps: 8 });
+    await page.mouse.up();
+  } else if (how === 'rtl') {
+    await page.mouse.move(box.x + box.width - 3, midY);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 1, midY, { steps: 8 });
+    await page.mouse.up();
+  } else if (how === 'two-words') {
+    const next = await page.locator('#hypertranscript span[data-m]:nth-of-type(4)').boundingBox();
+    await page.mouse.move(box.x + 1, midY);
+    await page.mouse.down();
+    await page.mouse.move(next.x + next.width - 3, next.y + next.height / 2, { steps: 10 });
+    await page.mouse.up();
+  }
+  await page.click('#strikethrough');
+  await page.waitForTimeout(120);
+  return page.evaluate(() =>
+    [...document.querySelectorAll('#hypertranscript [data-m]')]
+      .filter((s) => (s.style.textDecoration || '').includes('line-through'))
+      .map((s) => s.textContent.trim()));
+}
+
+for (const [engineName, engine] of [['WebKit', webkit], ['Chromium', chromium]]) {
+  test(`${engineName}: a strike covers only the words actually selected (#613)`, async () => {
+    let browser;
+    try {
+      browser = await engine.launch();
+    } catch (e) {
+      test.skip(true, `${engineName} build not installed: ${e.message}`);
+      return;
+    }
+    try {
+      const page = await (await browser.newContext()).newPage();
+      await page.goto('http://localhost:4173/index.html');
+      await page.waitForSelector('#hypertranscript [data-m]');
+
+      // the case that was broken: the drag begins on the word's first letter
+      expect(await strikeVia(page, 'ltr'), 'drag from the first letter').toEqual(['charlie']);
+      expect(await strikeVia(page, 'rtl'), 'drag right-to-left').toEqual(['charlie']);
+      expect(await strikeVia(page, 'two-words'), 'two words').toEqual(['charlie', 'delta']);
+      // and the case that always worked, which the fix must not disturb
+      expect(await strikeVia(page, 'dblclick'), 'double-click').toEqual(['charlie']);
+    } finally {
+      await browser.close();
+    }
+  });
+}

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!--  (C) The Hyperaudio Project. AGPL 3.0 @license: https://www.gnu.org/licenses/agpl-3.0.en.html -->
 
-<!--  Hyperaudio Lite Editor - Version 1.3.12 (last changed in release 1.3.12) -->
+<!--  Hyperaudio Lite Editor - Version 1.3.13 (last changed in release 1.3.13) -->
 
 <!--  Hyperaudio Lite Editor's source code is provided under a dual license model.
 
@@ -18,7 +18,7 @@ If you are creating an open source application under a license compatible with t
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="version" content="1.3.12">
+  <meta name="version" content="1.3.13">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">

--- a/index.html
+++ b/index.html
@@ -1103,7 +1103,7 @@ If you are creating an open source application under a license compatible with t
 
   <!-- service worker script for PWA -->
   <script src="js/editor-service-worker.js?v=0.6.12"></script>
-  <script type="module" src="js/editor-audio-cut.js?v=1.3.9"></script>
+  <script type="module" src="js/editor-audio-cut.js?v=1.3.13"></script>
 
   <!-- .hyperaudio project save/open + OPFS autosave (spec: docs/format/) -->
   <script src="js/hyperaudio-save.js?v=1.3.13"></script>

--- a/js/editor-audio-cut.js
+++ b/js/editor-audio-cut.js
@@ -238,6 +238,36 @@
     }
   }
 
+  // Does the selection actually COVER any of this span's text?
+  //
+  // intersectsNode() is true for a span the range merely touches, and WebKit
+  // touches the previous one constantly: a drag that starts on a word's first
+  // letter is anchored at the END of the PREVIOUS span's text node, where
+  // Chromium anchors at offset 0 of the word itself. The previous span then
+  // contributes no characters at all, and the leading-space trim below cannot
+  // notice, because the selected string starts cleanly at the word — the space
+  // sits before the anchor. Striking a word therefore struck its neighbour too,
+  // in Safari only.
+  //
+  // Clamping the range to the span and asking what text is left is the direct
+  // question, and only uses like-for-like boundary comparisons.
+  function coversText(range, span) {
+    const spanRange = document.createRange();
+    spanRange.selectNodeContents(span);
+    const clipped = range.cloneRange();
+    try {
+      if (clipped.compareBoundaryPoints(Range.START_TO_START, spanRange) < 0) {
+        clipped.setStart(spanRange.startContainer, spanRange.startOffset);
+      }
+      if (clipped.compareBoundaryPoints(Range.END_TO_END, spanRange) > 0) {
+        clipped.setEnd(spanRange.endContainer, spanRange.endOffset);
+      }
+    } catch (e) {
+      return true; // unexpected boundaries: keep the old, inclusive behaviour
+    }
+    return clipped.toString().trim() !== '';
+  }
+
   // Map the user's Range to the spans it actually covers, regardless of where
   // the caret was parked (text node, span boundary, or paragraph element).
   function applyStrikeThroughToSelection() {
@@ -252,7 +282,8 @@
     let startSpan = null;
     let endSpan = null;
     for (const span of allSpans) {
-      if (range.intersectsNode(span) && span.textContent.trim() !== '') {
+      if (range.intersectsNode(span) && span.textContent.trim() !== ''
+          && coversText(range, span)) {
         if (!startSpan) startSpan = span;
         endSpan = span;
       }


### PR DESCRIPTION
Seven fixes, two of them Safari-only, and one change every existing user will see.

- **#602 — the intro is a project like any other.** It was markup that boot fell back to: on screen, but with no library entry, so editing it autosaved nowhere and it could not be renamed, starred or deleted. It is seeded as a real project on first run, from the document rather than from constants, so an embedder shipping its own `index.html` gets its own intro with no API to call.
- **#603 — audio projects wear their own waveform** instead of the intro audio's artwork, so every audio project no longer looks identical. The library and the player draw the same image from `media-posters.js`.
- **#604 — a host can contribute project rows to Recents**, in the same division of labour as the poster seam. The panel never waits for the host: it draws its own rows and merges the host's when they arrive.
- **#605 — struck words follow the Entire/Edited media choice.** Exported text dropped struck words whatever media went with it, so choosing Entire media shipped the original file beside a transcript missing words you can hear.
- **#611 — document exports keep struck words where the format can mark them** (`~~word~~` in Markdown, `<w:strike/>` in DOCX) and drop them where it cannot (plain text), since an unmarked struck word reads as speech that was kept.
- **#612 — the in-progress row names what is being transcribed**, not the project that happens to be open. A URL transcription was labelled with the previous project's name.
- **#613 — Safari: striking a word no longer strikes the word before it.** WebKit anchors a drag at the end of the previous span, which `intersectsNode` counted even though it contributed no characters.

Fixes #602, #603, #604, #605, #611, #612, #613

Gate: 105 unit, 290 e2e passed, 1 skipped, plus the known clipboard flake (#606).
