### PR TITLE
Version 1.3.14

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ If you are creating an open source application under a license compatible with t
        per-file cache stamps, so a working tree reports the release it is
        becoming. The date is set by the release commit and stays empty until
        then: Settings shows "unreleased" in its place (#615). -->
-  <meta name="release-date" content="">
+  <meta name="release-date" content="2026-09-02">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">


### PR DESCRIPTION
A settings modal, posters that show a picture, and a run of export and layout fixes.

- **#615 — Settings.** A gear beside the PiP and audio-only buttons opens a modal for the user's choices, as opposed to the project's: double-click to play (#441, #541, off by default), the version with its release date, storage use, downloaded models listed per model with their own Remove, a way back from "don't tell me again", forgetting remembered API keys, and a reset that empties the editor and brings the intro back. Engines declare their model caches; settings knows none by name.
- **#582 — posters come from where the picture is.** The capture starts around 5s and works outward, refuses a flat frame, and writes nothing rather than black, so a black capture is no longer permanent; stored black posters are captured again when their project is next opened. The player shows a capture of the medium while it is being transcribed, and adopts the project's stored capture at the birth.
- **#619 — while transcribing, the player shows the medium being transcribed**, not the previous project's picture letterboxed into the new file's box.
- **#618 — audio glyphs get a real tint**, an oklch pastel in place of a near-white hsl, seeded by the file's created time so a project keeps its colour between HLE and Glider.
- **#617 — the video's top rides the navbar buttons**, with equal air around the controls row; the collapsed offsets are derived rather than measured.
- **#616 — the export modal's extra downloads are collapsed**, and **#608** says what each media choice gives you.
- **#606, #613 — tests**: the exported-page copy test no longer reads the real clipboard, and the unstrike direction is covered.

The version meta now bumps with a release's first change, and a release-date meta is set by the release commit.

Fixes #615, #441, #541, #582, #619, #618, #617, #616, #608, #606, #613

Gate: 105 unit; 321 e2e passed, 1 skipped (the known WebKit OPFS skip).
