### PR TITLE
Version 1.3.15

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ If you are creating an open source application under a license compatible with t
        per-file cache stamps, so a working tree reports the release it is
        becoming. The date is set by the release commit and stays empty until
        then: Settings shows "unreleased" in its place (#615). -->
-  <meta name="release-date" content="">
+  <meta name="release-date" content="2026-09-02">
   <title>Hyperaudio Lite Editor</title>
   <link rel="apple-touch-icon" href="images/icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">


### PR DESCRIPTION
A point release fixing the intro's poster on launch.

- **#621 — the intro's player wore the markup poster on launch** while the Recents popout drew the glyph, seen in Firefox on 1.3.14. The intro's medium is in the markup and starts loading before any script, so a cached mp3 could report metadata before media-first-frame had a listener, and the pass that draws the glyph never ran. The module now settles a medium whose metadata is already known when it wires up, and a library change settles audio still wearing the markup poster.

Fixes #621

Gate: 105 unit; 322 e2e passed, 1 skipped (the known WebKit OPFS skip).
